### PR TITLE
update filter docs to use cloud_cover as field_name

### DIFF
--- a/planet/api/filters.py
+++ b/planet/api/filters.py
@@ -56,16 +56,16 @@ def and_filter(*predicates):
     '''Build an `and` filter from the provided predicate filters.
 
     >>> filt = and_filter(
-    ...   range_filter('clouds', gt=0.1),
-    ...   range_filter('clouds', lt=0.2)
+    ...   range_filter('cloud_cover', gt=0.1),
+    ...   range_filter('cloud_cover', lt=0.2)
     ... )
     >>> filt['type']
     'AndFilter'
     >>> filt['config'][0] == \
-    {'config': {'gt': 0.1}, 'field_name': 'clouds', 'type': 'RangeFilter'}
+    {'config': {'gt': 0.1}, 'field_name': 'cloud_cover', 'type': 'RangeFilter'}
     True
     >>> filt['config'][1] == \
-    {'config': {'lt': 0.2}, 'field_name': 'clouds', 'type': 'RangeFilter'}
+    {'config': {'lt': 0.2}, 'field_name': 'cloud_cover', 'type': 'RangeFilter'}
     True
     '''
     return _filter('AndFilter', predicates)
@@ -78,7 +78,7 @@ def or_filter(*predicates):
     >>> n = datetime.datetime(year=2017, month=2, day=14)
     >>> filt = or_filter(
     ...   date_range('acquired', gt=n),
-    ...   range_filter('clouds', gt=0.1),
+    ...   range_filter('cloud_cover', gt=0.1),
     ... )
     >>> filt['type']
     'OrFilter'
@@ -87,7 +87,7 @@ def or_filter(*predicates):
     'type': 'DateRangeFilter'}
     True
     >>> filt['config'][1] == \
-    {'config': {'gt': 0.1}, 'field_name': 'clouds', 'type': 'RangeFilter'}
+    {'config': {'gt': 0.1}, 'field_name': 'cloud_cover', 'type': 'RangeFilter'}
     True
     '''
     return _filter('OrFilter', predicates)
@@ -123,8 +123,8 @@ def date_range(field_name, **kwargs):
 def range_filter(field_name, **kwargs):
     '''Build a RangeFilter.
 
-    >>> range_filter('clouds', gt=0.1) == \
-    {'config': {'gt': 0.1}, 'field_name': 'clouds', 'type': 'RangeFilter'}
+    >>> range_filter('cloud_cover', gt=0.1) == \
+    {'config': {'gt': 0.1}, 'field_name': 'cloud_cover', 'type': 'RangeFilter'}
     True
     '''
     return _filter('RangeFilter', config=kwargs, field_name=field_name)


### PR DESCRIPTION
Replaces use of `clouds` in filter docs. I noticed my queries returning no results when using `clouds`  as the `field_name` as directed in [the client docs](https://planetlabs.github.io/planet-client-python/api/reference.html?highlight=clouds#filters).

![image](https://user-images.githubusercontent.com/428784/30079250-7037d5e6-9234-11e7-8575-b025676bd253.png)

Note the empty feature collection in my results, despite using the `redding_reservoir` AOI from [the docs](https://www.planet.com/docs/api-quickstart-examples/step-1-search/):

```json
{"_links": {"_first": "https://api.planet.com/data/v1/searches/6296cb1bd39e4901848abc9c03e19647/results?_page=eyJxdWVyeV9wYXJhbXMiOiB7fSwgInNvcnRfcHJldiI6IGZhbHNlLCAicGFnZV9zaXplIjogMjUwLCAic29ydF9ieSI6ICJwdWJsaXNoZWQiLCAic29ydF9zdGFydCI6IG51bGwsICJzb3J0X2xhc3RfaWQiOiBudWxsLCAic29ydF9kZXNjIjogdHJ1ZX0%3D", "_next": null, "_self": "https://api.planet.com/data/v1/searches/6296cb1bd39e4901848abc9c03e19647/results?_page=eyJxdWVyeV9wYXJhbXMiOiB7fSwgInNvcnRfcHJldiI6IGZhbHNlLCAicGFnZV9zaXplIjogMjUwLCAic29ydF9ieSI6ICJwdWJsaXNoZWQiLCAic29ydF9zdGFydCI6IG51bGwsICJzb3J0X2xhc3RfaWQiOiBudWxsLCAic29ydF9kZXNjIjogdHJ1ZX0%3D"}, "features": [], "type": "FeatureCollection"}
```