### PR TITLE
add a max_number parameters

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -291,14 +291,20 @@ class ClientV1(_Base):
         url = self._url('basemaps/v1/series/{}/mosaics'.format(series_id))
         return self._get(url, models.Mosaics).get_body()
 
-    def get_mosaics(self, name_contains=None):
+    def get_mosaics(self, name_contains=None, max_number=None):
         '''Get information for all mosaics accessible by the current user.
-
+        
+        :param name_contain str: narrow down the mosaic list to the one including this string (optional)
+        :param max_number int: the maximum number of mosaics to list (optional)
         :returns: :py:Class:`planet.api.models.Mosaics`
         '''
         params = {}
         if name_contains:
             params['name__contains'] = name_contains
+            
+        if max_number:
+            params['_page_size'] = max_number
+            
         url = self._url('basemaps/v1/mosaics')
         return self._get(url, models.Mosaics, params=params).get_body()
 


### PR DESCRIPTION
add a `max_number` parameter to the `get_mosaics` function in order to get the full extend of the mosaic list if it exceed the default page size (50)

Fix #272 