### PR TITLE
Skip mosaic quads that a user does not have access to during downloading

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -16,7 +16,7 @@ import base64
 import json
 from .dispatch import RequestsDispatcher
 from . import auth
-from .exceptions import (InvalidIdentity, APIException)
+from .exceptions import (InvalidIdentity, APIException, NoPermission)
 from . import models
 from . import filters
 
@@ -357,14 +357,18 @@ class ClientV1(_Base):
         be invoked asynchronously.  Otherwise it is up to the caller to handle
         the response Body.
 
-        :param asset dict: A mosaic quad representation from the API
+        :param quad dict: A mosaic quad representation from the API
         :param callback: An optional function to aysnchronsously handle the
                          download. See :py:func:`planet.api.write_to_file`
         :returns: :py:Class:`planet.api.models.Response` containing a
                   :py:Class:`planet.api.models.Body` of the asset.
         :raises planet.api.exceptions.APIException: On API error.
         '''
-        download_url = quad['_links']['download']
+        try:
+            download_url = quad['_links']['download']
+        except KeyError:
+            msg = 'You do not have download permissions for quad {}'
+            raise NoPermission(msg.format(quad['id']))
         return self._get(download_url, models.Body, callback=callback)
 
     def check_analytics_connection(self):

--- a/planet/api/downloader.py
+++ b/planet/api/downloader.py
@@ -16,7 +16,7 @@ import os
 import threading
 import time
 from .utils import write_to_file
-from planet.api.exceptions import RequestCancelled
+from planet.api.exceptions import (RequestCancelled, NoPermission)
 try:
     import Queue as queue
 except ImportError:
@@ -466,9 +466,12 @@ class _MosaicDownloadStage(_DStage):
     def _do(self, task):
         func = self._write_tracker(task, None)
         writer = write_to_file(self._dest, func, overwrite=False)
-        self._downloads += 1
-        self._results.put((task, {'type': 'quad'},
-                           self._client.download_quad(task, writer)))
+        try:
+            self._results.put((task, {'type': 'quad'},
+                               self._client.download_quad(task, writer)))
+            self._downloads += 1
+        except NoPermission:
+            _info('No download permisson for %s, skipping', task['id'])
 
 
 class _MosaicDownloader(_Downloader):


### PR DESCRIPTION
Permission for mosaic quad download often varies spatially for a given user.  It's common for someone to have access to some quads within an AOI but not all.  Currently, when a user tries to download quads they don't have access to the client raises an unexpected error:

```
ERROR - unexpected error in <planet.api.downloader._MosaicDownloadStage object at 0x10d87b240> Traceback (most recent call last):   File
"~/pl/planet-client-python/planet/api/downloader.py", line 159, in _process_task     self._do(self._doing)   File "/~/pl/planet-client-
python/planet/api/downloader.py", line 471, in _do     self._client.download_quad(task, writer)))   File "~/pl/planet-client-python/planet/api/client.py", line
363, in download_quad     download_url = quad['_links']['download'] KeyError: 'download'
```

This PR changes `client.download_quad` to raise a `NoPermission` error when that occurs and changes the `planet mosaics download` command (and associated downloader infrastructure) to skip mosaic quads that a user does not have permission for during downloading.