### PR TITLE
Download order locations one by one

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -565,7 +565,9 @@ class ClientV1(_Base):
 
         order = self._get(url, models.Order).get_body()
         locations = order.get_locations()
-        return self._get(locations, models.JSON, callback=callback)
+
+        return [self.download_location(location, callback=callback)
+                for location in locations]
 
     def download_location(self, location, callback=None):
         '''Download an item in an order.


### PR DESCRIPTION
Hi,

I've tried to use `ClientV1.download_order` to download all locations at once and got exception:
```
# ...
File "/usr/local/lib/python3.7/site-packages/planet/api/client.py", line 568, in download_order
  return self._get(locations, models.JSON, callback=callback)
File "/usr/local/lib/python3.7/site-packages/planet/api/client.py", line 61, in _get
  request = self._request(path, body_type, params)
File "/usr/local/lib/python3.7/site-packages/planet/api/client.py", line 52, in _request
  return models.Request(self._url(path), auth or self.auth, params,
File "/usr/local/lib/python3.7/site-packages/planet/api/client.py", line 45, in _url
  if path.startswith('http'):
AttributeError: 'list' object has no attribute 'startswith'
```

Looks like the problem is that client `_get` method expects a single location but gets a list instead.

This PR is a possible solution.