### PR TITLE
Add `strict` keyword argument to searches

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -130,6 +130,9 @@ class ClientV1(_Base):
             params['_page_size'] = kw['page_size']
         if 'sort' in kw and kw['sort']:
             params['_sort'] = ''.join(kw['sort'])
+        if 'strict' in kw:
+            # This transforms a Python boolean into a JSON boolean
+            params['strict'] = json.dumps(kw['strict'])
         return params
 
     def create_search(self, request):


### PR DESCRIPTION
According to the API documentation (https://developers.planet.com/docs/api/reference/#operation/QuickSearch), it is possible to pass a `strict` argument to QuickSearches and SavedSearches.

This didn't seem to be implemented in the Python client, so I have added it.

I expect the user to pass in a call such as:
```python
result = client.quick_search(request, strict=True)
```

with a Python boolean as the value for the keyword argument.

I do not know what low-level request-handling library you are using, but it seems that it does not automatically encode the `params` dict into a `JSON` string (for example, the library `requests` does that for you, if you call `requests.post` with a `json` keyword argument (documentation [here](https://2.python-requests.org/en/master/user/quickstart/#more-complicated-post-requests)).

In order to get around this problem, I `json.dumps` the value given, such that if you call `_params(strict=True)`, it returns `{"strict": "true"}`.