### PR TITLE
Add new UDM2 and related asset types

### DIFF
--- a/planet/api/utils.py
+++ b/planet/api/utils.py
@@ -329,7 +329,7 @@ def handle_interrupt(cancel, f, *a, **kw):
     t.start()
     # poll (or we miss the interrupt) and await completion
     try:
-        while t.isAlive():
+        while t.is_alive():
             t.join(.1)
     except KeyboardInterrupt:
         cancel()

--- a/planet/scripts/item_asset_types.py
+++ b/planet/scripts/item_asset_types.py
@@ -11,36 +11,62 @@ _asset_types = None
 # Default values here are used as a fallback
 # In case the API fails to respond or takes too long.
 DEFAULT_ITEM_TYPES = [
-    "PSScene4Band", "PSScene3Band", "REScene", "REOrthoTile",
-    "Sentinel2L1C", "PSOrthoTile", "Landsat8L1G", "Sentinel1",
-    "MOD09GA", "MOD09GQ", "MYD09GA", "MYD09GQ",
-    "SkySatScene", "SkySatCollect"]
+    'Landsat8L1G',
+    'MOD09GA',
+    'MOD09GQ',
+    'MYD09GA',
+    'MYD09GQ',
+    'PSOrthoTile',
+    'PSScene3Band',
+    'PSScene4Band',
+    'REOrthoTile',
+    'REScene',
+    'Sentinel1',
+    'Sentinel2L1C',
+    'SkySatCollect',
+    'SkySatScene'
+]
 
 DEFAULT_ASSET_TYPES = [
-    "analytic", "analytic_b1", "analytic_b10", "analytic_b11", "analytic_b12",
-    "analytic_b2", "analytic_b3", "analytic_b4", "analytic_b5", "analytic_b6",
-    "analytic_b7", "analytic_b8", "analytic_b8a", "analytic_b9",
-    "analytic_bqa", "analytic_dn", "analytic_dn_xml", "analytic_ms",
-    "analytic_xml", "analytic_sr", "basic_analytic", "basic_analytic_b1",
-    "basic_analytic_b1_nitf", "basic_analytic_b2", "basic_analytic_b2_nitf",
-    "basic_analytic_b3", "basic_analytic_b3_nitf", "basic_analytic_b4",
-    "basic_analytic_b4_nitf", "basic_analytic_b5", "basic_analytic_b5_nitf",
-    "basic_analytic_dn", "basic_analytic_dn_nitf", "basic_analytic_dn_rpc",
-    "basic_analytic_dn_rpc_nitf", "basic_analytic_dn_xml",
-    "basic_analytic_dn_xml_nitf", "basic_analytic_nitf", "basic_analytic_rpc",
-    "basic_analytic_rpc_nitf", "basic_analytic_sci", "basic_analytic_xml",
-    "basic_analytic_xml_nitf", "basic_panchromatic_dn",
-    "basic_panchromatic_dn_rpc", "basic_udm", "browse", "metadata_aux",
-    "metadata_txt", "ortho_analytic_dn", "ortho_analytic_udm",
-    "ortho_panchromatic_dn", "ortho_panchromatic_udm", "ortho_pansharpened",
-    "ortho_pansharpened_udm", "ortho_visual", "udm", "visual", "visual_xml"]
+    'analytic', 'analytic_b1', 'analytic_b10', 'analytic_b11', 'analytic_b12',
+    'analytic_b2', 'analytic_b3', 'analytic_b4', 'analytic_b5', 'analytic_b6',
+    'analytic_b7', 'analytic_b8', 'analytic_b8a', 'analytic_b9',
+    'analytic_bqa', 'analytic_dn', 'analytic_dn_xml', 'analytic_gflags',
+    'analytic_granule_pnt', 'analytic_iobs_res', 'analytic_ms',
+    'analytic_num_observations', 'analytic_num_observations_1km',
+    'analytic_num_observations_500m', 'analytic_obscov',
+    'analytic_obscov_500m', 'analytic_orbit_pnt', 'analytic_q_scan',
+    'analytic_qc_250m', 'analytic_qc_500m', 'analytic_range',
+    'analytic_sensor_azimuth', 'analytic_sensor_zenith',
+    'analytic_solar_azimuth', 'analytic_solar_zenith', 'analytic_sr',
+    'analytic_state_1km', 'analytic_sur_refl_b01', 'analytic_sur_refl_b02',
+    'analytic_sur_refl_b03', 'analytic_sur_refl_b04', 'analytic_sur_refl_b05',
+    'analytic_sur_refl_b06', 'analytic_sur_refl_b07', 'analytic_xml',
+    'basic_analytic', 'basic_analytic_b1', 'basic_analytic_b1_nitf',
+    'basic_analytic_b2', 'basic_analytic_b2_nitf', 'basic_analytic_b3',
+    'basic_analytic_b3_nitf', 'basic_analytic_b4', 'basic_analytic_b4_nitf',
+    'basic_analytic_b5', 'basic_analytic_b5_nitf', 'basic_analytic_dn',
+    'basic_analytic_dn_nitf', 'basic_analytic_dn_rpc',
+    'basic_analytic_dn_rpc_nitf', 'basic_analytic_dn_xml',
+    'basic_analytic_dn_xml_nitf', 'basic_analytic_nitf', 'basic_analytic_rpc',
+    'basic_analytic_rpc_nitf', 'basic_analytic_sci', 'basic_analytic_udm2',
+    'basic_analytic_xml', 'basic_analytic_xml_nitf', 'basic_panchromatic',
+    'basic_panchromatic_dn', 'basic_panchromatic_dn_rpc',
+    'basic_panchromatic_rpc', 'basic_panchromatic_udm2', 'basic_udm',
+    'basic_udm2', 'browse', 'metadata_aux', 'metadata_txt', 'ortho_analytic',
+    'ortho_analytic_dn', 'ortho_analytic_hh', 'ortho_analytic_hv',
+    'ortho_analytic_udm', 'ortho_analytic_udm2', 'ortho_analytic_vh',
+    'ortho_analytic_vv', 'ortho_panchromatic', 'ortho_panchromatic_dn',
+    'ortho_panchromatic_udm', 'ortho_panchromatic_udm2', 'ortho_pansharpened',
+    'ortho_pansharpened_udm', 'ortho_pansharpened_udm2', 'ortho_visual', 'udm',
+    'udm2', 'visual', 'visual_xml'
+]
 
 
-def _get_json_or_raise(url, timeout=0.7):
+def _get_json_or_raise(url, timeout=11):
     api_key = find_api_key()
     headers = {'User-Agent': _get_user_agent(),
-               'Authorization': 'api-key %s' % api_key
-               }
+               'Authorization': 'api-key %s' % api_key}
     resp = requests.get(url, timeout=timeout, headers=headers)
     resp.raise_for_status()
     return resp.json()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,7 +13,9 @@
 # limitations under the License
 
 import json
-from planet.scripts.types import get_item_types
+import mock
+from planet.scripts.item_asset_types import DEFAULT_ASSET_TYPES
+from planet.scripts.item_asset_types import DEFAULT_ITEM_TYPES
 from planet.scripts.types import AssetType
 from planet.scripts.types import GeomFilter
 from planet.scripts.types import ItemType
@@ -27,10 +29,12 @@ def convert_asserter(t):
     return asserter
 
 
+@mock.patch('planet.scripts.types.get_item_types',
+            new=mock.Mock(return_value=DEFAULT_ITEM_TYPES))
 def test_item_type():
     check = convert_asserter(ItemType())
 
-    check('all', get_item_types())
+    check('all', DEFAULT_ITEM_TYPES)
     check('psscene', ['PSScene3Band', 'PSScene4Band'])
     check('Sentinel2L1C', ['Sentinel2L1C'])
     check('psscene,sent', ['PSScene3Band', 'PSScene4Band',
@@ -40,7 +44,8 @@ def test_item_type():
         ItemType().convert('x', None, None)
     assert 'invalid choice: x' in str(e.value)
 
-
+@mock.patch('planet.scripts.types.get_asset_types',
+            new=mock.Mock(return_value=DEFAULT_ASSET_TYPES))
 def test_asset_type():
     check = convert_asserter(AssetType())
     check('visual*', ['visual', 'visual_xml'])


### PR DESCRIPTION
This pull request does 4 things:
- Changes usage of the deprecated `.isAlive` from the `threading` library to `.is_alive`
- Adds all item and asset types from the current staging environment to the supported default list, to prevent/limit calls to `get_remote_choices`
- Makes the default timeout for `_get_json_or_raise` go to 11, as 0.7 was too short of a time to do an authenticated round-trip to the server and was triggering unhelpful user errors when attempting to query for non-local asset or item types
- Mocks out calls in `tests/test_types.py` that would raise a 401 error when attempting to get remote item types or asset types, as these endpoints now require authentication