### PR TITLE
Build universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
     - $HOME/.cache/pip
 before_install:
-  - pip install --upgrade pytest
+  - pip install setuptools pip --upgrade
 install:
   - pip install -e .[dev]
 script:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal: 1
+
+[metadata]
+license_file: LICENSE

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,7 @@ test_requires = [
 
 dev_requires = [
     'flake8',
-    # with pex 1.2.2, seems that more recent setuptools break things
-    # and the planet package will not be found
-    # see https://github.com/pantsbuild/pex/issues/301
-    'setuptools<21',
+    'setuptools',
     'pex',
     'pytest-cov',
     'sphinx',


### PR DESCRIPTION
I noticed that the current release on PyPI only includes a wheel for Python 3.5.  Since this project is compatible with Python 2, Python 3, and does not rely on any C extensions it is safe to upload a universal wheel.