### PR TITLE
Response sometimes can print twice

### DIFF
--- a/planet/scripts/util.py
+++ b/planet/scripts/util.py
@@ -171,23 +171,26 @@ def echo_json_response(response, pretty, limit=None, ndjson=False):
         sort_keys = True
         nl = True
     try:
-        if ndjson and hasattr(response, 'items_iter'):
+        if hasattr(response, 'items_iter'):
             items = response.items_iter(limit)
-            for item in items:
-                click.echo(json.dumps(item))
+            if ndjson:
+                for item in items:
+                    click.echo(json.dumps(item))
+            else:
+                click.echo(json.dumps(list(items)))
         elif not ndjson and hasattr(response, 'json_encode'):
             response.json_encode(click.get_text_stream('stdout'), limit=limit,
                                  indent=indent, sort_keys=sort_keys)
-
-        res = response.get_raw()
-        if len(res) == 0:  # if the body is empty, just return the status
-            click.echo("status: {}".format(response.response.status_code))
         else:
-            res = json.dumps(json.loads(res), indent=indent,
-                             sort_keys=sort_keys)
-            click.echo(res)
-        if nl:
-            click.echo()
+            res = response.get_raw()
+            if len(res) == 0:  # if the body is empty, just return the status
+                click.echo("status: {}".format(response.response.status_code))
+            else:
+                res = json.dumps(json.loads(res), indent=indent,
+                                 sort_keys=sort_keys)
+                click.echo(res)
+            if nl:
+                click.echo()
     except IOError as ioe:
         # hide scary looking broken pipe stack traces
         raise click.ClickException(str(ioe))

--- a/planet/scripts/util.py
+++ b/planet/scripts/util.py
@@ -171,13 +171,10 @@ def echo_json_response(response, pretty, limit=None, ndjson=False):
         sort_keys = True
         nl = True
     try:
-        if hasattr(response, 'items_iter'):
+        if ndjson and hasattr(response, 'items_iter'):
             items = response.items_iter(limit)
-            if ndjson:
-                for item in items:
-                    click.echo(json.dumps(item))
-            else:
-                click.echo(json.dumps(list(items)))
+            for item in items:
+                click.echo(json.dumps(item))
         elif not ndjson and hasattr(response, 'json_encode'):
             response.json_encode(click.get_text_stream('stdout'), limit=limit,
                                  indent=indent, sort_keys=sort_keys)


### PR DESCRIPTION
Under the existing code for `echo_json_response`, if either of the first two conditions resulted in the response body being printed, the raw response would get printed a second time.