### PR TITLE
TEST: fix python 2.7 test failure

### DIFF
--- a/tests/test_v1_cli.py
+++ b/tests/test_v1_cli.py
@@ -46,10 +46,10 @@ def assert_success(result, expected_output, exit_code=0):
 
 def assert_failure(result, error):
     assert result.exit_code != 0
-    if error not in result.output:
-        print(result.output)
-        raise Exception(traceback.format_tb(result.exc_info[2]))
-    assert error in result.output
+    # replace all double quotes with single quotes before comparison
+    error = error.replace('"', "'")
+    output = result.output.replace('"', "'")
+    assert error in output
 
 
 def test_filter(runner):


### PR DESCRIPTION
This recent master build failed: https://travis-ci.org/github/planetlabs/planet-client-python/jobs/684531600

It was difficult to see that the problem was a minor difference in single vs. double quotes in different environments because a custom error gets raised without showing the error message and output being compared in `assert_failure`:
`Exception(traceback.format_tb(result.exc_info[2]))`

This PR does two things:
1. relax error output comparison by changing all double quotes to single quotes
2. show the error and output being checked by relying on the `assert error in output` instead of raising a new exception 