### PR TITLE
add sentinel1 item-type and fix test breakage

### DIFF
--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -11,7 +11,7 @@ _asset_types = None
 # In case the API fails to respond or takes too long.
 DEFAULT_ITEM_TYPES = [
     "PSScene4Band", "PSScene3Band", "REScene", "SkySatScene",
-    "REOrthoTile", "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G"]
+    "REOrthoTile", "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G", "Sentinel1"]
 
 DEFAULT_ASSET_TYPES = [
     "analytic", "analytic_b1", "analytic_b10", "analytic_b11", "analytic_b12",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -33,7 +33,8 @@ def test_item_type():
     check('all', get_item_types())
     check('psscene', ['PSScene3Band', 'PSScene4Band'])
     check('Sentinel2L1C', ['Sentinel2L1C'])
-    check('psscene,sent', ['PSScene3Band', 'PSScene4Band', 'Sentinel2L1C'])
+    check('psscene,sent', ['PSScene3Band', 'PSScene4Band',
+                           'Sentinel1', 'Sentinel2L1C'])
 
     with pytest.raises(Exception) as e:
         ItemType().convert('x', None, None)


### PR DESCRIPTION
An API addition broke a glob test in the client. This fixes the tests on master