### PR TITLE
add tox config for (optional) testing locally against multiple Python versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, py36
+
+[testenv]
+deps = pytest
+commands = 
+    pip install -e .[dev]
+    pytest


### PR DESCRIPTION
See relevant updates to the wiki: https://github.com/planetlabs/planet-client-python/wiki#managing-python-2--3

This basically mirrors our travis config (with a couple extra versions added) locally, to make it easier to test against multiple Pythons before pushing to GH