### PR TITLE
Support Python 3.7 by removing keywords.

### DIFF
--- a/planet/api/downloader.py
+++ b/planet/api/downloader.py
@@ -350,7 +350,7 @@ class _Downloader(Downloader):
         self._opts = opts
         self._stages = []
         self._completed = 0
-        self._awaiting = None
+        self._waiting = None
 
     def activate(self, items, asset_types):
         return self._run(items, asset_types)
@@ -398,10 +398,10 @@ class _Downloader(Downloader):
                         self.on_complete(item, assets[a])
                 # otherwise it is a download
                 else:
-                    item, asset, self._awaiting = n
+                    item, asset, self._waiting = n
                     try:
-                        body = self._awaiting.await()
-                        self._awaiting = None
+                        body = self._waiting.wait()
+                        self._waiting = None
                         dl = os.path.join(self._dest, body.name)
                         self.on_complete(item, asset, dl)
                     except RequestCancelled:
@@ -455,7 +455,7 @@ class _Downloader(Downloader):
     def shutdown(self):
         for s in self._stages:
             s.cancel()
-        self._awaiting and self._awaiting.cancel()
+        self._waiting and self._waiting.cancel()
         self._stages = []
         self._client.shutdown()
 

--- a/planet/api/models.py
+++ b/planet/api/models.py
@@ -52,18 +52,18 @@ class Response(object):
         check_status(response)
         self._body = self._create_body(response)
         self._handler(self._body)
-        if self._await:
-            self._await(self._body)
+        if self._wait:
+            self._wait(self._body)
 
-    def get_body_async(self, handler, await=None):
+    def get_body_async(self, handler, wait=None):
         if self._future is None:
             self._handler = handler
-            self._await = await
+            self._wait = wait
             self._future = self._dispatcher._dispatch_async(
                 self.request, self._async_callback
             )
 
-    def await(self):
+    def wait(self):
         '''Await completion of this request.
 
         :returns Body: A Body object containing the response.

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -33,7 +33,7 @@ class Body(object):
         callback(finish=self)
         self._got_write = True
 
-    def await(self):
+    def wait(self):
         pass
 
     def cancel(self):
@@ -51,7 +51,7 @@ class Download(object):
         # don't write to the body synchronously
         threading.Timer(WRITE_DELAY, respond).start()
 
-    def await(self):
+    def wait(self):
         return self._future.result()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Changed `await` to `wait` to provide Python 3.7 compatibility. Closes issue #147.