### PR TITLE
only use futures, add request/response/body

### DIFF
--- a/examples/download-tiffs.py
+++ b/examples/download-tiffs.py
@@ -62,5 +62,5 @@ print 'fetching tiffs for'
 print '\n'.join(ids)
 results = client.fetch_scene_thumbnails(ids, callback=api.write_to_file(dest_dir))
 
-# results are 'future' objects and we have to ensure they all process
-map(lambda r: r.result(), results)
+# results are async objects and we have to ensure they all process
+map(lambda r: r.await(), results)

--- a/planet/scripts/__init__.py
+++ b/planet/scripts/__init__.py
@@ -61,7 +61,7 @@ def call_and_wrap(func, *args, **kw):
 def check_futures(futures):
     for f in futures:
         try:
-            f.result()
+            f.await()
         except api.InvalidAPIKey as invalid:
             click_exception(invalid)
         except api.APIException as other:
@@ -243,7 +243,7 @@ def sync(destination, scene_type, limit):
         features = page.get()['features'][:counter.remaining]
         if not features: break
         ids = [f['id'] for f in features]
-        futures = client.fetch_scene_thumbnails(
+        futures = client.fetch_scene_geotiffs(
             ids, scene_type, callback=write_callback
         )
         for f in features:

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -81,7 +81,7 @@ def test_assert_client_execution_failure():
         
         # Check that an exception is raised
         try:
-            client._get('whatevs')
+            client._get('whatevs').get_body()
         except api.APIException as e:
             assert True
             return
@@ -115,7 +115,7 @@ def test_status_code_404():
         m.get(uri, text='not exist', status_code=404)
         
         try:
-            client._get('whatevs')
+            client._get('whatevs').get_body()
         except api.MissingResource as e:
             
             # TODO: Check returned string. Currently issues between Python 3 bytes and Python 2 strings
@@ -133,7 +133,7 @@ def test_status_code_other():
         m.get(uri, text='emergency', status_code=911)
         
         try:
-            client._get('whatevs')
+            client._get('whatevs').get_body()
         except api.APIException as e:
             
             assert True


### PR DESCRIPTION
@kapadia 

I introduced two new concepts: `Request` and `Dispatcher`
And renamed `Response` to `Body`

The `Client` now is just a higher-level wrapper around the above.
