### PR TITLE
Rename --rbox to --bbox in mosaic functions, leaving --rbox as an alias

### DIFF
--- a/docs/source/cli/examples.rst
+++ b/docs/source/cli/examples.rst
@@ -71,9 +71,9 @@ list all quads. Keep in mind that there may be millions for a global mosaic.)::
 
 Find all quads inside a particular area of interest::
     
-    planet mosaics search global_monthly_2018_09_mosaic --rbox=-95.5,29.6,-95.3,29.8
+    planet mosaics search global_monthly_2018_09_mosaic --bbox=-95.5,29.6,-95.3,29.8
 
-Note that the format of ``--rbox`` is "xmin,ymin,xmax,ymax", so longitude comes
+Note that the format of ``--bbox`` is "xmin,ymin,xmax,ymax", so longitude comes
 before latitude.
 
 Get basic information (footprint, etc) for a particular mosaic quad::
@@ -91,7 +91,7 @@ are hundreds of Terabytes in size)::
 
 Download all quads inside of a rectangular box for a mosaic::
 
-    planet mosaics download global_monthly_2018_09_mosaic --rbox=-95.5,29.6,-95.3,29.8
+    planet mosaics download global_monthly_2018_09_mosaic --bbox=-95.5,29.6,-95.3,29.8
 
 Integration With Other Tools
 ----------------------------

--- a/planet/scripts/types.py
+++ b/planet/scripts/types.py
@@ -277,7 +277,7 @@ class SortSpec(CompositeParamType):
 
 
 class BoundingBox(click.ParamType):
-    name = 'rbox'
+    name = 'bbox'
 
     def convert(self, val, param, ctx):
         try:

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -237,17 +237,19 @@ def list_mosaics(pretty):
 
 @mosaics.command('search')
 @click.argument('name')
-@click.option('--rbox', type=BoundingBox(), help=(
+@click.option('--bbox', type=BoundingBox(), help=(
     'Region to query as a comma-delimited string:'
     ' lon_min,lat_min,lon_max,lat_max'
 ))
+@click.option('--rbox', type=BoundingBox(), help='Alias for --bbox')
 @limit_option(None)
 @pretty
-def search_mosaics(name, rbox, limit, pretty):
+def search_mosaics(name, bbox, rbox, limit, pretty):
     '''Get quad IDs and information for a mosaic'''
+    bbox = bbox or rbox
     cl = clientv1()
     mosaic, = cl.get_mosaic_by_name(name).items_iter(1)
-    response = call_and_wrap(cl.get_quads, mosaic, rbox)
+    response = call_and_wrap(cl.get_quads, mosaic, bbox)
     echo_json_response(response, pretty, limit)
 
 
@@ -286,10 +288,11 @@ def quad_contributions(name, quad, pretty):
 
 @mosaics.command('download')
 @click.argument('name')
-@click.option('--rbox', type=BoundingBox(), help=(
+@click.option('--bbox', type=BoundingBox(), help=(
     'Region to download as a comma-delimited string:'
     ' lon_min,lat_min,lon_max,lat_max'
 ))
+@click.option('--rbox', type=BoundingBox(), help='Alias for --bbox')
 @click.option('--quiet', is_flag=True, help=(
     'Disable ANSI control output'
 ))
@@ -298,8 +301,9 @@ def quad_contributions(name, quad, pretty):
      exists=True, resolve_path=True, writable=True, file_okay=False
 ))
 @limit_option(None)
-def download_quads(name, rbox, quiet, dest, limit):
+def download_quads(name, bbox, rbox, quiet, dest, limit):
     '''Download quads from a mosaic'''
+    bbox = bbox or rbox
     cl = clientv1()
 
     dl = downloader.create(cl, mosaic=True)
@@ -307,7 +311,7 @@ def download_quads(name, rbox, quiet, dest, limit):
     output.start()
     try:
         mosaic, = cl.get_mosaic_by_name(name).items_iter(1)
-        items = cl.get_quads(mosaic, rbox).items_iter(limit)
+        items = cl.get_quads(mosaic, bbox).items_iter(limit)
     except Exception as ex:
         output.cancel()
         click_exception(ex)


### PR DESCRIPTION
Currently, mosaic search/etc functions use the rather non-standard "rbox" parameter to specify a bounding box, instead of the more common "bbox".  The underlying api uses `bbox` as the parameter name, as do most similar interfaces and libraries.  

This PR adds a `--bbox` option to `planet mosaics search` and `planet mosaics download` and leaves `--rbox` as an alias to `--bbox` for backwards compatibility.