### PR TITLE
Add mosaic support

### DIFF
--- a/planet/api/models.py
+++ b/planet/api/models.py
@@ -267,3 +267,11 @@ class Items(Features):
 
 class Searches(Paged):
     ITEM_KEY = 'searches'
+
+
+class Mosaics(Paged):
+    ITEM_KEY = 'mosaics'
+
+
+class MosaicQuads(Paged):
+    ITEM_KEY = 'items'

--- a/planet/scripts/types.py
+++ b/planet/scripts/types.py
@@ -274,3 +274,14 @@ class SortSpec(CompositeParamType):
             raise click.BadParameter(
                 'order only supports: %s' % ' '.join(orders))
         return ' '.join(val)
+
+
+class BoundingBox(click.ParamType):
+    name = 'rbox'
+
+    def convert(self, val, param, ctx):
+        try:
+            xmin, ymin, xmax, ymax = map(float, val.split(','))
+        except (TypeError, ValueError):
+            raise click.BadParameter('Invalid bounding box')
+        return (xmin, ymin, xmax, ymax)


### PR DESCRIPTION
Currently, the Python client does not support the v1 mosaics api.  As a result, there's no straightforward way for customers to download quads in bluk, as the Python client provides the main CLI tool for downloading. 

This still needs tests added, but I wanted to at least start discussion and see if this is the right place/way to include mosaic support in the python client.