### PR TITLE
V2: Add authentication handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ pull request is initiated on the repository.
 
 ### Testing Documentation
 
+NOTE: Doc tests need to be reworked and are failing. See
+[#275](https://github.com/planetlabs/planet-client-python/issues/275).
+
 There are many code examples written into the documentation that need to be
 tested to ensure they are accurate. These tests are not run by default because
 they communicate with the Planet services, and thus are slower and also could

--- a/README.md
+++ b/README.md
@@ -35,16 +35,15 @@ Let's start with creating an order with the Orders API:
 >>> import os
 >>> import planet
 >>>
->>> API_KEY = os.getenv('PL_API_KEY')
->>>
 >>> image_ids = ['3949357_1454705_2020-12-01_241c']
 >>> order_details = planet.OrderDetails(
 ...     'test_order',
 ...     [planet.Product(image_ids, 'analytic', 'psorthotile')]
 ... )
 >>>
+>>> auth = planet.Auth.from_env()
 >>> async def create_order(order_details):
-...     async with planet.Session(auth=(API_KEY, '')) as ps:
+...     async with planet.Session(auth=auth) as ps:
 ...         client = planet.OrdersClient(ps)
 ...         return await client.create_order(order_details)
 >>>

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Let's start with creating an order with the Orders API:
 ...     [planet.Product(image_ids, 'analytic', 'psorthotile')]
 ... )
 >>>
->>> auth = planet.Auth.from_env()
 >>> async def create_order(order_details):
-...     async with planet.Session(auth=auth) as ps:
+...     async with planet.Session() as ps:
 ...         client = planet.OrdersClient(ps)
 ...         return await client.create_order(order_details)
 >>>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,9 @@
 # API Reference 
 
+## ::: planet.Auth
+    rendering:
+      show_root_full_path: false
+
 ## ::: planet.Session
     rendering:
       show_root_full_path: false
@@ -7,7 +11,6 @@
 ## ::: planet.OrdersClient
     rendering:
       show_root_full_path: false
-
 
 ## order_details 
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -81,7 +81,7 @@ environment variable:
 >>>
 >>> auth = Auth.from_env('ALTERNATE_VAR')
 >>> async def main():
-...     async with Session() as sess:
+...     async with Session(auth=auth) as sess:
 ...         # perform operations here
 ...         pass
 ...

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -46,6 +46,8 @@ in `Auth.from_key()`.
 
 Once the authentication information is obtained, the most convenient way of
 managing it for local use is to write it to a secret file using `Auth.write()`.
+It can also be accessed, e.g. to store in an environment variable, as
+`Auth.value`.
 
 For example, to obtain and store authentication information:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -34,13 +34,43 @@ Alternatively, use `await Session.aclose()` to close a `Session` explicitly:
 
 ## Authentication
 
-By default, authentication is read from the environment variable
-`PL_API_KEY`. If that variable is not set, then authentication is read from
-the planet secret file, named `.planet.json` and stored in the user directory.
+There are two steps to managing authentication information, obtaining the
+authentication information from Planet and then managing it for local retrieval
+for authentication purposes.
 
-This behavior can be motified by specifying Auth explicitely using the methods
-`Auth.from_key()`, `Auth.from_file()`, and `Auth.from_env()`. For example,
-authentication can be read from a custom environment variable:
+The recommended method for obtaining authentication information is through
+logging in, using `Auth.from_login()` (note: using something like the `getpass`
+module is recommended to ensure your password remains secure). Alternatively,
+the api key can be obtained directly from the Planet account site and then used
+in `Auth.from_key()`.
+
+Once the authentication information is obtained, the most convenient way of
+managing it for local use is to write it to a secret file using `Auth.write()`.
+
+For example, to obtain and store authentication information:
+
+```python
+>>> import getpass
+>>> from planet import Auth
+>>>
+>>> pw = getpass.getpass()
+>>> auth = Auth.from_login('user', 'pw')
+>>> auth.write()
+
+```
+
+When a `Session` is created, by default, authentication is read from the
+environment variable `PL_API_KEY`. If that variable is not set, then
+authentication is read from the secret file created with `Auth.write()`.
+This behavior can be modified by specifying Auth explicitely using the methods
+`Auth.from_file()`, and `Auth.from_env()`. While `Auth.from_key()` and
+`Auth.from_login` can be used, it is recommended that
+those functions be used in authentication initialization and the authentication
+information be stored in an environment variable or secret file.
+
+The file and environment variable read from can be customized in the
+respective functions. For example, authentication can be read from a custom
+environment variable:
 
 ```python
 >>> import asyncio

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -61,14 +61,12 @@ For example, to obtain and store authentication information:
 
 ```
 
-When a `Session` is created, by default, authentication is read from the
-environment variable `PL_API_KEY`. If that variable is not set, then
-authentication is read from the secret file created with `Auth.write()`.
-This behavior can be modified by specifying Auth explicitely using the methods
-`Auth.from_file()`, and `Auth.from_env()`. While `Auth.from_key()` and
-`Auth.from_login` can be used, it is recommended that
-those functions be used in authentication initialization and the authentication
-information be stored in an environment variable or secret file.
+When a `Session` is created, by default, authentication is read from the secret
+file created with `Auth.write()`. This behavior can be modified by specifying
+`Auth` explicitely using the methods `Auth.from_file()` and `Auth.from_env()`.
+While `Auth.from_key()` and `Auth.from_login` can be used, it is recommended
+that those functions be used in authentication initialization and the
+authentication information be stored using `Auth.write()`.
 
 The file and environment variable read from can be customized in the
 respective functions. For example, authentication can be read from a custom

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -11,10 +11,8 @@ provide for automatic clean up of connections when the context is left.
 >>> import os
 >>> from planet import Session
 >>>
->>> AUTH = (os.getenv('PL_API_KEY'), '')
->>>
 >>> async def main():
-...     async with Session(auth=AUTH) as sess:
+...     async with Session() as sess:
 ...         # perform operations here
 ...         pass
 ...
@@ -26,9 +24,34 @@ Alternatively, use `await Session.aclose()` to close a `Session` explicitly:
 
 ```python
 >>> async def main():
-...     sess = Session(auth=AUTH)
+...     sess = Session()
 ...     # perform operations here
 ...     await sess.aclose()
+...
+>>> asyncio.run(main())
+
+```
+
+## Authentication
+
+By default, authentication is read from the environment variable
+`PL_API_KEY`. If that variable is not set, then authentication is read from
+the planet secret file, named `.planet.json` and stored in the user directory.
+
+This behavior can be motified by specifying Auth explicitely using the methods
+`Auth.from_key()`, `Auth.from_file()`, and `Auth.from_env()`. For example,
+authentication can be read from a custom environment variable:
+
+```python
+>>> import asyncio
+>>> import os
+>>> from planet import Auth, Session
+>>>
+>>> auth = Auth.from_env('ALTERNATE_VAR')
+>>> async def main():
+...     async with Session() as sess:
+...         # perform operations here
+...         pass
 ...
 >>> asyncio.run(main())
 
@@ -45,7 +68,7 @@ order is completed and to download an entire order.
 >>> from planet import OrdersClient
 >>>
 >>> async def main():
-...     async with Session(auth=AUTH) as sess:
+...     async with Session() as sess:
 ...         client = OrdersClient(sess)
 ...         # perform operations here
 ...
@@ -94,7 +117,7 @@ the context of a `Session` with the `OrdersClient`:
 
 ```python
 >>> async def main():
-...     async with Session(auth=AUTH) as sess:
+...     async with Session() as sess:
 ...         cl = OrdersClient(sess)
 ...         order_id = await cl.create_order(order_detail)
 ...

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,16 +29,15 @@ Let's start with creating an order with the Orders API:
 >>> import os
 >>> import planet
 >>>
->>> API_KEY = os.getenv('PL_API_KEY')
->>>
 >>> image_ids = ['3949357_1454705_2020-12-01_241c']
 >>> order_details = planet.OrderDetails(
 ...     'test_order',
 ...     [planet.Product(image_ids, 'analytic', 'psorthotile')]
 ... )
 >>>
+>>> auth = planet.Auth.from_env()
 >>> async def create_order(order_details):
-...     async with planet.Session(auth=(API_KEY, '')) as ps:
+...     async with planet.Session(auth=auth) as ps:
 ...         client = planet.OrdersClient(ps)
 ...         return await client.create_order(order_details)
 >>>
@@ -92,4 +91,3 @@ Planet's APIs require an account for use.
 
 To contribute or develop with this library, see
 [CONTRIBUTING](https://github.com/planetlabs/planet-client-python/CONTRIBUTING.md)
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,9 +35,8 @@ Let's start with creating an order with the Orders API:
 ...     [planet.Product(image_ids, 'analytic', 'psorthotile')]
 ... )
 >>>
->>> auth = planet.Auth.from_env()
 >>> async def create_order(order_details):
-...     async with planet.Session(auth=auth) as ps:
+...     async with planet.Session() as ps:
 ...         client = planet.OrdersClient(ps)
 ...         return await client.create_order(order_details)
 >>>

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ def test(session):
     session.install("-e", ".[test]")
 
     options = session.posargs
-    session.run("pytest", "-v", 'tests/', *options)
+    session.run('pytest', '--ignore', 'examples/', '-v', *options)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,8 @@ def test(session):
     session.install("-e", ".[test]")
 
     options = session.posargs
+    if '-k' in options:
+        options.append('--no-cov')
     session.run('pytest', '--ignore', 'examples/', '-v', *options)
 
 

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .auth import Auth
 from .api.http import Session
 from .api.models import Order
 from .api.orders import OrdersClient
@@ -21,6 +22,7 @@ from .api.order_details import (
 from .api.__version__ import __version__  # NOQA
 
 __all__ = [
+    Auth,
     Session,
     OrdersClient,
     Order,

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .auth import Auth
 from .api.http import Session
 from .api.models import Order
 from .api.orders import OrdersClient
@@ -20,9 +19,10 @@ from .api.order_details import (
     AzureBlobStorageDelivery, GoogleCloudStorageDelivery,
     GoogleEarthEngineDelivery, Tool)
 from .api.__version__ import __version__  # NOQA
+from .auth import Auth
+
 
 __all__ = [
-    Auth,
     Session,
     OrdersClient,
     Order,
@@ -34,5 +34,6 @@ __all__ = [
     AzureBlobStorageDelivery,
     GoogleCloudStorageDelivery,
     GoogleEarthEngineDelivery,
-    Tool
+    Tool,
+    Auth
 ]

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -71,11 +71,6 @@ class BaseSession():
         }.get(status, None)
 
         msg = response.text
-        # try:
-        #     msg = response.text
-        # except httpx.ResponseNotRead:
-        #     await response.aread()
-        #     msg = response.text
 
         # differentiate between over quota and rate-limiting
         if status == 429 and 'quota' in msg.lower():
@@ -90,10 +85,9 @@ class BaseSession():
 class Session(BaseSession):
     '''Context manager for asynchronous communication with the Planet service.
 
-    The default behavior is to look for authentication information as the
-    an api key stored in the environment variable, `PL_API_KEY`. Failing that,
-    the api key is read from the secret key. This behavior can be overridden
-    by providing an `auth.Auth` instance as an argument.
+    The default behavior is to read authentication information stored in the
+    secret file. This behavior can be overridden by providing an `auth.Auth`
+    instance as an argument.
 
     Example:
     ```python
@@ -134,7 +128,7 @@ class Session(BaseSession):
         Parameters:
             auth: Planet server authentication.
         """
-        auth = auth or Auth.read()
+        auth = auth or Auth.from_file()
 
         self._client = httpx.AsyncClient(auth=auth)
         self._client.headers.update({'User-Agent': self._get_user_agent()})

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -14,6 +14,7 @@
 
 """Functionality to perform HTTP requests"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
+# import abc
 import asyncio
 from http import HTTPStatus
 import logging
@@ -35,13 +36,64 @@ class SessionException(Exception):
     pass
 
 
-class Session():
+class BaseSession():
+    @staticmethod
+    def _get_user_agent():
+        return 'planet-client-python/' + __version__
+
+    @staticmethod
+    def _log_request(request):
+        LOGGER.info(f'{request.method} {request.url} - Sent')
+
+    @staticmethod
+    def _log_response(response):
+        request = response.request
+        LOGGER.info(
+            f'{request.method} {request.url} - '
+            f'Status {response.status_code}')
+
+    @staticmethod
+    def _raise_for_status(response):
+        # TODO: consider using http_response.reason_phrase
+        status = response.status_code
+
+        miminum_bad_request_code = HTTPStatus.MOVED_PERMANENTLY
+        if status < miminum_bad_request_code:
+            return
+
+        exception = {
+            HTTPStatus.BAD_REQUEST: exceptions.BadQuery,
+            HTTPStatus.UNAUTHORIZED: exceptions.InvalidAPIKey,
+            HTTPStatus.FORBIDDEN: exceptions.NoPermission,
+            HTTPStatus.NOT_FOUND: exceptions.MissingResource,
+            HTTPStatus.TOO_MANY_REQUESTS: exceptions.TooManyRequests,
+            HTTPStatus.INTERNAL_SERVER_ERROR: exceptions.ServerError
+        }.get(status, None)
+
+        msg = response.text
+        # try:
+        #     msg = response.text
+        # except httpx.ResponseNotRead:
+        #     await response.aread()
+        #     msg = response.text
+
+        # differentiate between over quota and rate-limiting
+        if status == 429 and 'quota' in msg.lower():
+            exception = exceptions.OverQuota
+
+        if exception:
+            raise exception(msg)
+
+        raise exceptions.APIException(f'{status}: {msg}')
+
+
+class Session(BaseSession):
     '''Context manager for asynchronous communication with the Planet service.
 
     The default behavior is to look for authentication information as the
     an api key stored in the environment variable, `PL_API_KEY`. Failing that,
     the api key is read from the secret key. This behavior can be overridden
-    by providing an `auth.Auth()` instance as an argument.
+    by providing an `auth.Auth` instance as an argument.
 
     Example:
     ```python
@@ -59,7 +111,7 @@ class Session():
 
     Example:
     ```python
-    >>> import asyncio
+    >>> import async
     >>> from planet import Auth, Session
     >>>
     >>> async def main():
@@ -86,10 +138,20 @@ class Session():
 
         self._client = httpx.AsyncClient(auth=auth)
         self._client.headers.update({'User-Agent': self._get_user_agent()})
-        self._client.event_hooks['request'] = [self._log_request]
+
+        async def alog_request(*args, **kwargs):
+            return self._log_request(*args, **kwargs)
+
+        async def alog_response(*args, **kwargs):
+            return self._log_response(*args, **kwargs)
+
+        async def araise_for_status(*args, **kwargs):
+            return self._raise_for_status(*args, **kwargs)
+
+        self._client.event_hooks['request'] = [alog_request]
         self._client.event_hooks['response'] = [
-            self._log_response,
-            self._raise_for_status
+            alog_response,
+            araise_for_status
         ]
         self.retry_wait_time = RETRY_WAIT_TIME
         self.retry_count = RETRY_COUNT
@@ -170,53 +232,24 @@ class Session():
             request=request
         )
 
-    @staticmethod
-    def _get_user_agent():
-        return 'planet-client-python/' + __version__
 
-    @staticmethod
-    async def _log_request(request):
-        LOGGER.info(f'{request.method} {request.url} - Sent')
+class AuthSession(BaseSession):
+    '''Synchronous connection to the Planet Auth service.'''
+    def __init__(self):
+        """Initialize an AuthSession.
+        """
+        self._client = httpx.Client(timeout=None)
+        self._client.headers.update({'User-Agent': self._get_user_agent()})
+        self._client.event_hooks['request'] = [self._log_request]
+        self._client.event_hooks['response'] = [
+            self._log_response,
+            self._raise_for_status
+        ]
 
-    @staticmethod
-    async def _log_response(response):
-        request = response.request
-        LOGGER.info(
-            f'{request.method} {request.url} - '
-            f'Status {response.status_code}')
-
-    @staticmethod
-    async def _raise_for_status(response):
-        # TODO: consider using http_response.reason_phrase
-        status = response.status_code
-
-        miminum_bad_request_code = HTTPStatus.MOVED_PERMANENTLY
-        if status < miminum_bad_request_code:
-            return
-
-        exception = {
-            HTTPStatus.BAD_REQUEST: exceptions.BadQuery,
-            HTTPStatus.UNAUTHORIZED: exceptions.InvalidAPIKey,
-            HTTPStatus.FORBIDDEN: exceptions.NoPermission,
-            HTTPStatus.NOT_FOUND: exceptions.MissingResource,
-            HTTPStatus.TOO_MANY_REQUESTS: exceptions.TooManyRequests,
-            HTTPStatus.INTERNAL_SERVER_ERROR: exceptions.ServerError
-        }.get(status, None)
-
-        try:
-            msg = response.text
-        except httpx.ResponseNotRead:
-            await response.aread()
-            msg = response.text
-
-        # differentiate between over quota and rate-limiting
-        if status == 429 and 'quota' in msg.lower():
-            exception = exceptions.OverQuota
-
-        if exception:
-            raise exception(msg)
-
-        raise exceptions.APIException(f'{status}: {msg}')
+    def request(self, request):
+        '''Submit a request'''
+        http_resp = self._client.send(request.http_request)
+        return models.Response(request, http_resp)
 
 
 class Stream():

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -41,8 +41,7 @@ class Session():
     The default behavior is to look for authentication information as the
     an api key stored in the environment variable, `PL_API_KEY`. Failing that,
     the api key is read from the secret key. This behavior can be overridden
-    by providing an `auth.Auth()` instance as a parameter. See `auth.Auth()`
-    for more information.
+    by providing an `auth.Auth()` instance as an argument.
 
     Example:
     ```python
@@ -64,7 +63,7 @@ class Session():
     >>> from planet import Auth, Session
     >>>
     >>> async def main():
-    ...     auth = Auth(key='examplekey')
+    ...     auth = Auth.from_key('examplekey')
     ...     async with Session(auth=auth) as sess:
     ...         # communicate with services here
     ...         pass
@@ -83,9 +82,9 @@ class Session():
         Parameters:
             auth: Planet server authentication.
         """
-        auth = auth or Auth()
+        auth = auth or Auth.read()
 
-        self._client = httpx.AsyncClient(auth=auth.auth())
+        self._client = httpx.AsyncClient(auth=auth)
         self._client.headers.update({'User-Agent': self._get_user_agent()})
         self._client.event_hooks['request'] = [self._log_request]
         self._client.event_hooks['response'] = [

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -14,7 +14,6 @@
 
 """Functionality to perform HTTP requests"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
-# import abc
 import asyncio
 from http import HTTPStatus
 import logging

--- a/planet/api/models.py
+++ b/planet/api/models.py
@@ -100,14 +100,13 @@ class Response():
         '''
         return self.http_response.status_code
 
-    @property
     def json(self):
-        '''Response json.
+        '''Get response json.
 
-        :returns: json
+        :returns:response json
         :rtype: dict
         '''
-        return self.http_response.json
+        return self.http_response.json()
 
     async def aclose(self):
         await self.http_response.aclose()

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -17,6 +17,8 @@ import json
 import logging
 import os
 
+import httpx
+
 ENV_API_KEY = 'PL_API_KEY'
 
 SECRET_FILE_PATH = os.path.join(os.path.expanduser('~'), '.planet.json')
@@ -45,8 +47,8 @@ class Auth():
 
         When oauth is implemented, this will attempt oauth first.
 
-        The default environment variable is "PL_API_KEY" and the default
-        secret file is named ".planet.json" and stored in the user directory.
+        The default environment variable is `PL_API_KEY` and the default
+        secret file is named `.planet.json` and stored in the user directory.
 
         Parameters:
             key: API key.
@@ -86,8 +88,8 @@ class Auth():
 
         secret_file.write(secrets)
 
-    def header(self):
-        return self._auth.header()
+    def auth(self):
+        return self._auth.as_auth()
 
 
 class SecretFile():
@@ -161,6 +163,5 @@ class APIKey():
         '''Represent key as a dict.'''
         return {self.DICT_KEY: self._val}
 
-    def header(self) -> dict:
-        '''Create authorization header for api key'''
-        return {'Authorization': f'api-key {self._val}'}
+    def as_auth(self):
+        return httpx.BasicAuth(self._val, '')

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -161,6 +161,11 @@ class Auth(metaclass=abc.ABCMeta):
     ) -> Auth:
         pass
 
+    @property
+    @abc.abstractmethod
+    def value(self):
+        pass
+
     def write(
         self,
         filename: str = None
@@ -254,8 +259,8 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
         '''
         if not key:
             raise APIKeyAuthException('API key cannot be empty.')
-        self.key = key
-        super().__init__(self.key, '')
+        self._key = key
+        super().__init__(self._key, '')
 
     @classmethod
     def from_dict(
@@ -268,7 +273,11 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
 
     def to_dict(self):
         '''Represent APIKeyAuth as a dict.'''
-        return {self.DICT_KEY: self.key}
+        return {self.DICT_KEY: self._key}
+
+    @property
+    def value(self):
+        return self._key
 
 
 class _SecretFile():

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -134,7 +134,8 @@ class Auth(metaclass=abc.ABCMeta):
     @staticmethod
     def from_login(
         email: str,
-        password: str
+        password: str,
+        base_url: str = None
     ) -> Auth:
         '''Create authentication from login email and password.
 
@@ -143,9 +144,11 @@ class Auth(metaclass=abc.ABCMeta):
 
         Parameters:
             email: Planet account email address.
-            password:  Planet account password.
+            password: Planet account password.
+            base_url: The base URL to use. Defaults to production
+                authentication API base url.
         '''
-        cl = AuthClient()
+        cl = AuthClient(base_url=base_url)
         auth_data = cl.login(email, password)
 
         api_key = auth_data['api_key']

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -33,70 +33,164 @@ class AuthException(Exception):
 
 class Auth():
     '''Handle authentication information for use with Planet APIs.'''
-    def __init__(
-        self,
+    @staticmethod
+    def read(
         key: str = None,
         environment_variable: str = None,
         secret_file_path: str = None
-    ):
-        '''Initiaize Auth
+    ) -> APIKeyAuth:
+        '''Read authentication information.
 
         If key is provided, uses the key. Otherwise, tries to find key from
-        environment variable. Finally, tries to find key from planet secret
-        file.
-
-        When oauth is implemented, this will attempt oauth first.
-
-        The default environment variable is `PL_API_KEY` and the default
-        secret file is named `.planet.json` and stored in the user directory.
+        environment variable `PL_API_KEY`. Finally, tries to find key from the
+        planet secret file, named `.planet.json` and stored in the user
+        directory.
 
         Parameters:
-            key: API key.
-            environment_variable: Alternate environment variable to read.
-            secret_file_path: Alternate path to the secret file.
+            key: Planet API key
+            environment_variable: Alternate environment variable.
+            secret_file_path: Alternate path for the planet secret file.
         '''
-        self.secret_file_path = secret_file_path or SECRET_FILE_PATH
-        environment_variable = environment_variable or ENV_API_KEY
-
         if key:
-            self._auth = APIKey(key=key)
-            LOGGER.info('Auth set from key parameter.')
+            auth = Auth.from_key(key)
         else:
             try:
-                self._auth = APIKey.from_env(environment_variable)
-                LOGGER.info('Auth set from environment variable '
-                            f'{environment_variable}')
-            except APIKeyException:
+                environment_variable = environment_variable or ENV_API_KEY
+                auth = Auth.from_env(environment_variable)
+            except APIKeyAuthException:
                 try:
-                    secrets = SecretFile(self.secret_file_path).read()
-                    self._auth = APIKey.from_dict(secrets)
-                    LOGGER.info('Auth set from secret file '
-                                f'{self.secret_file_path}.')
+                    filename = secret_file_path or SECRET_FILE_PATH
+                    auth = Auth.from_file(filename)
                 except FileNotFoundError:
                     raise AuthException(
                         'Could not find authentication information. Set '
                         f'environment variable {ENV_API_KEY} or store '
-                        'information in secret file with Auth.store()')
+                        'information in secret file with `APIKeyAuth.write()`')
+        return auth
 
-    def store(self):
-        try:
-            secret_file = SecretFile(self.secret_file_path)
-            secrets = secret_file.read()
-            secrets.update(self._auth.to_dict())
-        except FileNotFoundError:
-            secrets = self._auth.to_dict()
+    @staticmethod
+    def write(
+        auth: Auth,
+        filename: str = None
+    ):
+        '''Write authentication information.
 
-        secret_file.write(secrets)
+        Parameters:
+            filename: Alternate path for the planet secret file.
+        '''
+        filename = filename or SECRET_FILE_PATH
+        secret_file = _SecretFile(filename)
+        secret_file.write(auth.to_dict())
 
-    def auth(self):
-        return self._auth.as_auth()
+    @staticmethod
+    def from_key(
+        key: str
+    ) -> APIKeyAuth:
+        '''Obtain authentication from api key.
+
+        Parameters:
+            key: Planet API key
+        '''
+        auth = APIKeyAuth(key=key)
+        LOGGER.debug('Auth obtained from api key.')
+        return auth
+
+    @staticmethod
+    def from_file(
+        filename: str = None
+    ) -> APIKeyAuth:
+        '''Create authentication from secret file.
+
+        The secret file is named `.planet.json` and is stored in the user
+        directory. The file has a special format and should have been created
+        with `Auth.write()`.
+
+        Parameters:
+            filename: Alternate path for the planet secret file.
+
+        '''
+        filename = filename or SECRET_FILE_PATH
+        secrets = _SecretFile(filename).read()
+        auth = APIKeyAuth.from_dict(secrets)
+
+        LOGGER.debug(f'Auth read from secret file {filename}.')
+        return auth
+
+    @staticmethod
+    def from_env(
+        variable_name: str = None
+    ) -> APIKeyAuth:
+        '''Create authentication from environment variable.
+
+        Reads the `PL_API_KEY` environment variable
+
+        Parameters:
+            variable_name: Alternate environment variable.
+        '''
+        variable_name = variable_name or ENV_API_KEY
+        api_key = os.getenv(variable_name)
+        auth = APIKeyAuth(api_key)
+        LOGGER.info(f'Auth set from environment variable {variable_name}')
+        return auth
 
 
-class SecretFile():
+class APIKeyAuthException(Exception):
+    '''exceptions thrown by APIKeyAuth'''
+    pass
+
+
+class APIKeyAuth(httpx.BasicAuth, Auth):
+    '''Planet API Key authentication.'''
+    DICT_KEY = 'key'
+
+    def __init__(
+        self,
+        key: str
+    ):
+        '''Initialize APIKeyAuth.
+
+        Parameters:
+            key: API key.
+
+        Raises:
+            APIKeyException: If API key is None or empty string.
+        '''
+        if not key:
+            raise APIKeyAuthException('API key cannot be empty.')
+        self.key = key
+        super().__init__(self.key, '')
+
+    @classmethod
+    def from_dict(
+        cls,
+        secrets: dict
+    ) -> APIKeyAuth:
+        '''Instantiate APIKeyAuth from a dict.'''
+        api_key = secrets.get(cls.DICT_KEY, None)
+        return cls(api_key)
+
+    def to_dict(self):
+        '''Represent APIKeyAuth as a dict.'''
+        return {self.DICT_KEY: self.key}
+
+
+class _SecretFile():
     def __init__(self, path):
         self.path = path
 
     def write(
+        self,
+        contents: dict
+    ):
+        try:
+            secrets_to_write = self.read()
+            secrets_to_write.update(contents)
+        except FileNotFoundError:
+            secrets_to_write = contents
+
+        self._write(secrets_to_write)
+
+    def _write(
         self,
         contents: dict
     ):
@@ -109,59 +203,3 @@ class SecretFile():
         with open(self.path, 'r') as fp:
             contents = json.loads(fp.read())
         return contents
-
-
-class APIKeyException(Exception):
-    '''exceptions thrown by APIKey'''
-    pass
-
-
-class APIKey():
-    '''Planet API Key authentication.'''
-    DICT_KEY = 'key'
-
-    def __init__(
-        self,
-        key: str
-    ):
-        '''Initialize APIKey.
-
-        Parameters:
-            key: API key.
-
-        Raises:
-            APIKeyException: If API key is None or empty string.
-        '''
-        if not key:
-            raise APIKeyException('API key cannot be empty.')
-
-        self._val = key
-
-    @classmethod
-    def from_env(
-        cls,
-        variable_name: str
-    ) -> APIKey:
-        '''Get key from environment.
-
-        Parameters:
-            variable_name: Environment variable to read.
-        '''
-        api_key = os.getenv(variable_name)
-        return cls(api_key)
-
-    @classmethod
-    def from_dict(
-        cls,
-        secrets: dict
-    ) -> APIKey:
-        '''Instantiate key from a dict.'''
-        api_key = secrets.get(cls.DICT_KEY, None)
-        return cls(api_key)
-
-    def to_dict(self):
-        '''Represent key as a dict.'''
-        return {self.DICT_KEY: self._val}
-
-    def as_auth(self):
-        return httpx.BasicAuth(self._val, '')

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -1,0 +1,166 @@
+# Copyright 2020 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''Manage authentication with Planet APIs'''
+from __future__ import annotations  # https://stackoverflow.com/a/33533514
+import json
+import logging
+import os
+
+ENV_API_KEY = 'PL_API_KEY'
+
+SECRET_FILE_PATH = os.path.join(os.path.expanduser('~'), '.planet.json')
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AuthException(Exception):
+    '''exceptions thrown by Auth'''
+    pass
+
+
+class Auth():
+    '''Handle authentication information for use with Planet APIs.'''
+    def __init__(
+        self,
+        key: str = None,
+        environment_variable: str = None,
+        secret_file_path: str = None
+    ):
+        '''Initiaize Auth
+
+        If key is provided, uses the key. Otherwise, tries to find key from
+        environment variable. Finally, tries to find key from planet secret
+        file.
+
+        When oauth is implemented, this will attempt oauth first.
+
+        The default environment variable is "PL_API_KEY" and the default
+        secret file is named ".planet.json" and stored in the user directory.
+
+        Parameters:
+            key: API key.
+            environment_variable: Alternate environment variable to read.
+            secret_file_path: Alternate path to the secret file.
+        '''
+        self.secret_file_path = secret_file_path or SECRET_FILE_PATH
+        environment_variable = environment_variable or ENV_API_KEY
+
+        if key:
+            self._auth = APIKey(key=key)
+            LOGGER.info('Auth set from key parameter.')
+        else:
+            try:
+                self._auth = APIKey.from_env(environment_variable)
+                LOGGER.info('Auth set from environment variable '
+                            f'{environment_variable}')
+            except APIKeyException:
+                try:
+                    secrets = SecretFile(self.secret_file_path).read()
+                    self._auth = APIKey.from_dict(secrets)
+                    LOGGER.info('Auth set from secret file '
+                                f'{self.secret_file_path}.')
+                except FileNotFoundError:
+                    raise AuthException(
+                        'Could not find authentication information. Set '
+                        f'environment variable {ENV_API_KEY} or store '
+                        'information in secret file with Auth.store()')
+
+    def store(self):
+        try:
+            secret_file = SecretFile(self.secret_file_path)
+            secrets = secret_file.read()
+            secrets.update(self._auth.to_dict())
+        except FileNotFoundError:
+            secrets = self._auth.to_dict()
+
+        secret_file.write(secrets)
+
+    def header(self):
+        return self._auth.header()
+
+
+class SecretFile():
+    def __init__(self, path):
+        self.path = path
+
+    def write(
+        self,
+        contents: dict
+    ):
+        LOGGER.debug(f'Writing to {self.path}')
+        with open(self.path, 'w') as fp:
+            fp.write(json.dumps(contents))
+
+    def read(self) -> dict:
+        LOGGER.debug(f'Reading from {self.path}')
+        with open(self.path, 'r') as fp:
+            contents = json.loads(fp.read())
+        return contents
+
+
+class APIKeyException(Exception):
+    '''exceptions thrown by APIKey'''
+    pass
+
+
+class APIKey():
+    '''Planet API Key authentication.'''
+    DICT_KEY = 'key'
+
+    def __init__(
+        self,
+        key: str
+    ):
+        '''Initialize APIKey.
+
+        Parameters:
+            key: API key.
+
+        Raises:
+            APIKeyException: If API key is None or empty string.
+        '''
+        if not key:
+            raise APIKeyException('API key cannot be empty.')
+
+        self._val = key
+
+    @classmethod
+    def from_env(
+        cls,
+        variable_name: str
+    ) -> APIKey:
+        '''Get key from environment.
+
+        Parameters:
+            variable_name: Environment variable to read.
+        '''
+        api_key = os.getenv(variable_name)
+        return cls(api_key)
+
+    @classmethod
+    def from_dict(
+        cls,
+        secrets: dict
+    ) -> APIKey:
+        '''Instantiate key from a dict.'''
+        api_key = secrets.get(cls.DICT_KEY, None)
+        return cls(api_key)
+
+    def to_dict(self):
+        '''Represent key as a dict.'''
+        return {self.DICT_KEY: self._val}
+
+    def header(self) -> dict:
+        '''Create authorization header for api key'''
+        return {'Authorization': f'api-key {self._val}'}

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -41,35 +41,6 @@ class AuthException(Exception):
 class Auth(metaclass=abc.ABCMeta):
     '''Handle authentication information for use with Planet APIs.'''
     @staticmethod
-    def read(
-        key: str = None
-    ) -> APIKeyAuth:
-        '''Reads authentication information.
-
-        If key is provided, uses the key. Otherwise, tries to find key from
-        environment variable `PL_API_KEY`. Finally, tries to find key from the
-        planet secret file, named `.planet.json` and stored in the user
-        directory.
-
-        Parameters:
-            key: Planet API key
-        '''
-        if key:
-            auth = Auth.from_key(key)
-        else:
-            try:
-                auth = Auth.from_env(ENV_API_KEY)
-            except AuthException:
-                try:
-                    auth = Auth.from_file(SECRET_FILE_PATH)
-                except FileNotFoundError:
-                    raise AuthException(
-                        'Could not find authentication information. Set '
-                        f'environment variable {ENV_API_KEY} or store '
-                        'information in secret file with `Auth.write()`')
-        return auth
-
-    @staticmethod
     def from_key(
         key: str
     ) -> Auth:

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -14,12 +14,12 @@
 '''Manage authentication with Planet APIs'''
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
 import abc
-import base64
 import json
 import logging
 import os
 
 import httpx
+import jwt
 
 from . import constants
 from .api import http, models
@@ -198,16 +198,9 @@ class AuthClient():
 
     @staticmethod
     def decode_response(response):
-        '''This is magic I don't understand'''
-        jwt = response.json()['token']
-
-        # stuff before the first '.' and after the second '.' doesn't matter
-        payload = jwt.split('.')[1]
-
-        # the '===' addition ensures adequate padding
-        payload = base64.urlsafe_b64decode(payload + '===')
-        decoded = json.loads(payload.decode())
-        return decoded
+        '''Decode the token JWT'''
+        token = response.json()['token']
+        return jwt.decode(token, options={'verify_signature': False})
 
 
 class APIKeyAuthException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ with open('planet/api/__version__.py') as f:
 
 install_requires = [
     'httpx==0.16',
+    'pyjwt>=2.1',
     'tqdm>=4.56',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,21 @@ from pathlib import Path
 
 import pytest
 
+from planet.auth import _SecretFile
+
 _here = Path(os.path.abspath(os.path.dirname(__file__)))
 _test_data_path = _here / 'data'
+
+
+@pytest.fixture(autouse=True, scope='module')
+def test_secretfile_read():
+    '''Returns valid auth results as if reading a secret file'''
+    def mockreturn(self):
+        return {'key': 'testkey'}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_SecretFile, 'read', mockreturn)
+        yield
 
 
 @pytest.fixture

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 import respx
 
-from planet import OrdersClient, Session
+from planet import Auth, OrdersClient, Session
 
 
 TEST_URL = 'http://MockNotRealURL/'
@@ -35,7 +35,8 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture
 @pytest.mark.asyncio
 async def session():
-    async with Session() as ps:
+    auth = Auth.from_key('mockkey')
+    async with Session(auth=auth) as ps:
         yield ps
 
 

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 import respx
 
-from planet import Auth, OrdersClient, Session
+from planet import OrdersClient, Session
 
 
 TEST_URL = 'http://MockNotRealURL/'
@@ -35,8 +35,7 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture
 @pytest.mark.asyncio
 async def session():
-    auth = Auth.from_key('mockkey')
-    async with Session(auth=auth) as ps:
+    async with Session() as ps:
         yield ps
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -25,38 +25,6 @@ from planet import auth
 LOGGER = logging.getLogger(__name__)
 
 
-def test_Auth_read_key():
-    test_auth = auth.Auth.read(key='test')
-    assert test_auth.value == 'test'
-
-
-def test_Auth_read_env(monkeypatch):
-    monkeypatch.setenv('PL_API_KEY', 'a')
-
-    test_auth_env1 = auth.Auth.read()
-    assert test_auth_env1.value == 'a'
-
-
-def test_Auth_read_file(tmp_path, monkeypatch):
-    secret_path = str(tmp_path / '.test')
-    with open(secret_path, 'w') as fp:
-        fp.write('{"key": "testvar"}')
-
-    monkeypatch.delenv('PL_API_KEY', raising=False)
-    monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
-    test_auth = auth.Auth.read()
-    assert test_auth.value == 'testvar'
-
-
-def test_Auth_read_error(tmp_path, monkeypatch):
-    secret_path = str(tmp_path / '.doesnotexist')
-
-    monkeypatch.delenv('PL_API_KEY', raising=False)
-    monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
-    with pytest.raises(auth.AuthException):
-        auth.Auth.read()
-
-
 def test_Auth_from_key_empty():
     with pytest.raises(auth.APIKeyAuthException):
         _ = auth.Auth.from_key('')

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -27,14 +27,14 @@ LOGGER = logging.getLogger(__name__)
 
 def test_Auth_read_key():
     test_auth = auth.Auth.read(key='test')
-    assert test_auth.key == 'test'
+    assert test_auth.value == 'test'
 
 
 def test_Auth_read_env(monkeypatch):
     monkeypatch.setenv('PL_API_KEY', 'a')
 
     test_auth_env1 = auth.Auth.read()
-    assert test_auth_env1.key == 'a'
+    assert test_auth_env1.value == 'a'
 
 
 def test_Auth_read_file(tmp_path, monkeypatch):
@@ -45,7 +45,7 @@ def test_Auth_read_file(tmp_path, monkeypatch):
     monkeypatch.delenv('PL_API_KEY', raising=False)
     monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
     test_auth = auth.Auth.read()
-    assert test_auth.key == 'testvar'
+    assert test_auth.value == 'testvar'
 
 
 def test_Auth_read_error(tmp_path, monkeypatch):
@@ -68,7 +68,7 @@ def test_Auth_from_file_alternate_success(tmp_path):
         fp.write('{"key": "testvar"}')
 
     test_auth = auth.Auth.from_file(secret_path)
-    assert test_auth.key == 'testvar'
+    assert test_auth.value == 'testvar'
 
 
 def test_Auth_from_file_alternate_doesnotexist(tmp_path):
@@ -92,7 +92,7 @@ def test_Auth_from_env_alternate_success(monkeypatch):
     monkeypatch.delenv('PL_API_KEY', raising=False)
 
     test_auth_env1 = auth.Auth.from_env(alternate)
-    assert test_auth_env1.key == 'testkey'
+    assert test_auth_env1.value == 'testkey'
 
 
 def test_Auth_from_env_alternate_doesnotexist(monkeypatch):
@@ -121,7 +121,7 @@ def test_Auth_from_login(monkeypatch):
 
     monkeypatch.setattr(auth, 'AUTH_URL', test_url)
     test_auth = auth.Auth.from_login('email', 'pw')
-    assert test_auth.key == 'foobar'
+    assert test_auth.value == 'foobar'
 
 
 def test_Auth_write_doesnotexist(tmp_path):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -119,8 +119,8 @@ def test_Auth_from_login(monkeypatch):
     mock_resp = httpx.Response(HTTPStatus.OK, json=response)
     respx.post(login_url).return_value = mock_resp
 
-    monkeypatch.setattr(auth, 'AUTH_URL', test_url)
-    test_auth = auth.Auth.from_login('email', 'pw')
+    # monkeypatch.setattr(auth, 'AUTH_URL', test_url)
+    test_auth = auth.Auth.from_login('email', 'pw', base_url=test_url)
     assert test_auth.value == 'foobar'
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import base64
 from http import HTTPStatus
 import json
 import logging
 
 import httpx
+import jwt
 import pytest
 import respx
 
@@ -114,13 +114,9 @@ def test_Auth_from_login(monkeypatch):
     test_url = 'http://MockNotRealURL/'
     login_url = test_url + 'login'
 
-    apikey = base64.urlsafe_b64encode(
-        json.dumps({'api_key': 'foobar'}).encode()
-    ).decode()
-
     response = {
-        'token':  'junk.' + apikey
-    }
+        'token': jwt.encode({'api_key': 'foobar'}, key='')
+        }
     mock_resp = httpx.Response(HTTPStatus.OK, json=response)
     respx.post(login_url).return_value = mock_resp
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -25,9 +25,23 @@ from planet import auth
 LOGGER = logging.getLogger(__name__)
 
 
+def test_Auth_from_key():
+    test_auth_env1 = auth.Auth.from_key('testkey')
+    assert test_auth_env1.value == 'testkey'
+
+
 def test_Auth_from_key_empty():
     with pytest.raises(auth.APIKeyAuthException):
         _ = auth.Auth.from_key('')
+
+
+# def test_Auth_from_file(tmp_path):
+#     secret_path = str(tmp_path / '.test')
+#     with open(secret_path, 'w') as fp:
+#         fp.write('{"key": "testvar"}')
+#
+#     test_auth = auth.Auth.from_file(secret_path)
+#     assert test_auth.value == 'testvar'
 
 
 def test_Auth_from_file_alternate_success(tmp_path):
@@ -54,13 +68,25 @@ def test_Auth_from_file_alternate_wrongformat(tmp_path):
         _ = auth.Auth.from_file(secret_path)
 
 
+def test_Auth_from_env(monkeypatch):
+    monkeypatch.setenv('PL_API_KEY', 'testkey')
+    test_auth_env = auth.Auth.from_env()
+    assert test_auth_env.value == 'testkey'
+
+
+def test_Auth_from_env_failure(monkeypatch):
+    monkeypatch.delenv('PL_API_KEY', raising=False)
+    with pytest.raises(auth.AuthException):
+        _ = auth.Auth.from_env()
+
+
 def test_Auth_from_env_alternate_success(monkeypatch):
     alternate = 'OTHER_VAR'
     monkeypatch.setenv(alternate, 'testkey')
     monkeypatch.delenv('PL_API_KEY', raising=False)
 
-    test_auth_env1 = auth.Auth.from_env(alternate)
-    assert test_auth_env1.value == 'testkey'
+    test_auth_env = auth.Auth.from_env(alternate)
+    assert test_auth_env.value == 'testkey'
 
 
 def test_Auth_from_env_alternate_doesnotexist(monkeypatch):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,137 @@
+# Copyright 2020 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+
+import pytest
+
+from planet import auth
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_APIKey_init():
+    with pytest.raises(auth.APIKeyException):
+        key = auth.APIKey('')
+
+    key = auth.APIKey('mockkey')
+    assert key._val == 'mockkey'
+
+
+def test_APIKey_from_env(monkeypatch):
+    monkeypatch.setenv('PL_API_KEY', 'a')
+    monkeypatch.setenv('OTHER_VAR', 'b')
+
+    key = auth.APIKey.from_env('PL_API_KEY')
+    assert key._val == 'a'
+
+    key = auth.APIKey.from_env('OTHER_VAR')
+    assert key._val == 'b'
+
+
+def test_APIKey_from_dict():
+    test_dict = {'key': 'test_key'}
+
+    key = auth.APIKey.from_dict(test_dict)
+    assert key._val == 'test_key'
+
+
+def test_APIKey_to_dict():
+    key = auth.APIKey(key='test_key')
+    assert key.to_dict() == {'key': 'test_key'}
+
+
+def test_APIKey_header():
+    key = auth.APIKey(key='test_key')
+    assert key.header() == {'Authorization': 'api-key test_key'}
+
+
+def test_SecretFile_write(tmp_path):
+    secret_path = str(tmp_path / '.test')
+    contents = {'testkey': 'testvar'}
+    auth.SecretFile(secret_path).write(contents)
+
+    with open(secret_path, 'r') as fp:
+        assert fp.read() == '{"testkey": "testvar"}'
+
+
+def test_SecretFile_read(tmp_path):
+    secret_path = str(tmp_path / '.test')
+
+    with open(secret_path, 'w') as fp:
+        fp.write('{"testkey": "testvar"}')
+
+    contents = auth.SecretFile(secret_path).read()
+    assert contents == {'testkey': 'testvar'}
+
+
+def test_Auth_init_key():
+    test_auth = auth.Auth(key='test')
+    assert test_auth._auth._val == 'test'
+
+
+def test_Auth_init_env(monkeypatch):
+    monkeypatch.setenv('PL_API_KEY', 'a')
+    monkeypatch.setenv('OTHER_VAR', 'b')
+
+    test_auth_env1 = auth.Auth()
+    assert test_auth_env1._auth._val == 'a'
+
+    test_auth_env2 = auth.Auth(environment_variable='OTHER_VAR')
+    assert test_auth_env2._auth._val == 'b'
+
+
+def test_Auth_init_secretfile(tmp_path, monkeypatch):
+    monkeypatch.delenv('PL_API_KEY')
+    secret_path = str(tmp_path / '.test')
+    with open(secret_path, 'w') as fp:
+        fp.write('{"key": "testvar"}')
+
+    test_auth = auth.Auth(secret_file_path=secret_path)
+    assert test_auth._auth._val == 'testvar'
+
+
+def test_Auth_init_error(tmp_path, monkeypatch):
+    monkeypatch.delenv('PL_API_KEY')
+    secret_path = str(tmp_path / '.test')
+
+    with pytest.raises(auth.AuthException):
+        auth.Auth(secret_file_path=secret_path)
+
+
+def test_Auth_store_doesnotexist(tmp_path):
+    secret_path = str(tmp_path / '.test')
+    test_auth = auth.Auth(key='test', secret_file_path=secret_path)
+    test_auth.store()
+
+    with open(secret_path, 'r') as fp:
+        assert json.loads(fp.read()) == {"key": "test"}
+
+
+def test_Auth_store_exists(tmp_path):
+    secret_path = str(tmp_path / '.test')
+    test_auth = auth.Auth(key='test', secret_file_path=secret_path)
+
+    with open(secret_path, 'w') as fp:
+        fp.write('{"existing": "exists"}')
+
+    test_auth.store()
+
+    with open(secret_path, 'r') as fp:
+        assert json.loads(fp.read()) == {"key": "test", "existing": "exists"}
+
+
+def test_Auth_header():
+    test_auth = auth.Auth(key='test')
+    assert test_auth.header() == {'Authorization': 'api-key test'}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -52,11 +52,6 @@ def test_APIKey_to_dict():
     assert key.to_dict() == {'key': 'test_key'}
 
 
-def test_APIKey_header():
-    key = auth.APIKey(key='test_key')
-    assert key.header() == {'Authorization': 'api-key test_key'}
-
-
 def test_SecretFile_write(tmp_path):
     secret_path = str(tmp_path / '.test')
     contents = {'testkey': 'testvar'}
@@ -130,8 +125,3 @@ def test_Auth_store_exists(tmp_path):
 
     with open(secret_path, 'r') as fp:
         assert json.loads(fp.read()) == {"key": "test", "existing": "exists"}
-
-
-def test_Auth_header():
-    test_auth = auth.Auth(key='test')
-    assert test_auth.header() == {'Authorization': 'api-key test'}

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -21,7 +21,6 @@ import respx
 import pytest
 
 from planet.api import exceptions, http
-from planet.auth import Auth
 
 
 TEST_URL = 'mock://fantastic.com'
@@ -36,11 +35,6 @@ def mock_request():
         'GET',
         TEST_URL)
     yield r
-
-
-@pytest.fixture
-def auth():
-    return Auth.from_key('mockkey')
 
 
 @pytest.mark.asyncio
@@ -71,16 +65,16 @@ async def test_basesession__raise_for_status():
 
 
 @pytest.mark.asyncio
-async def test_session_contextmanager(auth):
-    async with http.Session(auth=auth):
+async def test_session_contextmanager():
+    async with http.Session():
         pass
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request(auth, mock_request):
+async def test_session_request(mock_request):
 
-    async with http.Session(auth=auth) as ps:
+    async with http.Session() as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -90,8 +84,8 @@ async def test_session_request(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_stream(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_stream(mock_request):
+    async with http.Session() as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -102,8 +96,8 @@ async def test_session_stream(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request_retry(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_request_retry(mock_request):
+    async with http.Session() as ps:
         route = respx.get(TEST_URL)
         route.side_effect = [
             httpx.Response(HTTPStatus.TOO_MANY_REQUESTS),
@@ -118,8 +112,8 @@ async def test_session_request_retry(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_retry(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_retry(mock_request):
+    async with http.Session() as ps:
         async def test_func():
             raise exceptions.TooManyRequests
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -38,6 +38,11 @@ def mock_request():
     yield r
 
 
+@pytest.fixture
+def auth():
+    return Auth.from_key('mockkey')
+
+
 @pytest.mark.asyncio
 async def test_basesession__raise_for_status():
     http.BaseSession._raise_for_status(Mock(
@@ -66,16 +71,16 @@ async def test_basesession__raise_for_status():
 
 
 @pytest.mark.asyncio
-async def test_session_contextmanager():
-    auth = Auth.from_key('mockkey')
+async def test_session_contextmanager(auth):
     async with http.Session(auth=auth):
         pass
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request(mock_request):
-    async with http.Session() as ps:
+async def test_session_request(auth, mock_request):
+
+    async with http.Session(auth=auth) as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -85,8 +90,8 @@ async def test_session_request(mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_stream(mock_request):
-    async with http.Session() as ps:
+async def test_session_stream(auth, mock_request):
+    async with http.Session(auth=auth) as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -97,8 +102,8 @@ async def test_session_stream(mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request_retry(mock_request):
-    async with http.Session() as ps:
+async def test_session_request_retry(auth, mock_request):
+    async with http.Session(auth=auth) as ps:
         route = respx.get(TEST_URL)
         route.side_effect = [
             httpx.Response(HTTPStatus.TOO_MANY_REQUESTS),
@@ -113,8 +118,8 @@ async def test_session_request_retry(mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_retry(mock_request):
-    async with http.Session() as ps:
+async def test_session_retry(auth, mock_request):
+    async with http.Session(auth=auth) as ps:
         async def test_func():
             raise exceptions.TooManyRequests
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -21,6 +21,7 @@ import respx
 import pytest
 
 from planet.api import exceptions, http
+from planet.auth import Auth
 
 
 TEST_URL = 'mock://fantastic.com'
@@ -66,7 +67,8 @@ async def test_basesession__raise_for_status():
 
 @pytest.mark.asyncio
 async def test_session_contextmanager():
-    async with http.Session():
+    auth = Auth.from_key('mockkey')
+    async with http.Session(auth=auth):
         pass
 
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -38,6 +38,33 @@ def mock_request():
 
 
 @pytest.mark.asyncio
+async def test_basesession__raise_for_status():
+    http.BaseSession._raise_for_status(Mock(
+        status_code=HTTPStatus.CREATED, text=''
+    ))
+
+    with pytest.raises(exceptions.BadQuery):
+        http.BaseSession._raise_for_status(Mock(
+            status_code=HTTPStatus.BAD_REQUEST, text=''
+        ))
+
+    with pytest.raises(exceptions.TooManyRequests):
+        http.BaseSession._raise_for_status(Mock(
+            status_code=HTTPStatus.TOO_MANY_REQUESTS, text=''
+        ))
+
+    with pytest.raises(exceptions.OverQuota):
+        http.BaseSession._raise_for_status(Mock(
+            status_code=HTTPStatus.TOO_MANY_REQUESTS, text='exceeded QUOTA'
+        ))
+
+    with pytest.raises(exceptions.APIException):
+        http.BaseSession._raise_for_status(Mock(
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED, text='not sure'
+        ))
+
+
+@pytest.mark.asyncio
 async def test_session_contextmanager():
     async with http.Session():
         pass
@@ -66,28 +93,6 @@ async def test_session_stream(mock_request):
             assert txt == b'bubba'
 
 
-@pytest.mark.asyncio
-async def test_session__raise_for_status():
-    await http.Session._raise_for_status(Mock(
-        status_code=HTTPStatus.CREATED, text=''
-    ))
-
-    with pytest.raises(exceptions.BadQuery):
-        await http.Session._raise_for_status(Mock(
-            status_code=HTTPStatus.BAD_REQUEST, text=''
-        ))
-
-    with pytest.raises(exceptions.TooManyRequests):
-        await http.Session._raise_for_status(Mock(
-            status_code=HTTPStatus.TOO_MANY_REQUESTS, text=''
-        ))
-
-    with pytest.raises(exceptions.OverQuota):
-        await http.Session._raise_for_status(Mock(
-            status_code=HTTPStatus.TOO_MANY_REQUESTS, text='exceeded QUOTA'
-        ))
-
-
 @respx.mock
 @pytest.mark.asyncio
 async def test_session_request_retry(mock_request):
@@ -114,3 +119,14 @@ async def test_session_retry(mock_request):
         ps.retry_wait_time = 0
         with pytest.raises(http.SessionException):
             await ps._retry(test_func)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_authsession_request(mock_request):
+    sess = http.AuthSession()
+    mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
+    respx.get(TEST_URL).return_value = mock_resp
+
+    resp = sess.request(mock_request)
+    assert resp.http_response.text == 'bubba'


### PR DESCRIPTION
This PR introduces an `auth` module that handles obtaining, managing, and using authentication with the Planet services. `auth.Auth` is elevated to a first-level import. Additionally, `Session` provides default behavior for obtaining authentication information which can be overridden with an `Auth` instance. To support obtaining authentication information from the Planet Auth API, a new, synchronous HTTP session is introduced, `http.AuthSession`, and both `http.Session` and `http.AuthSession` inherit from a new base class `http.BaseSession`.

Places to check on changes in usability are the docs, `README.md` and `docs/guide.md` being the primary two.

(Resolution: documented that doctests fail and updated #275 to fix doctests) Right now, there is a code example for obtaining authentication using login in the "User Guide" documentation page that fails doctests. This is because the example username and password are, obviously, not going to lead to a successful authentication. I'm not sure how to skip this test at this time and may add this to or make it a cousin of #275, which is about how to enable doctests without prefixes and may lead to more refined control over which doctests are run. I would love any other suggestions. 

(Resolution: remove reading from environment variable by default, mock the read of the secret file and override locally for auth tests) Another issue I've found is that the local tests may pass but the remote tests may fail because the remote tests are in an environment where the default secret file and environment variable do not exist. I am interested in finding solutions to this.

Closes #248