### PR TITLE
Get lists of item & asset types from the server

### DIFF
--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -1,0 +1,56 @@
+import requests
+
+ITEM_TYPE_URL = 'https://api.planet.com/data/v1/item-types/'
+ASSET_TYPE_URL = 'https://api.planet.com/data/v1/asset-types/'
+
+_item_types = None
+_asset_types = None
+
+# Default values here are used as a fallback
+# In case the API fails to respond or takes too long.
+_default_item_types = [
+    "PSScene4Band", "PSScene3Band", "REScene", "SkySatScene",
+    "REOrthoTile", "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G"]
+
+_default_asset_types = [
+    "analytic", "analytic_b1", "analytic_b10", "analytic_b11", "analytic_b12",
+    "analytic_b2", "analytic_b3", "analytic_b4", "analytic_b5", "analytic_b6",
+    "analytic_b7", "analytic_b8", "analytic_b8a", "analytic_b9",
+    "analytic_bqa", "analytic_dn", "analytic_dn_xml", "analytic_ms",
+    "analytic_xml", "basic_analytic", "basic_analytic_b1",
+    "basic_analytic_b1_nitf", "basic_analytic_b2", "basic_analytic_b2_nitf",
+    "basic_analytic_b3", "basic_analytic_b3_nitf", "basic_analytic_b4",
+    "basic_analytic_b4_nitf", "basic_analytic_b5", "basic_analytic_b5_nitf",
+    "basic_analytic_dn", "basic_analytic_dn_nitf", "basic_analytic_dn_rpc",
+    "basic_analytic_dn_rpc_nitf", "basic_analytic_dn_xml",
+    "basic_analytic_dn_xml_nitf", "basic_analytic_nitf", "basic_analytic_rpc",
+    "basic_analytic_rpc_nitf", "basic_analytic_sci", "basic_analytic_xml",
+    "basic_analytic_xml_nitf", "basic_panchromatic_dn",
+    "basic_panchromatic_dn_rpc", "basic_udm", "browse", "metadata_aux",
+    "metadata_txt", "udm", "visual", "visual_xml"
+]
+
+def _get_json_or_raise(url, timeout=0.7):
+    resp = requests.get(url, timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+def get_item_types():
+    global _item_types
+    if _item_types is None:
+        try:
+            data = _get_json_or_raise(ITEM_TYPE_URL)
+            _item_types = [it['id'] for it in data['item_types']]
+        except:
+            _item_types = _default_item_types
+    return _item_types
+
+def get_asset_types():
+    global _asset_types
+    if _asset_types is None:
+        try:
+            data = _get_json_or_raise(ASSET_TYPE_URL)
+            _asset_types = [a['id'] for a in data['asset_types']]
+        except:
+            _asset_types = _default_asset_types
+    return _asset_types

--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -8,11 +8,11 @@ _asset_types = None
 
 # Default values here are used as a fallback
 # In case the API fails to respond or takes too long.
-_default_item_types = [
+DEFAULT_ITEM_TYPES = [
     "PSScene4Band", "PSScene3Band", "REScene", "SkySatScene",
     "REOrthoTile", "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G"]
 
-_default_asset_types = [
+DEFAULT_ASSET_TYPES = [
     "analytic", "analytic_b1", "analytic_b10", "analytic_b11", "analytic_b12",
     "analytic_b2", "analytic_b3", "analytic_b4", "analytic_b5", "analytic_b6",
     "analytic_b7", "analytic_b8", "analytic_b8a", "analytic_b9",
@@ -44,7 +44,7 @@ def get_item_types():
             data = _get_json_or_raise(ITEM_TYPE_URL)
             _item_types = [it['id'] for it in data['item_types']]
         except:
-            _item_types = _default_item_types
+            _item_types = DEFAULT_ITEM_TYPES
     return _item_types
 
 
@@ -55,5 +55,5 @@ def get_asset_types():
             data = _get_json_or_raise(ASSET_TYPE_URL)
             _asset_types = [a['id'] for a in data['asset_types']]
         except:
-            _asset_types = _default_asset_types
+            _asset_types = DEFAULT_ASSET_TYPES
     return _asset_types

--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -31,7 +31,7 @@ _default_asset_types = [
 ]
 
 def _get_json_or_raise(url, timeout=0.7):
-    resp = requests.get(url, timeout)
+    resp = requests.get(url, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 

--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -30,10 +30,12 @@ _default_asset_types = [
     "metadata_txt", "udm", "visual", "visual_xml"
 ]
 
+
 def _get_json_or_raise(url, timeout=0.7):
     resp = requests.get(url, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
+
 
 def get_item_types():
     global _item_types
@@ -44,6 +46,7 @@ def get_item_types():
         except:
             _item_types = _default_item_types
     return _item_types
+
 
 def get_asset_types():
     global _asset_types

--- a/planet/scripts/types.py
+++ b/planet/scripts/types.py
@@ -24,28 +24,8 @@ from .util import _split
 from planet.api import filters
 from planet.api.utils import geometry_from_json
 from planet.api.utils import strp_lenient
+from planet.scripts.item_asset_types import get_item_types, get_asset_types
 
-_allowed_item_types = [
-    "PSScene4Band", "PSScene3Band", "REScene", "SkySatScene",
-    "REOrthoTile", "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G"]
-
-_allowed_asset_types = [
-    "analytic", "analytic_b1", "analytic_b10", "analytic_b11", "analytic_b12",
-    "analytic_b2", "analytic_b3", "analytic_b4", "analytic_b5", "analytic_b6",
-    "analytic_b7", "analytic_b8", "analytic_b8a", "analytic_b9",
-    "analytic_bqa", "analytic_dn", "analytic_dn_xml", "analytic_ms",
-    "analytic_xml", "basic_analytic", "basic_analytic_b1",
-    "basic_analytic_b1_nitf", "basic_analytic_b2", "basic_analytic_b2_nitf",
-    "basic_analytic_b3", "basic_analytic_b3_nitf", "basic_analytic_b4",
-    "basic_analytic_b4_nitf", "basic_analytic_b5", "basic_analytic_b5_nitf",
-    "basic_analytic_dn", "basic_analytic_dn_nitf", "basic_analytic_dn_rpc",
-    "basic_analytic_dn_rpc_nitf", "basic_analytic_dn_xml",
-    "basic_analytic_dn_xml_nitf", "basic_analytic_nitf", "basic_analytic_rpc",
-    "basic_analytic_rpc_nitf", "basic_analytic_sci", "basic_analytic_xml",
-    "basic_analytic_xml_nitf", "basic_panchromatic_dn",
-    "basic_panchromatic_dn_rpc", "basic_udm", "browse", "metadata_aux",
-    "metadata_txt", "udm", "visual", "visual_xml"
-]
 
 metavar_docs = {
     'FIELD COMP VALUE...': '''A comparison query format where FIELD is a
@@ -130,14 +110,14 @@ class ItemType(_LenientChoice):
     allow_prefix = True
 
     def __init__(self):
-        _LenientChoice.__init__(self, _allowed_item_types)
+        _LenientChoice.__init__(self, get_item_types())
 
 
 class AssetType(_LenientChoice):
     name = 'asset-type'
 
     def __init__(self):
-        _LenientChoice.__init__(self, _allowed_asset_types)
+        _LenientChoice.__init__(self, get_asset_types())
 
 
 class AssetTypePerm(AssetType):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,7 +13,7 @@
 # limitations under the License
 
 import json
-from planet.scripts.types import _allowed_item_types
+from planet.scripts.types import get_item_types
 from planet.scripts.types import AssetType
 from planet.scripts.types import GeomFilter
 from planet.scripts.types import ItemType
@@ -30,7 +30,7 @@ def convert_asserter(t):
 def test_item_type():
     check = convert_asserter(ItemType())
 
-    check('all', _allowed_item_types)
+    check('all', get_item_types())
     check('psscene', ['PSScene3Band', 'PSScene4Band'])
     check('Sentinel2L1C', ['Sentinel2L1C'])
     check('psscene,sent', ['PSScene3Band', 'PSScene4Band', 'Sentinel2L1C'])


### PR DESCRIPTION
Pursuant to [PE-15836](https://hello.planet.com/jira/browse/PE-15836).

Here's a naive approach, with minimal impact on existing option parsing code... Still doing client-side argument validation, but fetching valid type lists from the server.  It will fall back to the hard coded list if the server errors out or takes too long to respond.

It doesn't seem to add a huge amount of response time (percentagewise) to normal API requests, though each of these list endpoints, tested individually, seems to take about 200ms to respond.

Tests TK.