### PR TITLE
WIP: Experimental basemaps client

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -20,12 +20,13 @@ from .exceptions import (InvalidIdentity, APIException)
 from . import models
 from . import filters
 
+BASE_URL = 'https://api.planet.com/'
+
 
 class _Base(object):
     '''High-level access to Planet's API.'''
 
-    def __init__(self, api_key=None, base_url='https://api.planet.com/',
-                 workers=4):
+    def __init__(self, api_key=None, base_url=BASE_URL, workers=4):
         '''
         :param str api_key: API key to use. Defaults to environment variable.
         :param str base_url: The base URL to use. Not required.

--- a/planet/api/experimental/basemaps_client.py
+++ b/planet/api/experimental/basemaps_client.py
@@ -1,0 +1,73 @@
+from .. import auth
+from ..client import BASE_URL
+from ..exceptions import APIException
+
+import requests
+from requests.adapters import HTTPAdapter
+
+
+class BasemapsClientV1(object):
+    def __init__(self, api_key=None, base_url=BASE_URL):
+        '''
+        :param str api_key: planet API key. Defaults to the PL_API_KEY env var.
+        :param str base_url: The base URL to use. Not required.
+        '''
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.base_url = base_url
+        self.api_key = api_key or auth.find_api_key()
+        session = requests.Session()
+        session.auth = (self.api_key, '')
+        adapter = HTTPAdapter(max_retries=5)
+        session.mount("https://", adapter)
+        self.session = session
+
+    def _get(self, url):
+        resp = self.session.get(url)
+        if not resp.ok:
+            raise APIException('{}: {}'.format(resp.status_code, resp.content))
+        return resp
+
+    def list_basemap_series(self):
+        url = self.base_url + 'basemaps/v1/series/'
+        while url:
+            resp = self._get(url)
+            series_list = resp.json().get('series', [])
+            for s in series_list:
+                yield s
+            url = resp.json().get('_links', {}).get('_next')
+
+    def get_basemap_series(self, series_id):
+        url = self.base_url + 'basemaps/v1/series/{}'.format(series_id)
+        return self._get(url).json()
+
+    def list_mosaics_in_basemap_series(self, series_id):
+        url = self.base_url + 'basemaps/v1/series/{}/mosaics'.format(series_id)
+        while url:
+            resp = self._get(url)
+            series_list = resp.json().get('mosaics', [])
+            for s in series_list:
+                yield s
+            url = resp.json().get('_links', {}).get('_next')
+
+    def get_mosaic(self, mosaic_id):
+        url = self.base_url + 'basemaps/v1/mosaics/{}'.format(mosaic_id)
+        return self._get(url).json()
+
+    def list_quads_in_mosaic(
+        self,
+        mosaic_id,
+        min_lat=-85,
+        min_lon=-180,
+        max_lat=85,
+        max_lon=180
+    ):
+        bbox = '{},{},{},{}'.format(min_lon, min_lat, max_lon, max_lat)
+        url = self.base_url + 'basemaps/v1/mosaics/{}/quads'.format(mosaic_id)
+        url += '?bbox={}'.format(bbox)
+        while url:
+            resp = self._get(url)
+            quad_list = resp.json().get('items', [])
+            for s in quad_list:
+                yield s
+            url = resp.json().get('_links', {}).get('_next')

--- a/tests/test_basemaps_client.py
+++ b/tests/test_basemaps_client.py
@@ -1,0 +1,77 @@
+import os
+import json
+
+import pytest
+import requests_mock
+from planet.api.experimental.basemaps_client import BasemapsClientV1
+from planet.api import APIException
+
+
+@pytest.fixture()
+def basemaps_client():
+    return BasemapsClientV1('fakekey')
+
+
+def test_list_basemap_series(basemaps_client):
+    with requests_mock.Mocker() as m:
+        path = 'basemaps/v1/series/'
+        page1_url = os.path.join(basemaps_client.base_url, path)
+        page2_url = page1_url + "?_page=2&_page_size=4"
+        # page1 has 4 results and a _next link
+        page1 = {
+            "_links": {
+                "_next": page2_url,
+                "_self": page1_url
+            },
+            "series": [{"id": i,
+                        "name": "test {}".format(i)}
+                       for i in range(1, 5)]
+        }
+        # page2 has 2 results and no _next link
+        page2 = {
+            "_links": {
+                "_self": page1_url
+            },
+            "series": [{"id": i,
+                        "name": "test {}".format(i)}
+                       for i in range(5, 7)]
+        }
+        m.get(page1_url, text=json.dumps(page1))
+        m.get(page2_url, text=json.dumps(page2))
+        # series is a generator
+        series = basemaps_client.list_basemap_series()
+        # check the first series value
+        first_result = next(series)
+        assert first_result.get("id") == 1
+        assert first_result.get("name") == "test 1"
+        # only requested page 1 so far
+        assert m.call_count == 1
+        series_list = list(basemaps_client.list_basemap_series())
+        assert len(series_list) == 6
+        # made 2 more requests for pages 1 and 2
+        assert m.call_count == 3
+
+
+def test_list_basemap_series_api_error(basemaps_client):
+    with requests_mock.Mocker() as m:
+        path = 'basemaps/v1/series/'
+        url = os.path.join(basemaps_client.base_url, path)
+        m.get(url, text='{"message":"oops"}', status_code=401)
+        with pytest.raises(APIException):
+            series = basemaps_client.list_basemap_series()
+            next(series)
+
+
+def test_get_basemap_series(basemaps_client):
+    with requests_mock.Mocker() as m:
+        test_id = "aaaa-bbb-ccc"
+        path = 'basemaps/v1/series/{}'.format(test_id)
+        url = os.path.join(basemaps_client.base_url, path)
+        test_series = {
+            "_links": {"_self": url},
+            "id": test_id,
+            "name": "test mosaic series",
+        }
+        m.get(url, text=json.dumps(test_series))
+        retrieved_series = basemaps_client.get_basemap_series(test_id)
+        assert retrieved_series == test_series


### PR DESCRIPTION
While the existing cli tooling in this package is quite useful for searching, ordering, and downloading from the command line, I have found the `ClientV1` class to be cumbersome and nonintuitive to use directly within python scripts. I almost always write my own client or use `requests` directly when working with our public apis.

The goal of this pull request is to demonstrate a lightweight importable client for one specific service (basemaps).

TODO:
- [ ] additional tests
- [ ] docstrings
- [ ] usage examples