### PR TITLE
Removed plural in bundle

### DIFF
--- a/planet/scripts/opts.py
+++ b/planet/scripts/opts.py
@@ -85,7 +85,7 @@ item_type_option = click.option(
 
 bundle_option = click.option(
     '--bundle', multiple=False, required=True, type=Bundle(), help=(
-       'Specify bundle(s)'
+       'Specify bundle'
     )
 )
 


### PR DESCRIPTION
I just had my hope raised that I could put in two bundles in one order because the 'help' said `bundle(s)`. It then failed, since required is false. If the order system can actually take two bundles that'd be awesome, but in the meantime this just corrects the language.