### PR TITLE
Update the `NotFilter` to match the backing API

### DIFF
--- a/planet/api/filters.py
+++ b/planet/api/filters.py
@@ -93,8 +93,8 @@ def or_filter(*predicates):
     return _filter('OrFilter', predicates)
 
 
-def not_filter(*predicates):
-    return _filter('NotFilter', predicates)
+def not_filter(predicate):
+    return _filter('NotFilter', predicate)
 
 
 def date_range(field_name, **kwargs):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -25,3 +25,74 @@ def test_date_range(dt, expected):
     arg = "gte"
 
     assert filters.date_range(fieldname, **{arg: dt}) == expected
+
+
+@pytest.mark.parametrize('predicate, expected', [
+    (
+        filters.string_filter('id', '20190625_070754_20_105c',
+                              '20190324_150924_104b'),
+        {
+            'type': 'NotFilter',
+            'config': {
+                'field_name': 'id',
+                'type': 'StringInFilter',
+                'config': (
+                    '20190625_070754_20_105c',
+                    '20190324_150924_104b'
+                )
+            }
+        }
+    ),
+    (
+        filters.string_filter('ground_control', 'false'),
+        {
+            'type': 'NotFilter',
+            'config': {
+                'type': 'StringInFilter',
+                'field_name': 'ground_control',
+                'config': ('false',)
+            }
+        }
+    )
+])
+def test_not_filter(predicate, expected):
+    assert expected == filters.not_filter(predicate)
+
+
+@pytest.mark.parametrize('filt, expected', [
+    (
+        filters.and_filter(
+            filters.date_range('published',
+                               lt='2019-08-29T13:20:37.776031Z'),
+            filters.not_filter(
+                filters.string_filter('id', '20190625_070754_20_105c',
+                                      '20190324_150924_104b')
+            )
+        ),
+        {
+            'type': 'AndFilter',
+            'config': (
+                {
+                    'field_name': 'published',
+                    'type': 'DateRangeFilter',
+                    'config': {
+                        'lt': '2019-08-29T13:20:37.776031Z'
+                    }
+                },
+                {
+                    'type': 'NotFilter',
+                    'config': {
+                        'field_name': 'id',
+                        'type': 'StringInFilter',
+                        'config': (
+                            '20190625_070754_20_105c',
+                            '20190324_150924_104b'
+                        )
+                    }
+                }
+            )
+        }
+    )
+])
+def test_complex(filt, expected):
+    assert expected == filt


### PR DESCRIPTION
This updates the `NotFilter` to use a single predicate object instead of an array of boolean or field filters. The documentation at https://developers.planet.com/docs/api/searches-filtering/#logical-filters will also need to be updated.