### PR TITLE
Pin requests-futures version to avoid error message.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click>=4.1
-requests-futures>=0.9.7
+requests-futures==0.9.7
 requests>=2.13

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='planet',
       install_requires=[
           'click',
           'requests',
-          'requests_futures',
+          'requests_futures == 0.9.7',
           'pywin32 >= 1.0;platform_system=="Windows"'
       ],
       extras_require={


### PR DESCRIPTION
Get rid of the error ...

```
`background_callback` is deprecated and will be removed in 1.0, use `hooks` instead
```