### PR TITLE
Fix make html-docs

### DIFF
--- a/docs/source/cli/reference.rst
+++ b/docs/source/cli/reference.rst
@@ -10,30 +10,40 @@ Option Types Formatting
 -----------------------
 
 
-.. _cli-metavar-FIELD-COMP-VALUE:
+.. _cli-metavar-ASSET-TYPE:
 
 
-FIELD COMP VALUE...
-...................
+ASSET-TYPE
+..........
 
 
-A comparison query format where FIELD is a
-property of the item-type and COMP is one of lt, lte, gt, gte and VALUE is
-the number or date to compare against.
-
-Note: ISO-8601 variants are supported. For example, ``2017`` is short for
-``2017-01-01T00:00:00+00:00``.
+Specify Asset-Type(s) of interest. Case-insenstive,
+supports glob-matching, e.g. ``visual*`` specifies ``visual`` and
+``visual_xml``.
 
 
-.. _cli-metavar-FIELD-VALUES:
+.. _cli-metavar-ITEM-TYPE:
 
 
-FIELD VALUES...
-...............
+ITEM-TYPE
+.........
 
 
-Specifies an 'in' query where FIELD is a property
-of the item-type and VALUES is space or comma separated text or numbers.
+Specify Item-Type(s) of interest. Case-insensitive,
+supports glob-matching, e.g. ``psscene*`` means ``PSScene3Band`` and
+``PSScene4Band``. The ``all`` value specifies every Item-Type.
+
+
+.. _cli-metavar-FILTER:
+
+
+FILTER
+......
+
+
+Specify a Data API search filter provided as JSON.
+``@-`` specifies stdin and ``@filename`` specifies reading from a file
+named 'filename'. Otherwise, the value is assumed to be JSON.
 
 
 .. _cli-metavar-GEOM:
@@ -49,40 +59,30 @@ reading from a file named 'filename'. Otherwise, the value is assumed to
 be GeoJSON.
 
 
-.. _cli-metavar-FILTER:
+.. _cli-metavar-FIELD-VALUES:
 
 
-FILTER
-......
+FIELD VALUES...
+...............
 
 
-Specify a Data API search filter provided as JSON.
-``@-`` specifies stdin and ``@filename`` specifies reading from a file
-named 'filename'. Otherwise, the value is assumed to be JSON.
+Specifies an 'in' query where FIELD is a property
+of the item-type and VALUES is space or comma separated text or numbers.
 
 
-.. _cli-metavar-ITEM-TYPE:
+.. _cli-metavar-FIELD-COMP-VALUE:
 
 
-ITEM-TYPE
-.........
+FIELD COMP VALUE...
+...................
 
 
-Specify Item-Type(s) of interest. Case-insensitive,
-supports glob-matching, e.g. ``psscene*`` means ``PSScene3Band`` and
-``PSScene4Band``. The ``all`` value specifies every Item-Type.
+A comparison query format where FIELD is a
+property of the item-type and COMP is one of lt, lte, gt, gte and VALUE is
+the number or date to compare against.
 
-
-.. _cli-metavar-ASSET-TYPE:
-
-
-ASSET-TYPE
-..........
-
-
-Specify Asset-Type(s) of interest. Case-insenstive,
-supports glob-matching, e.g. ``visual*`` specifies ``visual`` and
-``visual_xml``.
+Note: ISO-8601 variants are supported. For example, ``2017`` is short for
+``2017-01-01T00:00:00+00:00``.
 
 
 General Options
@@ -118,11 +118,11 @@ General Commands
 ----------------
 
 
-:ref:`cli-command-help` Get command help
+:ref:`cli-command-help` None
 
 
 
-:ref:`cli-command-init` Login using email/password
+:ref:`cli-command-init` None
 
 
 
@@ -175,31 +175,31 @@ Data API
 --------
 
 
-:ref:`cli-command-create-search` Create a saved search
+:ref:`cli-command-create-search` None
 
 
 
-:ref:`cli-command-download` Activate and download
+:ref:`cli-command-download` None
 
 
 
-:ref:`cli-command-filter` Output a AND filter as JSON to stdout.
+:ref:`cli-command-filter` None
 
 
 
-:ref:`cli-command-saved-search` Execute a saved search
+:ref:`cli-command-saved-search` None
 
 
 
-:ref:`cli-command-search` Execute a quick search.
+:ref:`cli-command-search` None
 
 
 
-:ref:`cli-command-searches` List searches
+:ref:`cli-command-searches` None
 
 
 
-:ref:`cli-command-stats` Get search stats
+:ref:`cli-command-stats` None
 
 
 
@@ -304,7 +304,7 @@ Usage: download [OPTIONS]
      - Format
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: None
 
      - NUMBER
 
@@ -471,7 +471,7 @@ Usage: saved-search [OPTIONS] [SEARCH_ID]
      - BOOLEAN
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: 100
 
        DEFAULT: `100`
      - NUMBER
@@ -499,7 +499,7 @@ Usage: search [OPTIONS]
      - Format
 
    * - limit
-     - Limit the number of items.
+     - Limit the number of items. Default: 100
 
        DEFAULT: `100`
      - NUMBER
@@ -587,6 +587,12 @@ Usage: searches [OPTIONS]
 
        DEFAULT: `True`
      - BOOLEAN
+
+   * - limit
+     - Limit the number of items. Default: 10
+
+       DEFAULT: `10`
+     - NUMBER
 
 .. index:: stats
 

--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -152,7 +152,7 @@ class ClientV1(_Base):
         '''Execute a quick search with the specified request.
 
         :param request: see :ref:`api-search-request`
-        :param **kw: See Options below
+        :param `**kw`: See Options below
         :returns: :py:class:`planet.api.models.Items`
         :raises planet.api.exceptions.APIException: On API error.
 
@@ -160,7 +160,6 @@ class ClientV1(_Base):
 
         * page_size (int): Size of response pages
         * sort (string): Sorting order in the form `field (asc|desc)`
-
         '''
         body = json.dumps(request)
         params = self._params(kw)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -44,6 +44,7 @@ def test_item_type():
         ItemType().convert('x', None, None)
     assert 'invalid choice: x' in str(e.value)
 
+
 @mock.patch('planet.scripts.types.get_asset_types',
             new=mock.Mock(return_value=DEFAULT_ASSET_TYPES))
 def test_asset_type():


### PR DESCRIPTION
This fixes the `make check html-docs` part of the build, which is now failing on master:
https://travis-ci.org/github/planetlabs/planet-client-python/builds/686344081

**Changes:**
- fix sphinx parameter to get rid of a warning
- update the checked in generated reference.rst file
- fix a flake8 lint error

**Demo**:
- `make check`
- `make html-docs`

**More Details**
Sphinx warning:
```
/path/to/planet-client-python/planet/api/client.py:docstring of planet.api.ClientV1.quick_search:4: WARNING: Inline strong start-string without end-string.
```

Repro steps for the sphinx warning fix (try on master and on this branch):
- `pip install -e ".[dev]"` in a new virtualenv for this repo
- `make html-docs`
