### PR TITLE
Put api.__version__ back in after version shuffle

### DIFF
--- a/planet/api/__init__.py
+++ b/planet/api/__init__.py
@@ -18,6 +18,7 @@ from .exceptions import (ServerError, RequestCancelled, TooManyRequests)
 from .client import (ClientV1)
 from .utils import write_to_file
 from . import filters
+from .__version__ import __version__  # NOQA
 
 __all__ = [
     ClientV1, APIException, BadQuery, InvalidAPIKey,


### PR DESCRIPTION
This lets us satisfy PEP-396 again (see also https://github.com/planetlabs/planet-client-python/issues/102) after the shuffle in https://github.com/planetlabs/planet-client-python/pull/119 temporarily removed `api.__version__` 