### PR TITLE
Display report with asset locations for all CLI downloads

### DIFF
--- a/planet/scripts/util.py
+++ b/planet/scripts/util.py
@@ -204,6 +204,8 @@ class _BaseOutput(object):
             'asset': asset['type'],
             'location': path or asset['location']
         }
+        # cancel() allows report log to persist for both ANSI & regular output
+        self.cancel()
         click.echo(json.dumps(msg))
 
     def __init__(self, thread, dl):
@@ -272,9 +274,6 @@ class AnsiOutput(_BaseOutput):
         with self._lock:
             self._stats.update(stats)
             self._do_output()
-
-    def _report_complete(self, item, asset, path=None):
-        pass
 
     def _do_output(self):
         # renders a terminal like:

--- a/planet/scripts/util.py
+++ b/planet/scripts/util.py
@@ -198,6 +198,14 @@ class _BaseOutput(object):
 
     refresh_rate = 1
 
+    def _report_complete(self, item, asset, path=None):
+        msg = {
+            'item': item['id'],
+            'asset': asset['type'],
+            'location': path or asset['location']
+        }
+        click.echo(json.dumps(msg))
+
     def __init__(self, thread, dl):
         self._thread = thread
         self._timer = None
@@ -227,14 +235,6 @@ class _BaseOutput(object):
 
 
 class Output(_BaseOutput):
-
-    def _report_complete(self, item, asset, path=None):
-        msg = {
-            'item': item['id'],
-            'asset': asset['type'],
-            'location': path or asset['location']
-        }
-        click.echo(json.dumps(msg))
 
     def _output(self, stats):
         logging.info('%s', stats)


### PR DESCRIPTION
Fix issue with ANSI output swallowing final report (ref: https://github.com/planetlabs/planet-client-python/issues/117). Asset location URLs are now displayed whether or not user uses `--quiet` output.