### PR TITLE
Check whether all images are either active or activating rather than …

### DIFF
--- a/planet/api/downloader.py
+++ b/planet/api/downloader.py
@@ -15,8 +15,12 @@ import logging
 import os
 import threading
 import time
+
+from typing import Iterable
+
 from .utils import write_to_file
 from planet.api.exceptions import RequestCancelled
+
 try:
     import Queue as queue
 except:
@@ -29,8 +33,10 @@ def _by_status(assets, types, status):
             t in assets and assets[t]['status'] == status]
 
 
-def _all_status(assets, types, status):
-    return all([assets[t]['status'] == status for t in types if t in assets])
+def _all_status(assets, types, statuses):
+    if not isinstance(statuses, Iterable):
+        statuses = [statuses]
+    return all([assets[t]['status'] in statuses for t in types if t in assets])
 
 
 _logger = logging.getLogger(__name__)
@@ -201,8 +207,7 @@ class _AStage(_Stage):
             self._tasks.append(item)
             return
 
-        if _all_status(assets, self._asset_types, 'activating') or \
-           _all_status(assets, self._asset_types, 'active'):
+        if _all_status(assets, self._asset_types, ['active', 'activating']):
             self._results.put((item, assets))
         else:
             # hmmm


### PR DESCRIPTION
…whether either all images are active or all images are activating.

I encountered an exception (`Exception: unexpected state [u'activating', u'active']`) when I tried to download both visual and analytic assets of a given item after previously downloading the visual assets. I believe that the exception arose because the visual asset was "active" while the analytic asset was still "activating." I think the fix is to have the _all_status function in `downloader.py` check whether all requested assets are either "active" or "activating" (allowing for a case in which some are active while others are activating), rather than checking whether they are either all "active" or all "activating."