### PR TITLE
Add LICENSE explicitly to setup.py so that pex can find it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(name='planet',
       url='https://github.com/planetlabs/planet-client-python',
       license='Apache 2.0',
       packages=find_packages(exclude=['examples', 'tests']),
+      data_files=[('', ['LICENSE'])],
       include_package_data=True,
       zip_safe=False,
       install_requires=[


### PR DESCRIPTION
With more recent versions of `setuptools` (or `distutils`), `pex` will explode on trying to include `LICENSE` unless it is explicitly declared.