### PR TITLE
removing monkey patch

### DIFF
--- a/planet/scripts/util.py
+++ b/planet/scripts/util.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Planet Labs, Inc.
+# Copyright 2017-2019 Planet Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
I don't believe this monkey patch works with Python 3.7.  I'm also not so sure that suppressing warnings about bad SSL practices was a good idea in the first place. 

On python 3.7, if you set the env variable DISABLE_STRICT_SSL to true to deactivate SSL cert checks in dispatch.py, you will encounter this error: 

> [  . . . Stack trace trimmed for brevity . . .  ]
>   File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/warnings.py", line 110, in _showwarnmsg
>     msg.file, msg.line)
> TypeError: hack() takes 4 positional arguments but 6 were given

This appears to be an issue with how the monkey patch interacts with the Python 3.7 warnings.py. 

(I also am not sure that the existing DISABLE_STRICT_SSL feature in dispatch.py works in all cases - I've seen it not cover everything the QGIS plugin does. But that's a question for another merge request.) 
