### PR TITLE
Recommend '$ pip install --user' instead of just '$ pip install'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,14 @@ Python client library and CLI for Planet's public API.
 Installation
 ------------
 
-Via pip::
+Via pip:
 
-    pip install planet
+.. code-block:: console
+
+    $ pip install planet
+
+The `--user <https://pip.pypa.io/en/stable/user_guide/#user-installs>`__
+flag is highly recommended for those new to `pip <https://pip.pypa.io>`__.
 
 A PEX executable (Windows not supported) and source releases are
 `here <https://github.com/planetlabs/planet-client-python/releases/latest>`__.


### PR DESCRIPTION
Kinda closes #134 

I have yet to encounter a good guide for introducing `pip` and communicating simple best practices but linking to something like that would be a big documentation win.