### PR TITLE
Set tls truststore

### DIFF
--- a/docs/source/cli/reference.rst
+++ b/docs/source/cli/reference.rst
@@ -10,30 +10,16 @@ Option Types Formatting
 -----------------------
 
 
-.. _cli-metavar-FIELD-COMP-VALUE:
+.. _cli-metavar-FILTER:
 
 
-FIELD COMP VALUE...
-...................
+FILTER
+......
 
 
-A comparison query format where FIELD is a
-property of the item-type and COMP is one of lt, lte, gt, gte and VALUE is
-the number or date to compare against.
-
-Note: ISO-8601 variants are supported. For example, ``2017`` is short for
-``2017-01-01T00:00:00+00:00``.
-
-
-.. _cli-metavar-FIELD-VALUES:
-
-
-FIELD VALUES...
-...............
-
-
-Specifies an 'in' query where FIELD is a property
-of the item-type and VALUES is space or comma separated text or numbers.
+Specify a Data API search filter provided as JSON.
+``@-`` specifies stdin and ``@filename`` specifies reading from a file
+named 'filename'. Otherwise, the value is assumed to be JSON.
 
 
 .. _cli-metavar-GEOM:
@@ -49,28 +35,30 @@ reading from a file named 'filename'. Otherwise, the value is assumed to
 be GeoJSON.
 
 
-.. _cli-metavar-FILTER:
+.. _cli-metavar-FIELD-VALUES:
 
 
-FILTER
-......
+FIELD VALUES...
+...............
 
 
-Specify a Data API search filter provided as JSON.
-``@-`` specifies stdin and ``@filename`` specifies reading from a file
-named 'filename'. Otherwise, the value is assumed to be JSON.
+Specifies an 'in' query where FIELD is a property
+of the item-type and VALUES is space or comma separated text or numbers.
 
 
-.. _cli-metavar-ITEM-TYPE:
+.. _cli-metavar-FIELD-COMP-VALUE:
 
 
-ITEM-TYPE
-.........
+FIELD COMP VALUE...
+...................
 
 
-Specify Item-Type(s) of interest. Case-insensitive,
-supports glob-matching, e.g. ``psscene*`` means ``PSScene3Band`` and
-``PSScene4Band``. The ``all`` value specifies every Item-Type.
+A comparison query format where FIELD is a
+property of the item-type and COMP is one of lt, lte, gt, gte and VALUE is
+the number or date to compare against.
+
+Note: ISO-8601 variants are supported. For example, ``2017`` is short for
+``2017-01-01T00:00:00+00:00``.
 
 
 .. _cli-metavar-ASSET-TYPE:
@@ -83,6 +71,18 @@ ASSET-TYPE
 Specify Asset-Type(s) of interest. Case-insenstive,
 supports glob-matching, e.g. ``visual*`` specifies ``visual`` and
 ``visual_xml``.
+
+
+.. _cli-metavar-ITEM-TYPE:
+
+
+ITEM-TYPE
+.........
+
+
+Specify Item-Type(s) of interest. Case-insensitive,
+supports glob-matching, e.g. ``psscene*`` means ``PSScene3Band`` and
+``PSScene4Band``. The ``all`` value specifies every Item-Type.
 
 
 General Options
@@ -109,6 +109,11 @@ General Options
 
 
 
+``--ssl-trustedcerts``
+   Path to a PEM file to use for verifying the server's certificates, overriding the default trust store. The environment variable PL_SSL_TRUSTEDCERTS may also be used to set this value. This is useful for environments with a SSL terminating proxy.
+
+
+
 ``--version``
    Show the version and exit.
 
@@ -118,11 +123,11 @@ General Commands
 ----------------
 
 
-:ref:`cli-command-help` Get command help
+:ref:`cli-command-help` None
 
 
 
-:ref:`cli-command-init` Login using email/password
+:ref:`cli-command-init` None
 
 
 
@@ -175,31 +180,31 @@ Data API
 --------
 
 
-:ref:`cli-command-create-search` Create a saved search
+:ref:`cli-command-create-search` None
 
 
 
-:ref:`cli-command-download` Activate and download
+:ref:`cli-command-download` None
 
 
 
-:ref:`cli-command-filter` Output a AND filter as JSON to stdout.
+:ref:`cli-command-filter` None
 
 
 
-:ref:`cli-command-saved-search` Execute a saved search
+:ref:`cli-command-saved-search` None
 
 
 
-:ref:`cli-command-search` Execute a quick search.
+:ref:`cli-command-search` None
 
 
 
-:ref:`cli-command-searches` List searches
+:ref:`cli-command-searches` None
 
 
 
-:ref:`cli-command-stats` Get search stats
+:ref:`cli-command-stats` None
 
 
 
@@ -304,7 +309,7 @@ Usage: download [OPTIONS]
      - Format
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: None
 
      - NUMBER
 
@@ -471,7 +476,7 @@ Usage: saved-search [OPTIONS] [SEARCH_ID]
      - BOOLEAN
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: 100
 
        DEFAULT: `100`
      - NUMBER
@@ -499,7 +504,7 @@ Usage: search [OPTIONS]
      - Format
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: 100
 
        DEFAULT: `100`
      - NUMBER
@@ -587,6 +592,12 @@ Usage: searches [OPTIONS]
 
        DEFAULT: `True`
      - BOOLEAN
+
+   * - limit
+     - Limit the number of items. Default: 10
+
+       DEFAULT: `10`
+     - NUMBER
 
 .. index:: stats
 

--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Planet Labs, Inc.
+# Copyright 2015-2019 Planet Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ class _Base(object):
     '''High-level access to Planet's API.'''
 
     def __init__(self, api_key=None, base_url='https://api.planet.com/',
-                 workers=4):
+                 workers=4, ssl_trustedcerts=None):
         '''
         :param str api_key: API key to use. Defaults to environment variable.
         :param str base_url: The base URL to use. Not required.
@@ -36,7 +36,7 @@ class _Base(object):
         self.base_url = base_url
         if not self.base_url.endswith('/'):
             self.base_url += '/'
-        self.dispatcher = RequestsDispatcher(workers)
+        self.dispatcher = RequestsDispatcher(workers, ssl_trustedcerts)
 
     def shutdown(self):
         self.dispatcher._asyncpool.executor.shutdown(wait=False)

--- a/planet/api/dispatch.py
+++ b/planet/api/dispatch.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Planet Labs, Inc.
+# Copyright 2015-2019 Planet Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ from . exceptions import TooManyRequests
 from . __version__ import __version__
 from requests.compat import urlparse
 
-
+# Cleanup? I don't think we use this for anything.
+# (Or, maybe have a mode to entirely disable cert checks.)
 USE_STRICT_SSL = not (os.getenv('DISABLE_STRICT_SSL', '').lower() == 'true')
 
 log = logging.getLogger(__name__)
@@ -133,9 +134,11 @@ def _do_request(sess, req, **kwargs):
 
 class RequestsDispatcher(object):
 
-    def __init__(self, workers=4):
+    def __init__(self, workers=4, ssl_truststore=None):
         # general session for sync api calls
         self.session = RedirectSession()
+        if ssl_truststore:
+            self.session.verify = ssl_truststore
         self.session.headers.update({'User-Agent': _get_user_agent()})
         # ensure all calls to the session are throttled
         self.session.request = _Throttler().wrap(self.session.request)

--- a/planet/api/dispatch.py
+++ b/planet/api/dispatch.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import os
 import re
 import threading
 import time
@@ -26,9 +25,6 @@ from . exceptions import InvalidAPIKey
 from . exceptions import TooManyRequests
 from . __version__ import __version__
 from requests.compat import urlparse
-
-# I don't think this is working as intended (even before my changes)
-USE_STRICT_SSL = not (os.getenv('DISABLE_STRICT_SSL', '').lower() == 'true')
 
 log = logging.getLogger(__name__)
 
@@ -117,7 +113,7 @@ def _do_request(sess, req, **kwargs):
             t = time.time()
             resp = sess.request(
                 req.method, req.url, data=req.data, headers=_headers(req),
-                params=req.params, verify=USE_STRICT_SSL, **kwargs
+                params=req.params, **kwargs
             )
             # futures session returns futures so only check actual responses
             # for futures these will be checked in the wrapper model
@@ -167,4 +163,4 @@ class RequestsDispatcher(object):
             })
         req = Request(method, url, params=params, data=data, headers=headers)
         _log_request(req)
-        return self.session.send(req.prepare(), verify=USE_STRICT_SSL)
+        return self.session.send(req.prepare())

--- a/planet/api/dispatch.py
+++ b/planet/api/dispatch.py
@@ -27,8 +27,7 @@ from . exceptions import TooManyRequests
 from . __version__ import __version__
 from requests.compat import urlparse
 
-# Cleanup? I don't think we use this for anything.
-# (Or, maybe have a mode to entirely disable cert checks.)
+# I don't think this is working as intended (even before my changes)
 USE_STRICT_SSL = not (os.getenv('DISABLE_STRICT_SSL', '').lower() == 'true')
 
 log = logging.getLogger(__name__)

--- a/planet/api/dispatch.py
+++ b/planet/api/dispatch.py
@@ -152,15 +152,3 @@ class RequestsDispatcher(object):
     def _dispatch(self, request, callback=None):
         return _do_request(self.session, request)
 
-    # @todo delete me w/ v0 removal
-    def dispatch_request(self, method, url, auth=None, params=None, data=None):
-        headers = {}
-        content_type = 'application/json'
-        if auth:
-            headers.update({
-                'Authorization': 'api-key %s' % auth.value,
-                'Content-Type': content_type
-            })
-        req = Request(method, url, params=params, data=data, headers=headers)
-        _log_request(req)
-        return self.session.send(req.prepare())

--- a/planet/api/dispatch.py
+++ b/planet/api/dispatch.py
@@ -17,7 +17,6 @@ import re
 import threading
 import time
 from requests_futures.sessions import FuturesSession
-from requests import Request
 from requests import Session
 from . utils import check_status
 from . models import Response
@@ -151,4 +150,3 @@ class RequestsDispatcher(object):
 
     def _dispatch(self, request, callback=None):
         return _do_request(self.session, request)
-

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Planet Labs, Inc.
+# Copyright 2017-2019 Planet Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,8 +62,15 @@ def configure_logging(verbosity):
 @click.option('-u', '--base-url', envvar='PL_API_BASE_URL',
               help='Change the base Planet API URL or ENV PL_API_BASE_URL'
                    ' - Default https://api.planet.com/')
+@click.option('-t', '--ssl-trustedcerts',
+              envvar='PL_SSL_TRUSTEDCERTS',
+              type=click.Path(exists=True),
+              help='Path to a PEM file to use for verifying the server'
+                   ' certificates, overriding the default trust store.'
+                   ' The environment variable PL_SSL_TRUSTEDCERTS may also be'
+                   ' used to set this value.')
 @click.version_option(version=__version__, message='%(version)s')
-def cli(context, verbose, api_key, base_url, workers):
+def cli(context, verbose, api_key, base_url, workers, ssl_trustedcerts):
     '''Planet API Client'''
 
     configure_logging(verbose)
@@ -73,6 +80,8 @@ def cli(context, verbose, api_key, base_url, workers):
     client_params['workers'] = workers
     if base_url:
         client_params['base_url'] = base_url
+    if ssl_trustedcerts:
+        client_params['ssl_trustedcerts'] = ssl_trustedcerts
 
 
 @cli.command('help')

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -69,7 +69,8 @@ def configure_logging(verbosity):
                    ' certificates, overriding the default trust store.'
                    ' The environment variable PL_SSL_TRUSTEDCERTS may also be'
                    ' used to set this value.'
-                   ' This is useful for environments with a SSL terminating proxy.')
+                   ' This is useful for environments with a SSL'
+                   ' terminating proxy.')
 @click.version_option(version=__version__, message='%(version)s')
 def cli(context, verbose, api_key, base_url, workers, ssl_trustedcerts):
     '''Planet API Client'''

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -65,10 +65,11 @@ def configure_logging(verbosity):
 @click.option('-t', '--ssl-trustedcerts',
               envvar='PL_SSL_TRUSTEDCERTS',
               type=click.Path(exists=True),
-              help='Path to a PEM file to use for verifying the server'
+              help='Path to a PEM file to use for verifying the server\'s'
                    ' certificates, overriding the default trust store.'
                    ' The environment variable PL_SSL_TRUSTEDCERTS may also be'
-                   ' used to set this value.')
+                   ' used to set this value.'
+                   ' This is useful for environments with a SSL terminating proxy.')
 @click.version_option(version=__version__, message='%(version)s')
 def cli(context, verbose, api_key, base_url, workers, ssl_trustedcerts):
     '''Planet API Client'''


### PR DESCRIPTION
Work to allow you to specify what certs to use to check the server cert.   While working on this I also noticed a feature where you could use an env variable (DISABLE_STRICT_SSL) to completely disable SSL checks.  From what I could tell, that wasn't working.  I have work on another branch to try and bring that functionality back, but I currently have other issues with that.

I also think there might be an issue with the generated docs.  The one line summaries of sub commands have been cleared out to "None".  Looking at the current live docs (https://planetlabs.github.io/planet-client-python/cli/reference.html), I don't think this is a new problem.  It just shows in this PR because I ran the doc generation and put it in the commit.