### PR TITLE
add config for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+mkdocs:
+  configuration: mkdocs.yml
+
+# pip install -e .[docs]
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Config file that tells readthedocs how to build our docs: based on https://docs.readthedocs.io/en/stable/config-file/v2.html

Docs build will be available at https://planet-sdk-for-python.readthedocs.io/

For now (while V2 is in development) a manual trigger is required to (re)build the RTD docs; after release we can change that to automatic builds out of `master`.