### PR TITLE
v2: add cli for orders api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ pull request is initiated on the repository.
 
 ### Testing Documentation
 
+NOTE: Doc tests need to be reworked and are failing. See
+[#275](https://github.com/planetlabs/planet-client-python/issues/275).
+
 There are many code examples written into the documentation that need to be
 tested to ensure they are accurate. These tests are not run by default because
 they communicate with the Planet services, and thus are slower and also could

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,9 @@
+# CLI Reference
+
+This page provides documentation for our command line tools.
+
+::: mkdocs-click
+    :module: planet.scripts.cli
+    :command: cli
+    :prog_name: planet
+    :depth: 1

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,6 +1,7 @@
 # User Guide
 
-## Session
+## API
+### Session
 
 Communication with the Planet services is provided with the `Session` class.
 The recommended way to use a `Session` is as a context manager. This will
@@ -32,7 +33,7 @@ Alternatively, use `await Session.aclose()` to close a `Session` explicitly:
 
 ```
 
-## Authentication
+### Authentication
 
 There are two steps to managing authentication information, obtaining the
 authentication information from Planet and then managing it for local retrieval
@@ -87,7 +88,7 @@ environment variable:
 
 ```
 
-## Orders Client
+### Orders Client
 
 The Orders Client mostly mirrors the
 [Orders API](https://developers.planet.com/docs/orders/reference/#tag/Orders),
@@ -106,7 +107,7 @@ order is completed and to download an entire order.
 
 ```
 
-### Creating an Order
+#### Creating an Order
 
 When creating an order, the order details must be provided to the API. There
 are two ways to specify the order details, a `JSON` blob and an `OrderDetails`
@@ -154,3 +155,122 @@ the context of a `Session` with the `OrdersClient`:
 >>> asyncio.run(main())
 
 ```
+
+## CLI
+
+### Authentication
+
+The `auth` command allows the CLI to authenticate with Planet servers. Before
+any other command is run, the CLI authentication should be initiated with
+
+```console
+$ planet auth init
+```
+
+To store the authentication information in an environment variable, e.g.
+for passing into a Docker instance:
+
+```console
+$ export PL_API_KEY=$(planet auth value)
+```
+
+### Orders API
+
+Most `orders` cli commands are simple wrappers around the
+[Planet Orders API](https://developers.planet.com/docs/orders/reference/#tag/Orders)
+commands.
+
+
+#### Create Order File Inputs
+
+Creating an order supports JSON files as inputs and these need to follow certain
+formats.
+
+
+##### --cloudconfig
+The file given with the `--cloudconfig` option should contain JSON that follows
+the options and format given in
+[Delivery to Cloud Storage](https://developers.planet.com/docs/orders/delivery/#delivery-to-cloud-storage).
+
+An example would be:
+
+Example: `cloudconfig.json`
+```
+{
+    "amazon_s3": {
+        "aws_access_key_id": "aws_access_key_id",
+        "aws_secret_access_key": "aws_secret_access_key",
+        "bucket": "bucket",
+        "aws_region": "aws_region"
+    },
+    "archive_type": "zip"
+}
+```
+
+##### --clip
+The file given with the `--clip` option should contain valid [GeoJSON](https://geojson.org/).
+It can be a Polygon geometry, a Feature, or a FeatureClass. If it is a FeatureClass,
+only the first Feature is used for the clip geometry.
+
+Example: `aoi.geojson`
+```
+{
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [
+                37.791595458984375,
+                14.84923123791421
+            ],
+            [
+                37.90214538574219,
+                14.84923123791421
+            ],
+            [
+                37.90214538574219,
+                14.945448293647944
+            ],
+            [
+                37.791595458984375,
+                14.945448293647944
+            ],
+            [
+                37.791595458984375,
+                14.84923123791421
+            ]
+        ]
+    ]
+}
+```
+
+##### --tools
+The file given with the `--tools` option should contain JSON that follows the
+format for a toolchain, the "tools" section of an order. The toolchain options
+and format are given in
+[Creating Toolchains](https://developers.planet.com/docs/orders/tools-toolchains/#creating-toolchains).
+
+Example: `tools.json`
+```
+[
+    {
+        "toar": {
+            "scale_factor": 10000
+        }
+    },
+    {
+        "reproject": {
+            "projection": "WGS84",
+            "kernel": "cubic"
+        }
+    },
+    {
+        "tile": {
+            "tile_size": 1232,
+            "origin_x": -180,
+            "origin_y": -90,
+            "pixel_size": 2.7056277056e-05,
+            "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
+        }
+    }
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,8 +31,10 @@ nav:
     - User Guide: 'guide.md'
     - Upgrading: 'upgrading.md'
     - API Reference: 'api.md'
+    - CLI Reference: 'cli.md'
 
 markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
+  - mkdocs-click
 

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -20,7 +20,6 @@ from .api.order_details import (
     GoogleEarthEngineDelivery, Tool, ClipTool)
 from .api.__version__ import __version__  # NOQA
 from .auth import Auth
-from .geojson import Geometry
 
 
 __all__ = [
@@ -38,5 +37,4 @@ __all__ = [
     ClipTool,
     Tool,
     Auth,
-    Geometry
 ]

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -17,7 +17,7 @@ from .api.orders import OrdersClient
 from .api.order_details import (
     OrderDetails, Product, Notifications, Delivery, AmazonS3Delivery,
     AzureBlobStorageDelivery, GoogleCloudStorageDelivery,
-    GoogleEarthEngineDelivery, Tool)
+    GoogleEarthEngineDelivery, Tool, ClipTool, GeoJSON)
 from .api.__version__ import __version__  # NOQA
 from .auth import Auth
 
@@ -34,6 +34,8 @@ __all__ = [
     AzureBlobStorageDelivery,
     GoogleCloudStorageDelivery,
     GoogleEarthEngineDelivery,
+    ClipTool,
+    GeoJSON,
     Tool,
     Auth
 ]

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -17,9 +17,10 @@ from .api.orders import OrdersClient
 from .api.order_details import (
     OrderDetails, Product, Notifications, Delivery, AmazonS3Delivery,
     AzureBlobStorageDelivery, GoogleCloudStorageDelivery,
-    GoogleEarthEngineDelivery, Tool, ClipTool, GeoJSON)
+    GoogleEarthEngineDelivery, Tool, ClipTool)
 from .api.__version__ import __version__  # NOQA
 from .auth import Auth
+from .geojson import Geometry
 
 
 __all__ = [
@@ -35,7 +36,7 @@ __all__ = [
     GoogleCloudStorageDelivery,
     GoogleEarthEngineDelivery,
     ClipTool,
-    GeoJSON,
     Tool,
-    Auth
+    Auth,
+    Geometry
 ]

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -51,8 +51,8 @@ class BaseSession():
             f'{request.method} {request.url} - '
             f'Status {response.status_code}')
 
-    @staticmethod
-    def _raise_for_status(response):
+    @classmethod
+    def _raise_for_status(cls, response):
         # TODO: consider using http_response.reason_phrase
         status = response.status_code
 
@@ -69,16 +69,43 @@ class BaseSession():
             HTTPStatus.INTERNAL_SERVER_ERROR: exceptions.ServerError
         }.get(status, None)
 
-        msg = response.text
+        LOGGER.debug(f"Exception type: {exception}")
 
-        # differentiate between over quota and rate-limiting
-        if status == 429 and 'quota' in msg.lower():
-            exception = exceptions.OverQuota
+        if exception == exceptions.TooManyRequests:
+            # differentiate between over quota and rate-limiting
+            if 'quota' in response.text.lower():
+                exception = exceptions.OverQuota
+
+        msg = cls._parse_message(response)
 
         if exception:
             raise exception(msg)
 
         raise exceptions.APIException(f'{status}: {msg}')
+
+    @staticmethod
+    def _parse_message(response):
+        msg = response.json()
+        LOGGER.debug(f'Raw response message: {msg}')
+
+        try:
+            msg = msg['message']
+        except KeyError:
+            try:
+                new_msg = msg['general'][0]['message']
+                try:
+                    msg_field = msg['field']
+                    key = list(msg_field.keys())[0]
+                    LOGGER.debug(f'key: {key}')
+                    new_msg = (new_msg + ' - ' + msg_field[key][0]['message'])
+                except Exception:
+                    pass
+                msg = new_msg
+            except Exception:
+                pass
+
+        LOGGER.debug(f'Processed response message: {msg}')
+        return msg
 
 
 class Session(BaseSession):

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -70,13 +70,17 @@ class BaseSession():
         }.get(status, None)
 
         LOGGER.debug(f"Exception type: {exception}")
+        LOGGER.debug(f"Response text: {response.text}")
 
         if exception == exceptions.TooManyRequests:
             # differentiate between over quota and rate-limiting
             if 'quota' in response.text.lower():
                 exception = exceptions.OverQuota
 
-        msg = cls._parse_message(response)
+        try:
+            msg = cls._parse_message(response)
+        except Exception:
+            msg = response.text
 
         if exception:
             raise exception(msg)

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -14,7 +14,6 @@
 
 """Functionality to perform HTTP requests"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
-# import abc
 import asyncio
 from http import HTTPStatus
 import logging

--- a/planet/api/http.py
+++ b/planet/api/http.py
@@ -244,6 +244,15 @@ class AuthSession(BaseSession):
         http_resp = self._client.send(request.http_request)
         return models.Response(request, http_resp)
 
+    @classmethod
+    def _raise_for_status(cls, response):
+        try:
+            super()._raise_for_status(response)
+        except exceptions.BadQuery:
+            raise exceptions.APIException('Not a valid email address.')
+        except exceptions.InvalidAPIKey:
+            raise exceptions.APIException('Incorrect email or password.')
+
 
 class Stream():
     '''Context manager for asynchronous response stream from Planet server.'''

--- a/planet/api/models.py
+++ b/planet/api/models.py
@@ -397,6 +397,10 @@ class Order():
         '''
         return self.data['id']
 
+    @property
+    def json(self):
+        return self.data
+
 
 class Orders(Paged):
     '''Asynchronous iterator over Orders from a paged response describing

--- a/planet/api/order_details.py
+++ b/planet/api/order_details.py
@@ -730,11 +730,5 @@ class ClipTool(Tool):
         Parameters:
             aoi: clip GeoJSON.
         """
-        if not isinstance(aoi, geojson.Polygon):
-            try:
-                aoi = geojson.Polygon.from_geometry(aoi)
-            except AttributeError:
-                aoi = geojson.Polygon(aoi)
-
-        parameters = {'aoi': aoi.to_dict()}
+        parameters = {'aoi': geojson.Polygon(aoi)}
         super().__init__('clip', parameters)

--- a/planet/api/order_details.py
+++ b/planet/api/order_details.py
@@ -306,7 +306,38 @@ class Delivery():
         self.archive_filename = archive_filename
 
     @classmethod
-    def from_dict(cls, details: dict) -> Delivery:
+    def from_dict(cls, details: dict, subclass: bool = True) -> Delivery:
+        """Create Delivery instance from Orders API spec representation.
+
+        Parameters:
+            details: API spec representation of delivery.
+            subclass: Create a subclass of Delivery if the necessary
+                information is provided.
+
+        Returns:
+            Delivery or Delivery subclass instance
+        """
+        def _create_subclass(details):
+            subclasses = [AmazonS3Delivery,
+                          AzureBlobStorageDelivery,
+                          GoogleCloudStorageDelivery,
+                          GoogleEarthEngineDelivery
+                          ]
+            created = False
+            for cls in subclasses:
+                try:
+                    created = cls.from_dict(details)
+                except KeyError:
+                    pass
+                else:
+                    break
+            return created
+
+        created = _create_subclass(details) or cls._from_dict(details)
+        return created
+
+    @classmethod
+    def _from_dict(cls, details: dict) -> Delivery:
         """Create Delivery instance from Orders API spec representation.
 
         Parameters:

--- a/planet/api/order_details.py
+++ b/planet/api/order_details.py
@@ -730,5 +730,5 @@ class ClipTool(Tool):
         Parameters:
             aoi: clip GeoJSON.
         """
-        parameters = {'aoi': geojson.Polygon(aoi)}
+        parameters = {'aoi': geojson.as_polygon(aoi)}
         super().__init__('clip', parameters)

--- a/planet/api/order_details.py
+++ b/planet/api/order_details.py
@@ -315,37 +315,6 @@ class Delivery():
         self.archive_filename = archive_filename
 
     @classmethod
-    def from_file(
-        cls,
-        filename: str,
-        subclass: bool = True
-        ) -> Union[
-                Delivery,
-                AmazonS3Delivery,
-                AzureBlobStorageDelivery,
-                GoogleCloudStorageDelivery,
-                GoogleEarthEngineDelivery]:
-        """Create Delivery instance from file containing Orders API spec
-        representation.
-
-        Parameters:
-            filename: Path to file.
-            subclass: Create a subclass of Delivery if the necessary
-                information is provided.
-
-        Raises:
-            FileNotFoundError: If filename does not exist.
-            json.decoder.JSONDecodeError: If filename contents is not valid
-                json.
-
-        Returns:
-            Delivery or Delivery subclass instance
-        """
-        with open(filename) as f:
-            details = json.load(f)
-        return cls.from_dict(details, subclass=subclass)
-
-    @classmethod
     def from_dict(
         cls,
         details: dict,

--- a/planet/api/orders.py
+++ b/planet/api/orders.py
@@ -158,7 +158,7 @@ class OrdersClient():
         resp = await self._do_request(req)
 
         order = Order(resp.json())
-        return order.id
+        return order
 
     async def get_order(
         self,

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -74,7 +74,7 @@ class Auth(metaclass=abc.ABCMeta):
             auth = APIKeyAuth.from_dict(secrets)
         except FileNotFoundError:
             raise AuthException(f'File {filename} does not exist.')
-        except KeyError:
+        except (KeyError, json.decoder.JSONDecodeError):
             raise AuthException(f'File {filename} is not the correct format.')
 
         LOGGER.debug(f'Auth read from secret file {filename}.')
@@ -265,7 +265,7 @@ class _SecretFile():
         try:
             secrets_to_write = self.read()
             secrets_to_write.update(contents)
-        except FileNotFoundError:
+        except (FileNotFoundError, KeyError, json.decoder.JSONDecodeError):
             secrets_to_write = contents
 
         self._write(secrets_to_write)

--- a/planet/geojson.py
+++ b/planet/geojson.py
@@ -89,7 +89,7 @@ def geom_from_geojson(data: dict) -> dict:
                 raise GeoJSONException('Invalid GeoJSON: {data}')
 
             if len(features) > 1:
-                raise DataLossWarning(
+                LOGGER.warning(
                     'FeatureClass has more than one Feature, using only first'
                     ' feature.')
 

--- a/planet/geojson.py
+++ b/planet/geojson.py
@@ -30,8 +30,9 @@ class WrongTypeException(GeoJSONException):
     pass
 
 
-class DataLossWarning(UserWarning):
-    """Warn that data will be lost."""
+class MultipleFeaturesException(GeoJSONException):
+    '''multiple features when only one is acceptable'''
+    pass
 
 
 def as_geom(data: dict) -> dict:
@@ -80,7 +81,7 @@ def geom_from_geojson(data: dict) -> dict:
     else:
         try:
             # feature
-            ret = as_geom(data["geometry"])
+            ret = as_geom(data['geometry'])
         except KeyError:
             try:
                 # featureclass
@@ -89,9 +90,9 @@ def geom_from_geojson(data: dict) -> dict:
                 raise GeoJSONException('Invalid GeoJSON: {data}')
 
             if len(features) > 1:
-                LOGGER.warning(
-                    'FeatureClass has more than one Feature, using only first'
-                    ' feature.')
+                raise MultipleFeaturesException(
+                    'FeatureClass has multiple features. Only one feature '
+                    'can be used to get geometry.')
 
             ret = as_geom(features[0])
     return ret

--- a/planet/geojson.py
+++ b/planet/geojson.py
@@ -1,0 +1,153 @@
+# Copyright 2021 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""Functionality for interacting with GeoJSON."""
+import json
+import logging
+
+import shapely.geometry as sgeom
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GeoJSONException(Exception):
+    '''invalid geojson'''
+    pass
+
+
+class WrongTypeException(GeoJSONException):
+    '''wrong GeoJSON type'''
+    pass
+
+
+class Geometry():
+    '''Manage and validate GeoJSON geometry description.'''
+    def __init__(
+        self,
+        data: dict
+    ):
+        """
+        Initialize GeoJSON.
+
+        If data represents a GeoJSON FeatureClass, the geometry of the first
+        Feature is used.
+
+        Parameters:
+            data: GeoJSON geometry, Feature, or FeatureClass.
+        """
+        self._data = self._geom_from_dict(data)
+        self._type = self._geom_type(self._data)
+
+    @classmethod
+    def _geom_from_dict(
+        cls,
+        data: dict
+    ):
+        '''Extract the geometry description from GeoJSON.
+
+        If data represents a FeatureClass, the geometry from the first feature
+        is used.
+
+        Parameters:
+            data: GeoJSON geometry, Feature, or FeatureClass.
+
+        Raises:
+            GeoJSONException: If data is not valid GeoJSON geometry, Feature,
+            or FeatureClass.
+        '''
+        if set(('coordinates', 'type')).issubset(set(data.keys())):
+            # already a geom
+            ret = data
+        else:
+            try:
+                # feature
+                ret = cls._geom_from_dict(data["geometry"])
+            except KeyError:
+                try:
+                    # featureclass
+                    features = data['features']
+                except KeyError:
+                    raise GeoJSONException('Invalid GeoJSON')
+
+                ret = cls._geom_from_dict(features[0])
+        return ret
+
+    @staticmethod
+    def _geom_type(data: dict):
+        '''
+        Parameters:
+            data: GeoJSON geometry
+
+        Raises:
+            GeoJSONException: If data is not valid GeoJSON geometry, Feature,
+            or FeatureClass.
+            WrongTypeException: If geometry coordinates to not fit type.
+        '''
+        if 'type' not in data:
+            raise GeoJSONException(
+                'Missing \'type\' key.')
+        elif 'coordinates' not in data:
+            raise GeoJSONException(
+                'Missing \'coordinates\' key.')
+
+        try:
+            # ugh, this changes the underlying data
+            # notably coordinates as a list are converted to a tuple
+            shape = sgeom.shape(data)
+        except ValueError as e:
+            # invalid type or coordinates
+            raise GeoJSONException(e)
+        except TypeError:
+            # wrong type
+            raise WrongTypeException('Geometry coordinates do not fit type')
+
+        return shape.type
+
+    def type_matches(self, other):
+        return issubclass(self._type, other)
+
+    def to_dict(self):
+        return self._data
+
+    def to_str(self):
+        return json.dumps(self.to_dict())
+
+
+class Polygon(Geometry):
+    def __init__(
+        self,
+        data: dict
+    ):
+        """
+        Initialize GeoJSON.
+
+        If data represents a GeoJSON FeatureClass, the geometry of the first
+        Feature is used.
+
+        Parameters:
+            data: Feature, FeatureClass, or geometry GeoJSON description.
+
+
+        Raises:
+            WrongTypeException: If data geometry type is not Polygon.
+        """
+        super().__init__(data)
+        if self._type.lower() != 'polygon':
+            raise WrongTypeException(
+                f'Invalid geometry type: {self._type} is not Polygon.'
+                )
+
+    @classmethod
+    def from_geometry(cls, geometry):
+        return cls(geometry.to_dict())

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -36,27 +36,6 @@ pretty = click.option('-pp', '--pretty', is_flag=True,
                       help='Format JSON output')
 
 
-def get_auth():
-    try:
-        auth = planet.Auth.from_file()
-    except planet.auth.AuthException:
-        raise click.ClickException(
-            'Auth information does not exist or is corrupted. Initialize '
-            'with `planet auth init`.')
-    return auth
-
-
-def write_auth(email, password, base_url):
-    try:
-        auth = planet.Auth.from_login(email, password, base_url=base_url)
-    except planet.api.exceptions.InvalidAPIKey:
-        raise click.ClickException('Invalid email or password.')
-    except planet.api.exceptions.BadQuery:
-        raise click.ClickException('Not a valid email address.')
-    else:
-        auth.write()
-
-
 def json_echo(json_dict, pretty):
     if pretty:
         json_str = json.dumps(json_dict, indent=2, sort_keys=True)
@@ -124,10 +103,31 @@ def init(ctx, email, password):
     click.echo('Initialized')
 
 
+def write_auth(email, password, base_url):
+    try:
+        auth = planet.Auth.from_login(email, password, base_url=base_url)
+    except planet.api.exceptions.InvalidAPIKey:
+        raise click.ClickException('Invalid email or password.')
+    except planet.api.exceptions.BadQuery:
+        raise click.ClickException('Not a valid email address.')
+    else:
+        auth.write()
+
+
 @auth.command()
 def value():
     '''Print the stored authentication information'''
     click.echo(get_auth().value)
+
+
+def get_auth():
+    try:
+        auth = planet.Auth.from_file()
+    except planet.auth.AuthException:
+        raise click.ClickException(
+            'Auth information does not exist or is corrupted. Initialize '
+            'with `planet auth init`.')
+    return auth
 
 
 @cli.group()

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -65,13 +65,29 @@ def auth(ctx, base_url):
 @click.option('--email', default=None, prompt=True, help=(
     'The email address associated with your Planet credentials.'
 ))
-@click.password_option('--password', help=(
+@click.password_option('--password', confirmation_prompt=False, help=(
     'Account password. Will not be saved.'
 ))
 def init(ctx, email, password):
-    '''Login using email/password'''
-    # auth = planet.Auth.from_login(email, pw)
-    click.echo(f'base_url: {ctx.obj["BASE_URL"]}')
+    '''Obtain and store authentication information'''
+    base_url = ctx.obj["BASE_URL"]
+    auth = planet.Auth.from_login(email, password, base_url=base_url)
+    auth.write()
+    click.echo('Initialized')
+
+
+@auth.command()
+def value():
+    '''Print the stored authentication information'''
+    try:
+        auth = planet.Auth.from_file()
+        click.echo(auth.value)
+    except planet.auth.AuthException:
+        click.echo(
+            'Stored authentication information cannot be found. '
+            'Please store authentication information with `planet auth init`.')
+
+
 
 # @cli.group('orders')
 # def orders():

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -21,6 +21,7 @@ import sys
 import click
 
 import planet
+from planet import OrdersClient, Session
 
 
 # https://github.com/pallets/click/issues/85#issuecomment-503464628
@@ -48,8 +49,8 @@ def json_echo(json_dict, pretty):
 async def orders_client(ctx):
     auth = ctx.obj['AUTH']
     base_url = ctx.obj['BASE_URL']
-    async with planet.Session(auth=auth) as sess:
-        cl = planet.OrdersClient(sess, base_url=base_url)
+    async with Session(auth=auth) as sess:
+        cl = OrdersClient(sess, base_url=base_url)
         yield cl
 
 

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -298,8 +298,12 @@ async def create(ctx, name, ids, bundle, item_type, email, cloudconfig, clip,
     if clip and tools:
         raise click.BadParameter("Specify only one of '--clip' or '--tools'")
     elif clip:
-        tools = [planet.ClipTool(clip)]
+        try:
+            clip = planet.geojson.Polygon(clip)
+        except planet.geojson.GeoJSONException as e:
+            raise click.BadParameter(e)
 
+        tools = [planet.ClipTool(clip)]
     elif tools:
         tools = [planet.Tool.from_dict(t) for t in tools]
     else:

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -1,0 +1,88 @@
+# Copyright 2017 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import logging
+import sys
+
+import planet
+# from planet import __version__
+from planet.constants import PLANET_BASE_URL
+
+
+@click.group()
+@click.pass_context
+@click.option('-v', '--verbose', count=True,
+              help=('Specify verbosity level of between 0 and 2 corresponding '
+                    'to log levels warning, info, and debug respectively.'))
+@click.option('-u', '--base-url',
+              default=PLANET_BASE_URL, show_default=True,
+              help='Change base Planet API URL.')
+@click.version_option(version=planet.__version__)
+def cli(ctx, verbose, base_url):
+    '''Planet API Client'''
+    _configure_logging(verbose)
+
+    # ensure that ctx.obj exists and is a dict (in case `cli()` is called
+    # by means other than the `if` block below)
+    ctx.ensure_object(dict)
+    # ctx.obj['BASE_URL'] = base_url
+
+
+def _configure_logging(verbosity):
+    '''configure logging via verbosity level of between 0 and 2 corresponding
+    to log levels warning, info and debug respectfully.'''
+    log_level = max(logging.DEBUG, logging.WARNING - logging.DEBUG*verbosity)
+    logging.basicConfig(
+        stream=sys.stderr, level=log_level,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+
+
+@cli.group()
+@click.pass_context
+@click.option('-u', '--base-url',
+              default=None,
+              help='Assign custom base Auth API URL.')
+def auth(ctx, base_url):
+    '''Commands for working with Planet authentication'''
+    ctx.obj['BASE_URL'] = base_url
+
+
+@auth.command()
+@click.pass_context
+@click.option('--email', default=None, prompt=True, help=(
+    'The email address associated with your Planet credentials.'
+))
+@click.password_option('--password', help=(
+    'Account password. Will not be saved.'
+))
+def init(ctx, email, password):
+    '''Login using email/password'''
+    # auth = planet.Auth.from_login(email, pw)
+    click.echo(f'base_url: {ctx.obj["BASE_URL"]}')
+
+# @cli.group('orders')
+# def orders():
+#     '''Commands for interacting with the Orders API'''
+#     pass
+#
+#
+# @orders.command('list')
+# # @click.option('--status', help="'all', 'in-progress', 'completed'")
+# @pretty
+# def list_orders(pretty):
+#     '''List all pending order requests; optionally filter by status'''
+#     cl = clientv1()
+#     echo_json_response(call_and_wrap(cl.get_orders), pretty)

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -262,14 +262,14 @@ def read_file_json(ctx, param, value):
 @coro
 @click.option('--name', required=True)
 @click.option('--id', 'ids', help='One or more comma-separated item IDs',
-              type=click.STRING, callback=split_id_list)
+              type=click.STRING, callback=split_id_list, required=True)
 # @click.option('--ids_from_search',
 #               help='Embedded data search')
 @click.option('--bundle', multiple=False, required=True,
               help='Specify bundle',
               type=click.Choice(planet.specs.get_product_bundles(),
                                 case_sensitive=False),
-              is_eager=True)
+              )
 @click.option('--item-type', multiple=False, required=True,
               help='Specify an item type',
               type=click.STRING)

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -236,7 +236,7 @@ def read_file_geojson(ctx, param, value):
         return value
 
     json_value = read_file_json(ctx, param, value)
-    geo = planet.Geometry(json_value)
+    geo = planet.geojson.as_geom(json_value)
     return geo
 
 
@@ -299,7 +299,7 @@ async def create(ctx, name, ids, bundle, item_type, email, cloudconfig, clip,
         raise click.BadParameter("Specify only one of '--clip' or '--tools'")
     elif clip:
         try:
-            clip = planet.geojson.Polygon(clip)
+            clip = planet.geojson.as_polygon(clip)
         except planet.geojson.GeoJSONException as e:
             raise click.BadParameter(e)
 

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -73,6 +73,7 @@ async def orders_client(ctx):
         cl = planet.OrdersClient(sess, base_url=base_url)
         yield cl
 
+
 @click.group()
 @click.pass_context
 @click.option('-v', '--verbose', count=True,
@@ -250,21 +251,3 @@ async def download(ctx, order_id, quiet, overwrite, dest):
 #     cl = clientv1()
 #     request = create_order_request(**kwargs)
 #     echo_json_response(call_and_wrap(cl.create_order, request), pretty)
-=======
-@click.option('--state',
-              help='Filter orders to given state.',
-              type=click.Choice(planet.api.orders.ORDERS_STATES,
-                                case_sensitive=False))
-@click.option('--limit', help='Filter orders to given limit.',
-              default=None, type=int)
-async def list(ctx, state, limit):
-    '''List orders'''
-    auth = ctx.obj['AUTH']
-    base_url = ctx.obj['BASE_URL']
-
-    async with planet.Session(auth=auth) as sess:
-        cl = planet.OrdersClient(sess, base_url=base_url)
-        orders = await cl.list_orders(state=state, limit=limit, as_json=True)
-
-    click.echo(json.dumps(orders))
->>>>>>> ad4c5b6050c8788d8c63d0dc868a149364de02cf

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -244,7 +244,7 @@ def read_file_geojson(ctx, param, value):
         return value
 
     json_value = read_file_json(ctx, param, value)
-    geo = planet.GeoJSON(json_value)
+    geo = planet.Geometry(json_value)
     return geo
 
 
@@ -265,6 +265,7 @@ def read_file_json(ctx, param, value):
 
 
 def read_tools(ctx, param, value):
+    # skip this if the filename is None
     if not value:
         return value
 

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -206,10 +206,12 @@ async def cancel(ctx, order_id):
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
     async with orders_client(ctx) as cl:
-        await cl.download_order(str(order_id),
-                                directory=dest,
-                                overwrite=overwrite,
-                                progress_bar=not quiet)
+        filenames = await cl.download_order(
+                str(order_id),
+                directory=dest,
+                overwrite=overwrite,
+                progress_bar=not quiet)
+    click.echo(f'Downloaded {len(filenames)} files.\n' + "\n".join(filenames))
 
 
 # @orders.command()

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -206,12 +206,13 @@ async def cancel(ctx, order_id):
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
     async with orders_client(ctx) as cl:
+        await cl.poll(str(order_id), verbose=True)
         filenames = await cl.download_order(
                 str(order_id),
                 directory=dest,
                 overwrite=overwrite,
                 progress_bar=not quiet)
-    click.echo(f'Downloaded {len(filenames)} files.\n' + "\n".join(filenames))
+    click.echo(f'Downloaded {len(filenames)} files.')
 
 
 # @orders.command()

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -38,10 +38,11 @@ def validate_bundle(bundle):
     return _validate_field(bundle, supported, 'product_bundle')
 
 
-def validate_item_type(item_type, bundle):
+def validate_item_type(item_type, bundle, report_field_name=True):
     bundle = validate_bundle(bundle)
     supported = get_item_types(bundle)
-    return _validate_field(item_type, supported, 'item_type')
+    field_name = 'item_type' if report_field_name else None
+    return _validate_field(item_type, supported, field_name)
 
 
 def validate_order_type(order_type):
@@ -61,7 +62,8 @@ def _validate_field(value, supported, field_name=None):
     try:
         value = get_match(value, supported)
     except(NoMatchException):
-        msg = f'\'{value}\' not in {list(supported)}'
+        opts = ', '.join(["'"+s+"'" for s in supported])
+        msg = f'\'{value}\' is not one of {opts}.'
         if field_name:
             msg = f'{field_name} - ' + msg
         raise SpecificationException(msg)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ with open('planet/api/__version__.py') as f:
 
 
 install_requires = [
-    'httpx==0.16',
+    'click>=8.0.0',
+    'httpx==0.16.1',
     'tqdm>=4.56',
 ]
 
@@ -76,5 +77,10 @@ setup(name='planet',
           'test': test_requires,
           'lint': lint_requires,
           'docs': doc_requires,
-          'dev': test_requires + lint_requires + doc_requires}
+          'dev': test_requires + lint_requires + doc_requires},
+      entry_points={
+          'console_scripts': [
+              'planet=planet.scripts.cli:cli',
+          ],
+        },
       )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ lint_requires = [
 
 doc_requires = [
     'mkdocs==1.1',
+    'mkdocs-click==0.4.0',
     'mkdocs-material',
     'mkdocstrings==0.15.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open('planet/api/__version__.py') as f:
 install_requires = [
     'click>=8.0.0',
     'httpx==0.16.1',
+    'shapely>=1.7.1',
     'tqdm>=4.56',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ lint_requires = [
 ]
 
 doc_requires = [
-    'mkdocs',
+    'mkdocs==1.1',
     'mkdocs-material',
     'mkdocstrings==0.15.0'
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,3 +67,60 @@ def orders_page():
 @pytest.fixture
 def oid():
     return 'b0cb3448-0a74-11eb-92a1-a3d779bb08e0'
+
+
+@pytest.fixture
+def write_to_tmp_json_file(tmp_path):
+    def write(data):
+        cc = tmp_path / 'cc.json'
+        with open(cc, 'w') as fp:
+            json.dump(data, fp)
+        return cc
+    return write
+
+
+@pytest.fixture
+def geom_geojson():
+    # these need to be tuples, not list, or they will be changed
+    # by shapely
+    return {
+        "type": "Polygon",
+        "coordinates": [[
+            [
+                37.791595458984375,
+                14.84923123791421
+                ],
+            [
+                37.90214538574219,
+                14.84923123791421
+                ],
+            [
+                37.90214538574219,
+                14.945448293647944
+                ],
+            [
+                37.791595458984375,
+                14.945448293647944
+                ],
+            [
+                37.791595458984375,
+                14.84923123791421
+                ]
+        ]]
+      }
+
+
+@pytest.fixture
+def feature_geojson(geom_geojson):
+    return {
+      "type": "Feature",
+      "properties": {},
+      "geometry": geom_geojson}
+
+
+@pytest.fixture
+def featureclass_geojson(feature_geojson):
+    return {
+          "type": "FeatureCollection",
+          "features": [feature_geojson]
+        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,8 +71,8 @@ def oid():
 
 @pytest.fixture
 def write_to_tmp_json_file(tmp_path):
-    def write(data):
-        cc = tmp_path / 'cc.json'
+    def write(data, filename):
+        cc = tmp_path / filename
         with open(cc, 'w') as fp:
             json.dump(data, fp)
         return cc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,21 @@ from pathlib import Path
 
 import pytest
 
+from planet.auth import _SecretFile
+
 _here = Path(os.path.abspath(os.path.dirname(__file__)))
 _test_data_path = _here / 'data'
+
+
+@pytest.fixture(autouse=True, scope='module')
+def test_secretfile_read():
+    '''Returns valid auth results as if reading a secret file'''
+    def mockreturn(self):
+        return {'key': 'testkey'}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_SecretFile, 'read', mockreturn)
+        yield
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,3 +124,14 @@ def featureclass_geojson(feature_geojson):
           "type": "FeatureCollection",
           "features": [feature_geojson]
         }
+
+
+@pytest.fixture
+def point_geom_geojson():
+    return {
+        "type": "Point",
+        "coordinates": [
+                37.791595458984375,
+                14.84923123791421
+                ]
+        }

--- a/tests/data/order_details_psorthotile_analytic.json
+++ b/tests/data/order_details_psorthotile_analytic.json
@@ -3,7 +3,7 @@
   "products": [
     {
       "item_ids": [
-        "4563990_2133707_2021-06-08_0f02"
+        "4500474_2133707_2021-05-20_2419"
       ],
       "item_type": "PSOrthoTile",
       "product_bundle": "ANALYTIC"

--- a/tests/data/order_details_psorthotile_analytic.json
+++ b/tests/data/order_details_psorthotile_analytic.json
@@ -3,7 +3,7 @@
   "products": [
     {
       "item_ids": [
-        "test_item_id"
+        "4563990_2133707_2021-06-08_0f02"
       ],
       "item_type": "PSOrthoTile",
       "product_bundle": "ANALYTIC"

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -148,6 +148,25 @@ async def test_list_orders_limit(order_descriptions, session):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_list_orders_asjson(order_descriptions, session):
+    list_url = TEST_URL + 'orders/v2/'
+
+    order1, order2, order3 = order_descriptions
+
+    page1_response = {
+        "_links": {"_self": "string"},
+        "orders": [order1]
+    }
+    mock_resp1 = httpx.Response(HTTPStatus.OK, json=page1_response)
+    respx.get(list_url).return_value = mock_resp1
+
+    cl = OrdersClient(session, base_url=TEST_URL)
+    orders = await cl.list_orders(as_json=True)
+    assert orders[0]['id'] == 'oid1'
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_create_order(oid, order_description, order_details, session):
     create_url = TEST_URL + 'orders/v2/'
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -173,9 +173,9 @@ async def test_create_order(oid, order_description, order_details, session):
     respx.post(create_url).return_value = mock_resp
 
     cl = OrdersClient(session, base_url=TEST_URL)
-    created_oid = await cl.create_order(order_details)
+    order = await cl.create_order(order_details)
 
-    assert created_oid == oid
+    assert order.json == order_description
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -24,7 +24,7 @@ import httpx
 import pytest
 import respx
 
-from planet import Auth, OrdersClient, Session
+from planet import OrdersClient, Session
 
 
 TEST_URL = 'http://MockNotRealURL/'
@@ -35,8 +35,7 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture
 @pytest.mark.asyncio
 async def session():
-    auth = Auth.from_key('mockkey')
-    async with Session(auth=auth) as ps:
+    async with Session() as ps:
         yield ps
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,75 @@
+# # Copyright 2021 Planet Labs, Inc.
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+import logging
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+import pytest
+
+import planet
+from planet.scripts.cli import cli
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_auth_init_bad_pw(runner, monkeypatch):
+    def invalidapikey(*args, **kwargs):
+        raise planet.api.exceptions.InvalidAPIKey
+
+    monkeypatch.setattr(planet.Auth, 'from_login', invalidapikey)
+    result = runner.invoke(cli, args=['auth', 'init'], input='email\npw\n')
+    assert 'Error: Invalid email or password.' in result.output
+
+
+def test_auth_init_bad_email(runner, monkeypatch):
+    def badquery(*args, **kwargs):
+        raise planet.api.exceptions.BadQuery
+
+    monkeypatch.setattr(planet.Auth, 'from_login', badquery)
+    result = runner.invoke(cli, args=['auth', 'init'], input='email\npw\n')
+    assert 'Error: Not a valid email address.' in result.output
+
+
+def test_auth_init_success(runner, monkeypatch):
+    mock_api_auth = MagicMock(spec=planet.auth.APIKeyAuth)
+    mock_auth = MagicMock(spec=planet.Auth)
+    mock_auth.from_login.return_value = mock_api_auth
+    monkeypatch.setattr(planet, 'Auth', mock_auth)
+
+    result = runner.invoke(cli, args=['auth', 'init'], input='email\npw\n')
+    mock_auth.from_login.assert_called_once()
+    mock_api_auth.write.assert_called_once()
+    assert 'Initialized' in result.output
+
+
+def test_auth_value_failure(runner, monkeypatch):
+    def authexception(*args, **kwargs):
+        raise planet.auth.AuthException
+
+    monkeypatch.setattr(planet.Auth, 'from_file', authexception)
+
+    result = runner.invoke(cli, ['auth', 'value'])
+    assert 'Error: Auth information does not exist or is corrupted.' \
+        in result.output
+
+
+def test_auth_value_success(runner):
+    result = runner.invoke(cli, ['auth', 'value'])
+    assert not result.exception
+    assert result.output == 'testkey\n'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -117,10 +117,14 @@ def test_cli_orders_cancel(runner, monkeypatch, order_description):
 def test_cli_orders_download(runner, monkeypatch):
     async def do(*arg, **kwarg):
         return ['file1']
-
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'download_order', do)
+
+    async def poll(*arg, **kwarg):
+        return
+    monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'poll', poll)
+
     result = runner.invoke(
         cli, ['orders', 'download', TEST_OID])
     assert not result.exception
     # assert "file1" in result.output
-    assert 'Downloaded 1 files.\nfile1\n' == result.output
+    assert 'Downloaded 1 files.\n' == result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -203,14 +203,13 @@ def test_cli_orders_create_cloudconfig(
                         create_order_params['item_type'])],
         delivery=planet.Delivery.from_file(cloudconfig)
         )
-    print(expected_details)
     mock_create_order.assert_called_with(expected_details)
 
 
 def test_cli_read_file_geojson(clipaoi):
     with open(clipaoi, 'r') as cfile:
         res = planet.scripts.cli.read_file_geojson({}, 'clip', cfile)
-    assert type(res) == planet.GeoJSON
+    assert type(res) == planet.Geometry
 
 
 def test_cli_orders_create_clip(
@@ -238,7 +237,6 @@ def test_cli_orders_create_clip(
                         create_order_params['item_type'])],
         tools=[planet.Tool('clip', {'aoi': geom_geojson})]
         )
-    print(expected_details)
     mock_create_order.assert_called_with(expected_details)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from click.testing import CliRunner
 import pytest
@@ -21,9 +21,6 @@ import planet
 from planet.scripts.cli import cli
 
 LOGGER = logging.getLogger(__name__)
-
-
-TEST_OID = 'a8e74f65-5fbd-4b2c-917e-8b69b7e0772b'
 
 
 @pytest.fixture(autouse=True)
@@ -94,27 +91,27 @@ def test_cli_orders_list_success(runner, monkeypatch):
     assert "{'order': 'yep'}" in result.output
 
 
-def test_cli_orders_get(runner, monkeypatch, order_description):
+def test_cli_orders_get(runner, monkeypatch, order_description, oid):
     async def go(*arg, **kwarg):
         return planet.api.orders.Order(order_description)
 
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'get_order', go)
     result = runner.invoke(
-        cli, ['orders', 'get', TEST_OID])
+        cli, ['orders', 'get', oid])
     assert not result.exception
 
 
-def test_cli_orders_cancel(runner, monkeypatch, order_description):
+def test_cli_orders_cancel(runner, monkeypatch, order_description, oid):
     async def co(*arg, **kwarg):
         return ''
 
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'cancel_order', co)
     result = runner.invoke(
-        cli, ['orders', 'cancel', TEST_OID])
+        cli, ['orders', 'cancel', oid])
     assert not result.exception
 
 
-def test_cli_orders_download(runner, monkeypatch):
+def test_cli_orders_download(runner, monkeypatch, oid):
     async def do(*arg, **kwarg):
         return ['file1']
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'download_order', do)
@@ -124,7 +121,225 @@ def test_cli_orders_download(runner, monkeypatch):
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'poll', poll)
 
     result = runner.invoke(
-        cli, ['orders', 'download', TEST_OID])
+        cli, ['orders', 'download', oid])
     assert not result.exception
     # assert "file1" in result.output
     assert 'Downloaded 1 files.\n' == result.output
+
+
+class AsyncMock(Mock):
+    '''Mock an async function'''
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+@pytest.fixture
+def cloudconfig(write_to_tmp_json_file):
+    as3_details = {
+        'amazon_s3': {
+            'aws_access_key_id': 'aws_access_key_id',
+            'aws_secret_access_key': 'aws_secret_access_key',
+            'bucket': 'bucket',
+            'aws_region': 'aws_region'
+            },
+        'archive_type': 'zip',
+    }
+    return write_to_tmp_json_file(as3_details)
+
+
+@pytest.fixture
+def clipaoi(feature_geojson, write_to_tmp_json_file):
+    return write_to_tmp_json_file(feature_geojson)
+
+
+@pytest.fixture
+def mock_create_order(monkeypatch, oid):
+    mock_create_order = AsyncMock(return_value=oid)
+    monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'create_order',
+                        mock_create_order)
+    return mock_create_order
+
+
+@pytest.fixture
+def test_ids(oid):
+    # uuid generated with https://www.uuidgenerator.net/
+    test_id2 = '65f4aa35-b46b-48ba-b165-12b49986795c'
+    return oid, test_id2
+
+
+@pytest.fixture
+def create_order_params(oid):
+    return {
+        'id': oid,
+        'name': 'test',
+        'bundle': 'analytic_udm2',
+        'item_type': 'PSScene4Band'
+    }
+
+
+def test_cli_orders_create_cloudconfig(
+        runner, mock_create_order, create_order_params, cloudconfig, oid
+        ):
+
+    basic_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type'],
+            '--cloudconfig', cloudconfig
+              ]
+    )
+    assert not basic_result.exception
+    assert f'Created order {oid}' in basic_result.output
+
+    mock_create_order.assert_called_once()
+
+    expected_details = planet.OrderDetails(
+        create_order_params['name'],
+        [planet.Product([create_order_params['id']],
+                        create_order_params['bundle'],
+                        create_order_params['item_type'])],
+        delivery=planet.Delivery.from_file(cloudconfig)
+        )
+    print(expected_details)
+    mock_create_order.assert_called_with(expected_details)
+
+
+def test_cli_read_file_geojson(clipaoi):
+    with open(clipaoi, 'r') as cfile:
+        res = planet.scripts.cli.read_file_geojson({}, 'clip', cfile)
+    assert type(res) == planet.GeoJSON
+
+
+def test_cli_orders_create_clip(
+        runner, mock_create_order, create_order_params, clipaoi, oid,
+        geom_geojson):
+    basic_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type'],
+            '--clip', clipaoi
+              ]
+    )
+    assert not basic_result.exception
+    assert f'Created order {oid}' in basic_result.output
+
+    mock_create_order.assert_called_once()
+
+    expected_details = planet.OrderDetails(
+        create_order_params['name'],
+        [planet.Product([create_order_params['id']],
+                        create_order_params['bundle'],
+                        create_order_params['item_type'])],
+        tools=[planet.Tool('clip', {'aoi': geom_geojson})]
+        )
+    print(expected_details)
+    mock_create_order.assert_called_with(expected_details)
+
+
+def test_cli_orders_create_validate_id(runner, mock_create_order,
+                                       create_order_params, oid):
+    # uuid generated with https://www.uuidgenerator.net/
+    test_id2 = '65f4aa35-b46b-48ba-b165-12b49986795c'
+    success_ids = ','.join([oid, test_id2])
+    fail_ids = '1.2,2'
+
+    # id string is correct format
+    success_mult_ids_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', success_ids,
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type']
+              ])
+    # assert not success_mult_ids_result.exception
+    assert f'Created order {oid}' in success_mult_ids_result.output
+
+    # id string is wrong format
+    failed_mult_ids_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', fail_ids,
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type']
+              ])
+    assert failed_mult_ids_result.exception
+    assert "Invalid value for '--id': '1.2' is not a valid UUID." \
+        in failed_mult_ids_result.output
+
+
+def test_cli_orders_create_validate_item_type(runner, mock_create_order,
+                                              create_order_params):
+    fail_item_type = 'PSScene3Band'
+
+    # item type is not valid for bundle
+    failed_item_type_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', fail_item_type
+              ])
+    assert failed_item_type_result.exception
+    assert "Invalid value for '--item-type'" in failed_item_type_result.output
+
+
+def test_cli_orders_create_validate_cloudconfig(runner, mock_create_order,
+                                                create_order_params, tmp_path):
+    # write invalid text to file
+    cc = tmp_path / 'cc.json'
+    with open(cc, 'w') as fp:
+        fp.write('')
+
+    # cloudconfig file is wrong format
+    wrong_format_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type'],
+            '--cloudconfig', cc
+              ])
+    assert wrong_format_result.exception
+    assert "File does not contain valid json." \
+        in wrong_format_result.output
+
+    # cloudconfig file doesn't exist
+    doesnotexistfile = tmp_path / 'doesnotexist.json'
+    doesnotexit_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type'],
+            '--cloudconfig', doesnotexistfile
+              ])
+    assert doesnotexit_result.exception
+    assert "No such file or directory" in doesnotexit_result.output
+
+
+def test_cli_orders_create_validate_tools(runner, mock_create_order,
+                                          create_order_params, tmp_path):
+    basic_result = runner.invoke(
+        cli, [
+            'orders', 'create',
+            '--name', create_order_params['name'],
+            '--id', create_order_params['id'],
+            '--bundle', create_order_params['bundle'],
+            '--item-type', create_order_params['item_type'],
+            '--clip', 'something',
+              ]
+    )
+    # assert not basic_result.exception
+    # assert f'Created order {d}' in basic_result.output
+    raise NotImplementedError

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -359,3 +359,17 @@ def test_cli_orders_create_validate_tools(
         cli, create_order_basic_cmds + ['--tools', tools, '--clip', clipaoi]
     )
     assert clip_and_tools_result.exception
+
+
+def test_cli_orders_create_validate_clip(
+        runner, mock_create_order, create_order_basic_cmds,
+        point_geom_geojson, write_to_tmp_json_file
+        ):
+    clip_point = write_to_tmp_json_file(point_geom_geojson, 'point.json')
+
+    clip_point_result = runner.invoke(
+        cli, create_order_basic_cmds + ['--clip', clip_point]
+    )
+    assert clip_point_result.exception
+    assert "Invalid geometry type: Point is not Polygon" in \
+        clip_point_result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -89,7 +89,7 @@ def test_cli_orders_list_success(runner, monkeypatch):
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'list_orders', lo)
     result = runner.invoke(cli, ['orders', 'list'])
     assert not result.exception
-    assert "{'order': 'yep'}" in result.output
+    assert '{"order": "yep"}' in result.output
 
 
 def test_cli_orders_get(runner, monkeypatch, order_description, oid):
@@ -322,7 +322,7 @@ def test_cli_orders_create_validate_item_type(
             '--item-type', 'PSScene3Band'
             ])
     assert failed_item_type_result.exception
-    assert "Invalid value for '--item-type'" in failed_item_type_result.output
+    assert "Invalid value: item_type" in failed_item_type_result.output
 
 
 def test_cli_orders_create_validate_cloudconfig(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -35,21 +35,11 @@ def runner():
 
 
 def test_cli_auth_init_bad_pw(runner, monkeypatch):
-    def invalidapikey(*args, **kwargs):
-        raise planet.api.exceptions.InvalidAPIKey
-
-    monkeypatch.setattr(planet.Auth, 'from_login', invalidapikey)
+    def apiexcept(*args, **kwargs):
+        raise planet.api.exceptions.APIException('nope')
+    monkeypatch.setattr(planet.Auth, 'from_login', apiexcept)
     result = runner.invoke(cli, args=['auth', 'init'], input='email\npw\n')
-    assert 'Error: Invalid email or password.' in result.output
-
-
-def test_cli_auth_init_bad_email(runner, monkeypatch):
-    def badquery(*args, **kwargs):
-        raise planet.api.exceptions.BadQuery
-
-    monkeypatch.setattr(planet.Auth, 'from_login', badquery)
-    result = runner.invoke(cli, args=['auth', 'init'], input='email\npw\n')
-    assert 'Error: Not a valid email address.' in result.output
+    assert 'Error: nope' in result.output
 
 
 def test_cli_auth_init_success(runner, monkeypatch):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
+import json
 import logging
 from unittest.mock import MagicMock, Mock
 
@@ -226,9 +227,12 @@ def test_cli_orders_create_cloudconfig(
 
     mock_create_order.assert_called_once()
 
+    with open(cloudconfig, 'r') as f:
+        cc = json.load(f)
+
     expected_details = planet.OrderDetails(
         name, products,
-        delivery=planet.Delivery.from_file(cloudconfig)
+        delivery=planet.Delivery.from_dict(cc)
         )
     mock_create_order.assert_called_with(expected_details)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -183,10 +183,10 @@ def test_id(order_details):
     return order_details['products'][0]['item_ids'][0]
 
 
-def test_cli_read_file_geojson(clipaoi):
+def test_cli_read_file_geojson(clipaoi, geom_geojson):
     with open(clipaoi, 'r') as cfile:
         res = planet.scripts.cli.read_file_geojson({}, 'clip', cfile)
-    assert type(res) == planet.Geometry
+    assert res == geom_geojson
 
 
 @pytest.fixture

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -23,6 +23,9 @@ from planet.scripts.cli import cli
 LOGGER = logging.getLogger(__name__)
 
 
+TEST_OID = 'a8e74f65-5fbd-4b2c-917e-8b69b7e0772b'
+
+
 @pytest.fixture(autouse=True)
 def patch_session(monkeypatch):
     '''Make sure we don't actually make any http calls'''
@@ -89,3 +92,35 @@ def test_cli_orders_list_success(runner, monkeypatch):
     result = runner.invoke(cli, ['orders', 'list'])
     assert not result.exception
     assert "{'order': 'yep'}" in result.output
+
+
+def test_cli_orders_get(runner, monkeypatch, order_description):
+    async def go(*arg, **kwarg):
+        return planet.api.orders.Order(order_description)
+
+    monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'get_order', go)
+    result = runner.invoke(
+        cli, ['orders', 'get', TEST_OID])
+    assert not result.exception
+
+
+def test_cli_orders_cancel(runner, monkeypatch, order_description):
+    async def co(*arg, **kwarg):
+        return ''
+
+    monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'cancel_order', co)
+    result = runner.invoke(
+        cli, ['orders', 'cancel', TEST_OID])
+    assert not result.exception
+
+
+def test_cli_orders_download(runner, monkeypatch):
+    async def do(*arg, **kwarg):
+        return ['file1']
+
+    monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'download_order', do)
+    result = runner.invoke(
+        cli, ['orders', 'download', TEST_OID])
+    assert not result.exception
+    # assert "file1" in result.output
+    assert 'Downloaded 1 files.\nfile1\n' == result.output

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -45,10 +45,6 @@ def test_geom_from_geojson_success(
     fcgeo = geojson.geom_from_geojson(featureclass_geojson)
     assert_geom_equal(fcgeo, geom_geojson)
 
-    featureclass_geojson['features'].append(feature_geojson)
-    ffcgeo = geojson.geom_from_geojson(featureclass_geojson)
-    assert_geom_equal(ffcgeo, geom_geojson)
-
 
 def test_geom_from_geojson_no_geometry(feature_geojson):
     feature_geojson.pop('geometry')
@@ -66,6 +62,13 @@ def test_geom_from_geojson_missing_type(geom_geojson):
     geom_geojson.pop('type')
     with pytest.raises(geojson.GeoJSONException):
         _ = geojson.geom_from_geojson(geom_geojson)
+
+
+def test_geom_from_geojson_multiple_features(featureclass_geojson):
+    # duplicate the feature
+    featureclass_geojson['features'] = 2 * featureclass_geojson['features']
+    with pytest.raises(geojson.MultipleFeaturesException):
+        _ = geojson.geom_from_geojson(featureclass_geojson)
 
 
 def test_validate_geom_invalid_type(geom_geojson):

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -1,0 +1,110 @@
+# Copyright 2021 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+
+import pytest
+
+from planet import geojson
+
+LOGGER = logging.getLogger(__name__)
+
+
+def assert_geom_eq(g1, g2):
+    g = json.loads(json.dumps(g1).replace(")", "]").replace("(", "["))
+    assert g == g2
+
+
+def test_Geometry__geom_type_success(geom_geojson):
+    gtype = geojson.Geometry._geom_type(geom_geojson)
+    assert gtype == geom_geojson['type']
+
+
+def test_Geometry__geom_type_missing_type(geom_geojson):
+    geom_geojson.pop('type')
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_type_invalid_type(geom_geojson):
+    geom_geojson['type'] = 'invalid'
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_type_wrong_type(geom_geojson):
+    geom_geojson['type'] = 'point'
+    with pytest.raises(geojson.WrongTypeException):
+        _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_type_missing_coordinates(geom_geojson):
+    geom_geojson.pop('coordinates')
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_type_invalid_coordinates(geom_geojson):
+    geom_geojson['coordinates'] = 'invalid'
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_type_empty_coordinates(geom_geojson):
+    geom_geojson['coordinates'] = []
+    _ = geojson.Geometry._geom_type(geom_geojson)
+
+
+def test_Geometry__geom_from_dict_success(
+        feature_geojson, featureclass_geojson, geom_geojson):
+    geom = geojson.Geometry._geom_from_dict(geom_geojson)
+    assert_geom_eq(geom, geom_geojson)
+
+    f_geom = geojson.Geometry._geom_from_dict(feature_geojson)
+    assert_geom_eq(f_geom, geom_geojson)
+
+    fc_geom = geojson.Geometry._geom_from_dict(featureclass_geojson)
+    assert_geom_eq(fc_geom, geom_geojson)
+
+
+def test_Geometry__geom_from_dict_no_geometry(feature_geojson):
+    feature_geojson.pop('geometry')
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.Geometry._geom_from_dict(feature_geojson)
+
+
+def test_Geometry__init__(geom_geojson):
+    geo = geojson.Geometry(geom_geojson)
+    assert_geom_eq(geo.to_dict(), geom_geojson)
+
+
+def test_Polygon__init__(geom_geojson):
+    geo = geojson.Polygon(geom_geojson)
+    assert_geom_eq(geo.to_dict(), geom_geojson)
+
+
+def test_Polygon_wrong_type(point_geom_geojson):
+    with pytest.raises(geojson.WrongTypeException):
+        _ = geojson.Polygon(point_geom_geojson)
+
+
+def test_Polygon_from_Geometry(geom_geojson):
+    geo = geojson.Geometry(geom_geojson)
+    _ = geojson.Polygon.from_geometry(geo)
+
+
+def test_Polygon_from_Geometry_wrong_type(point_geom_geojson):
+    geo = geojson.Geometry(point_geom_geojson)
+    with pytest.raises(geojson.WrongTypeException):
+        _ = geojson.Polygon.from_geometry(geo)

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import logging
 
 import pytest
@@ -20,85 +21,80 @@ from planet import geojson
 LOGGER = logging.getLogger(__name__)
 
 
-def test_Geometry__init__success(geom_geojson):
-    geo = geojson.Geometry(geom_geojson)
-    assert geo.type == geom_geojson['type']
+@pytest.fixture
+def assert_geom_equal():
+    def _tuple_to_list(obj):
+        return json.loads(json.dumps(obj).replace(")", "]").replace("(", "["))
+
+    def fcn(geom_1, geom_2):
+        str_1 = _tuple_to_list(geom_1)
+        str_2 = _tuple_to_list(geom_2)
+        assert str_1 == str_2
+    return fcn
 
 
-def test_Geometry__eq__(geom_geojson):
-    geom_tuple = {
-        "type": "Point",
-        "coordinates": (-103.0078125, 40.713955826286046)
-      }
-    geom_list = {
-        "type": "Point",
-        "coordinates": [-103.0078125, 40.713955826286046]
-      }
-
-    assert geojson.Geometry(geom_tuple) == geojson.Geometry(geom_list)
-
-
-def test_Geometry__init__missing_type(geom_geojson):
-    geom_geojson.pop('type')
-    with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry(geom_geojson)
+def test_geom_from_geojson_success(
+        geom_geojson, feature_geojson, featureclass_geojson,
+        assert_geom_equal):
+    ggeo = geojson.as_geom(geom_geojson)
+    assert_geom_equal(ggeo, geom_geojson)
+    #
+    # fgeo = geojson.geom_from_geojson(feature_geojson)
+    # assert_geom_equal(fgeo, geom_geojson)
+    #
+    # fcgeo = geojson.geom_from_geojson(featureclass_geojson)
+    # assert_geom_equal(fcgeo, geom_geojson)
 
 
-def test_Geometry__init__invalid_type(geom_geojson):
-    geom_geojson['type'] = 'invalid'
-    with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__wrong_type(geom_geojson):
-    geom_geojson['type'] = 'point'
-    with pytest.raises(geojson.WrongTypeException):
-        _ = geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__missing_coordinates(geom_geojson):
-    geom_geojson.pop('coordinates')
-    with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__invalid_coordinates(geom_geojson):
-    geom_geojson['coordinates'] = 'invalid'
-    with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__empty_coordinates(geom_geojson):
-    geom_geojson['coordinates'] = []
-    _ = geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__feature(geom_geojson, feature_geojson):
-    assert geojson.Geometry(feature_geojson) == \
-        geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__featureclass(geom_geojson, featureclass_geojson):
-    assert geojson.Geometry(featureclass_geojson) == \
-        geojson.Geometry(geom_geojson)
-
-
-def test_Geometry__init__no_geometry(feature_geojson):
+def test_geom_from_geojson_no_geometry(feature_geojson):
     feature_geojson.pop('geometry')
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry(feature_geojson)
+        _ = geojson.geom_from_geojson(feature_geojson)
 
 
-def test_Polygon__init__(geom_geojson):
-    geom = geojson.Geometry(geom_geojson)
-
-    # init from dict
-    assert geojson.Polygon(geom_geojson) == geom
-
-    # init from Geometry
-    assert geojson.Polygon(geom) == geom
+def test_geom_from_geojson_missing_coordinates(geom_geojson):
+    geom_geojson.pop('coordinates')
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.geom_from_geojson(geom_geojson)
 
 
-def test_Polygon_wrong_type(point_geom_geojson):
+def test_geom_from_geojson_missing_type(geom_geojson):
+    geom_geojson.pop('type')
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.geom_from_geojson(geom_geojson)
+
+
+def test_validate_geom_invalid_type(geom_geojson):
+    geom_geojson['type'] = 'invalid'
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.validate_geom(geom_geojson)
+
+
+def test_validate_geom_wrong_type(geom_geojson):
+    geom_geojson['type'] = 'point'
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.validate_geom(geom_geojson)
+
+
+def test_validate_geom_invalid_coordinates(geom_geojson):
+    geom_geojson['coordinates'] = 'invalid'
+    with pytest.raises(geojson.GeoJSONException):
+        _ = geojson.validate_geom(geom_geojson)
+
+
+def test_validate_geom_empty_coordinates(geom_geojson):
+    geom_geojson['coordinates'] = []
+    _ = geojson.validate_geom(geom_geojson)
+
+
+def test_as_geom(geom_geojson):
+    assert geojson.as_geom(geom_geojson) == geom_geojson
+
+
+def test_as_polygon(geom_geojson):
+    assert geojson.as_polygon(geom_geojson) == geom_geojson
+
+
+def test_as_polygon_wrong_type(point_geom_geojson):
     with pytest.raises(geojson.WrongTypeException):
-        _ = geojson.Polygon(point_geom_geojson)
+        _ = geojson.as_polygon(point_geom_geojson)

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -38,12 +38,16 @@ def test_geom_from_geojson_success(
         assert_geom_equal):
     ggeo = geojson.as_geom(geom_geojson)
     assert_geom_equal(ggeo, geom_geojson)
-    #
-    # fgeo = geojson.geom_from_geojson(feature_geojson)
-    # assert_geom_equal(fgeo, geom_geojson)
-    #
-    # fcgeo = geojson.geom_from_geojson(featureclass_geojson)
-    # assert_geom_equal(fcgeo, geom_geojson)
+
+    fgeo = geojson.geom_from_geojson(feature_geojson)
+    assert_geom_equal(fgeo, geom_geojson)
+
+    fcgeo = geojson.geom_from_geojson(featureclass_geojson)
+    assert_geom_equal(fcgeo, geom_geojson)
+
+    featureclass_geojson['features'].append(feature_geojson)
+    ffcgeo = geojson.geom_from_geojson(featureclass_geojson)
+    assert_geom_equal(ffcgeo, geom_geojson)
 
 
 def test_geom_from_geojson_no_geometry(feature_geojson):

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 
 import pytest
@@ -21,90 +20,85 @@ from planet import geojson
 LOGGER = logging.getLogger(__name__)
 
 
-def assert_geom_eq(g1, g2):
-    g = json.loads(json.dumps(g1).replace(")", "]").replace("(", "["))
-    assert g == g2
+def test_Geometry__init__success(geom_geojson):
+    geo = geojson.Geometry(geom_geojson)
+    assert geo.type == geom_geojson['type']
 
 
-def test_Geometry__geom_type_success(geom_geojson):
-    gtype = geojson.Geometry._geom_type(geom_geojson)
-    assert gtype == geom_geojson['type']
+def test_Geometry__eq__(geom_geojson):
+    geom_tuple = {
+        "type": "Point",
+        "coordinates": (-103.0078125, 40.713955826286046)
+      }
+    geom_list = {
+        "type": "Point",
+        "coordinates": [-103.0078125, 40.713955826286046]
+      }
+
+    assert geojson.Geometry(geom_tuple) == geojson.Geometry(geom_list)
 
 
-def test_Geometry__geom_type_missing_type(geom_geojson):
+def test_Geometry__init__missing_type(geom_geojson):
     geom_geojson.pop('type')
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry._geom_type(geom_geojson)
+        _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_type_invalid_type(geom_geojson):
+def test_Geometry__init__invalid_type(geom_geojson):
     geom_geojson['type'] = 'invalid'
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry._geom_type(geom_geojson)
+        _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_type_wrong_type(geom_geojson):
+def test_Geometry__init__wrong_type(geom_geojson):
     geom_geojson['type'] = 'point'
     with pytest.raises(geojson.WrongTypeException):
-        _ = geojson.Geometry._geom_type(geom_geojson)
+        _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_type_missing_coordinates(geom_geojson):
+def test_Geometry__init__missing_coordinates(geom_geojson):
     geom_geojson.pop('coordinates')
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry._geom_type(geom_geojson)
+        _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_type_invalid_coordinates(geom_geojson):
+def test_Geometry__init__invalid_coordinates(geom_geojson):
     geom_geojson['coordinates'] = 'invalid'
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry._geom_type(geom_geojson)
+        _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_type_empty_coordinates(geom_geojson):
+def test_Geometry__init__empty_coordinates(geom_geojson):
     geom_geojson['coordinates'] = []
-    _ = geojson.Geometry._geom_type(geom_geojson)
+    _ = geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_from_dict_success(
-        feature_geojson, featureclass_geojson, geom_geojson):
-    geom = geojson.Geometry._geom_from_dict(geom_geojson)
-    assert_geom_eq(geom, geom_geojson)
-
-    f_geom = geojson.Geometry._geom_from_dict(feature_geojson)
-    assert_geom_eq(f_geom, geom_geojson)
-
-    fc_geom = geojson.Geometry._geom_from_dict(featureclass_geojson)
-    assert_geom_eq(fc_geom, geom_geojson)
+def test_Geometry__init__feature(geom_geojson, feature_geojson):
+    assert geojson.Geometry(feature_geojson) == \
+        geojson.Geometry(geom_geojson)
 
 
-def test_Geometry__geom_from_dict_no_geometry(feature_geojson):
+def test_Geometry__init__featureclass(geom_geojson, featureclass_geojson):
+    assert geojson.Geometry(featureclass_geojson) == \
+        geojson.Geometry(geom_geojson)
+
+
+def test_Geometry__init__no_geometry(feature_geojson):
     feature_geojson.pop('geometry')
     with pytest.raises(geojson.GeoJSONException):
-        _ = geojson.Geometry._geom_from_dict(feature_geojson)
-
-
-def test_Geometry__init__(geom_geojson):
-    geo = geojson.Geometry(geom_geojson)
-    assert_geom_eq(geo.to_dict(), geom_geojson)
+        _ = geojson.Geometry(feature_geojson)
 
 
 def test_Polygon__init__(geom_geojson):
-    geo = geojson.Polygon(geom_geojson)
-    assert_geom_eq(geo.to_dict(), geom_geojson)
+    geom = geojson.Geometry(geom_geojson)
+
+    # init from dict
+    assert geojson.Polygon(geom_geojson) == geom
+
+    # init from Geometry
+    assert geojson.Polygon(geom) == geom
 
 
 def test_Polygon_wrong_type(point_geom_geojson):
     with pytest.raises(geojson.WrongTypeException):
         _ = geojson.Polygon(point_geom_geojson)
-
-
-def test_Polygon_from_Geometry(geom_geojson):
-    geo = geojson.Geometry(geom_geojson)
-    _ = geojson.Polygon.from_geometry(geo)
-
-
-def test_Polygon_from_Geometry_wrong_type(point_geom_geojson):
-    geo = geojson.Geometry(point_geom_geojson)
-    with pytest.raises(geojson.WrongTypeException):
-        _ = geojson.Polygon.from_geometry(geo)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -21,7 +21,6 @@ import respx
 import pytest
 
 from planet.api import exceptions, http
-from planet.auth import Auth
 
 
 TEST_URL = 'mock://fantastic.com'
@@ -36,11 +35,6 @@ def mock_request():
         'GET',
         TEST_URL)
     yield r
-
-
-@pytest.fixture
-def auth():
-    return Auth.from_key('mockkey')
 
 
 @pytest.mark.asyncio
@@ -71,16 +65,16 @@ async def test_basesession__raise_for_status():
 
 
 @pytest.mark.asyncio
-async def test_session_contextmanager(auth):
-    async with http.Session(auth=auth):
+async def test_session_contextmanager():
+    async with http.Session():
         pass
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request(auth, mock_request):
+async def test_session_request(mock_request):
 
-    async with http.Session(auth=auth) as ps:
+    async with http.Session() as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -90,8 +84,8 @@ async def test_session_request(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_stream(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_stream(mock_request):
+    async with http.Session() as ps:
         mock_resp = httpx.Response(HTTPStatus.OK, text='bubba')
         respx.get(TEST_URL).return_value = mock_resp
 
@@ -102,8 +96,8 @@ async def test_session_stream(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request_retry(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_request_retry(mock_request):
+    async with http.Session() as ps:
         route = respx.get(TEST_URL)
         route.side_effect = [
             httpx.Response(HTTPStatus.TOO_MANY_REQUESTS),
@@ -118,8 +112,8 @@ async def test_session_request_retry(auth, mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_retry(auth, mock_request):
-    async with http.Session(auth=auth) as ps:
+async def test_session_retry(mock_request):
+    async with http.Session() as ps:
         async def test_func():
             raise exceptions.TooManyRequests
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -37,30 +37,91 @@ def mock_request():
     yield r
 
 
-def test_basesession__raise_for_status():
-    http.BaseSession._raise_for_status(Mock(
-        status_code=HTTPStatus.CREATED, text=''
+@pytest.fixture
+def mock_response():
+    def mocker(code, text='', json={"message": "nope"}):
+        r = Mock()
+        r.status_code = code
+        r.text = text
+        r.json = Mock(return_value=json)
+        return r
+    return mocker
+
+
+def test_basesession__raise_for_status(mock_response):
+    http.BaseSession._raise_for_status(mock_response(
+        HTTPStatus.CREATED,
+        json={}
     ))
 
     with pytest.raises(exceptions.BadQuery):
-        http.BaseSession._raise_for_status(Mock(
-            status_code=HTTPStatus.BAD_REQUEST, text=''
+        http.BaseSession._raise_for_status(mock_response(
+            HTTPStatus.BAD_REQUEST,
+            json={}
         ))
 
     with pytest.raises(exceptions.TooManyRequests):
-        http.BaseSession._raise_for_status(Mock(
-            status_code=HTTPStatus.TOO_MANY_REQUESTS, text=''
+        http.BaseSession._raise_for_status(mock_response(
+            HTTPStatus.TOO_MANY_REQUESTS,
+            text='',
+            json={}
         ))
 
     with pytest.raises(exceptions.OverQuota):
-        http.BaseSession._raise_for_status(Mock(
-            status_code=HTTPStatus.TOO_MANY_REQUESTS, text='exceeded QUOTA'
+        http.BaseSession._raise_for_status(mock_response(
+            HTTPStatus.TOO_MANY_REQUESTS,
+            text='exceeded QUOTA"',
+            json={}
         ))
 
     with pytest.raises(exceptions.APIException):
-        http.BaseSession._raise_for_status(Mock(
-            status_code=HTTPStatus.METHOD_NOT_ALLOWED, text='not sure'
+        http.BaseSession._raise_for_status(mock_response(
+            HTTPStatus.METHOD_NOT_ALLOWED,
+            json={}
         ))
+
+
+def test_basesession__parse_message(mock_response):
+    create_order_bad_id_msg = {
+        "field": {
+            "Details": [
+                {"message": "Item ID 1 / Item Type PSScene3Band doesn't exist"}
+            ]
+        },
+        "general": [
+            {"message": "Unable to accept order"}
+        ]
+    }
+
+    msg = http.BaseSession._parse_message(mock_response(
+            HTTPStatus.BAD_REQUEST,
+            json=create_order_bad_id_msg
+        ))
+    assert msg == (
+        "Unable to accept order - " +
+        "Item ID 1 / Item Type PSScene3Band doesn't exist"
+    )
+
+    oid = 'f8da0a3e-174f-4359-b088-a961ac76f0e7'
+    id_not_found_msg = {
+        "message": f"Could not load order ID: {oid}."
+    }
+    msg = http.BaseSession._parse_message(mock_response(
+            HTTPStatus.NOT_FOUND,
+            json=id_not_found_msg
+        ))
+    assert msg == f"Could not load order ID: {oid}."
+
+    bad_oid = 'f8da0a3e-174f-4359-b088-a961ac76f0e'
+    bad_id_msg = {
+        "code": 601,
+        "message": f"order_id in path must be of type uuid: \"{bad_oid}\""
+    }
+    msg = http.BaseSession._parse_message(mock_response(
+            HTTPStatus.BAD_REQUEST,
+            json=bad_id_msg
+        ))
+    assert msg == f'order_id in path must be of type uuid: "{bad_oid}"'
 
 
 @pytest.mark.asyncio
@@ -95,12 +156,12 @@ async def test_session_stream(mock_request):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_session_request_retry(mock_request):
+async def test_session_request_retry(mock_request, mock_response):
     async with http.Session() as ps:
         route = respx.get(TEST_URL)
         route.side_effect = [
-            httpx.Response(HTTPStatus.TOO_MANY_REQUESTS),
-            httpx.Response(HTTPStatus.OK)
+            httpx.Response(HTTPStatus.TOO_MANY_REQUESTS, json={}),
+            httpx.Response(HTTPStatus.OK, json={})
         ]
 
         ps.retry_wait_time = 0  # lets not slow down tests for this
@@ -132,13 +193,15 @@ async def test_authsession_request(mock_request):
     assert resp.http_response.text == 'bubba'
 
 
-def test_authsession__raise_for_status():
+def test_authsession__raise_for_status(mock_response):
     with pytest.raises(exceptions.APIException):
-        http.AuthSession._raise_for_status(Mock(
-            status_code=HTTPStatus.BAD_REQUEST, text=''
+        http.AuthSession._raise_for_status(mock_response(
+            HTTPStatus.BAD_REQUEST,
+            json={}
             ))
 
     with pytest.raises(exceptions.APIException):
-        http.AuthSession._raise_for_status(Mock(
-            status_code=HTTPStatus.UNAUTHORIZED, text=''
+        http.AuthSession._raise_for_status(mock_response(
+            HTTPStatus.UNAUTHORIZED,
+            json={}
             ))

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -37,8 +37,7 @@ def mock_request():
     yield r
 
 
-@pytest.mark.asyncio
-async def test_basesession__raise_for_status():
+def test_basesession__raise_for_status():
     http.BaseSession._raise_for_status(Mock(
         status_code=HTTPStatus.CREATED, text=''
     ))
@@ -131,3 +130,15 @@ async def test_authsession_request(mock_request):
 
     resp = sess.request(mock_request)
     assert resp.http_response.text == 'bubba'
+
+
+def test_authsession__raise_for_status():
+    with pytest.raises(exceptions.APIException):
+        http.AuthSession._raise_for_status(Mock(
+            status_code=HTTPStatus.BAD_REQUEST, text=''
+            ))
+
+    with pytest.raises(exceptions.APIException):
+        http.AuthSession._raise_for_status(Mock(
+            status_code=HTTPStatus.UNAUTHORIZED, text=''
+            ))

--- a/tests/unit/test_order_details.py
+++ b/tests/unit/test_order_details.py
@@ -217,27 +217,6 @@ def test_Delivery_from_dict(as3_details, abs_details, delivery_details,
         assert isinstance(order_details.Delivery.from_dict(details), cls)
 
 
-def test_Delivery_from_file(tmp_path, delivery_details):
-    detail_file = tmp_path / 'cc.json'
-    with open(detail_file, 'w') as fp:
-        json.dump(delivery_details, fp)
-
-    d = order_details.Delivery.from_file(detail_file)
-    assert isinstance(d, order_details.Delivery)
-    assert d.archive_type == 'zip'
-
-    with pytest.raises(FileNotFoundError):
-        does_not_exist_file = tmp_path / 'doesnotexist.json'
-        order_details.Delivery.from_file(does_not_exist_file)
-
-    wrong_format_file = tmp_path / 'wrongformat.json'
-    with open(wrong_format_file, 'w') as fp:
-        fp.write('blahblah')
-
-    with pytest.raises(json.decoder.JSONDecodeError):
-        order_details.Delivery.from_file(wrong_format_file)
-
-
 def test_Delivery_to_dict(delivery_details):
     d = order_details.Delivery(archive_type='zip',
                                single_archive=True,

--- a/tests/unit/test_order_details.py
+++ b/tests/unit/test_order_details.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
 
 import pytest

--- a/tests/unit/test_order_details.py
+++ b/tests/unit/test_order_details.py
@@ -389,13 +389,11 @@ def test_ClipTool_success_dict(geom_geojson):
 
 
 def test_ClipTool_success_geom(geom_geojson):
-    geo = geojson.Geometry(geom_geojson)
-    ct = order_details.ClipTool(geo)
+    ct = order_details.ClipTool(geom_geojson)
     assert ct.name == 'clip'
     assert ct.parameters['aoi'] == geom_geojson
 
 
 def test_ClipTool_wrong_type(point_geom_geojson):
-    geom = geojson.Geometry(point_geom_geojson)
     with pytest.raises(geojson.WrongTypeException):
-        _ = order_details.ClipTool(geom)
+        _ = order_details.ClipTool(point_geom_geojson)

--- a/tests/unit/test_order_details.py
+++ b/tests/unit/test_order_details.py
@@ -190,30 +190,38 @@ def test_Delivery():
     assert d.archive_type == 'zip'
 
 
-def test_Delivery_from_dict():
-    test_details = {
+@pytest.fixture
+def delivery_details():
+    return {
       'archive_type': 'zip',
       'single_archive': True,
       'archive_filename': TEST_ARCHIVE_FILENAME
       }
 
-    d = order_details.Delivery.from_dict(test_details)
+
+def test_Delivery_from_dict(as3_details, abs_details, delivery_details,
+                            gcs_details, gee_details):
+    d = order_details.Delivery.from_dict(delivery_details)
+    assert isinstance(d, order_details.Delivery)
     assert d.archive_type == 'zip'
     assert d.single_archive
     assert d.archive_filename == TEST_ARCHIVE_FILENAME
 
+    subclass_details = [as3_details, abs_details, gcs_details, gee_details]
+    subclasses = [order_details.AmazonS3Delivery,
+                  order_details.AzureBlobStorageDelivery,
+                  order_details.GoogleCloudStorageDelivery,
+                  order_details.GoogleEarthEngineDelivery]
+    for details, cls in zip(subclass_details, subclasses):
+        assert isinstance(order_details.Delivery.from_dict(details), cls)
 
-def test_Delivery_to_dict():
+
+def test_Delivery_to_dict(delivery_details):
     d = order_details.Delivery(archive_type='zip',
                                single_archive=True,
                                archive_filename=TEST_ARCHIVE_FILENAME)
     details = d.to_dict()
-    expected = {
-      'archive_type': 'zip',
-      'single_archive': True,
-      'archive_filename': TEST_ARCHIVE_FILENAME
-      }
-    assert details == expected
+    assert details == delivery_details
 
     d = order_details.Delivery(archive_type='zip')
     details = d.to_dict()
@@ -223,8 +231,9 @@ def test_Delivery_to_dict():
     assert details == expected
 
 
-def test_AmazonS3Delivery_from_dict():
-    test_details = {
+@pytest.fixture
+def as3_details():
+    return {
         'amazon_s3': {
             'aws_access_key_id': 'aws_access_key_id',
             'aws_secret_access_key': 'aws_secret_access_key',
@@ -232,19 +241,19 @@ def test_AmazonS3Delivery_from_dict():
             'aws_region': 'aws_region'
             },
         'archive_type': 'zip',
-        'single_archive': True,
-        'archive_filename': TEST_ARCHIVE_FILENAME
     }
 
-    d2 = order_details.AmazonS3Delivery.from_dict(test_details)
+
+def test_AmazonS3Delivery_from_dict(as3_details):
+    d2 = order_details.AmazonS3Delivery.from_dict(as3_details)
     assert d2.aws_region == 'aws_region'
 
 
-def test_AmazonS3Delivery_to_dict():
-    aws_access_key_id = 'keyid'
-    aws_secret_access_key = 'accesskey'
+def test_AmazonS3Delivery_to_dict(as3_details):
+    aws_access_key_id = 'aws_access_key_id'
+    aws_secret_access_key = 'aws_secret_access_key'
     bucket = 'bucket'
-    aws_region = 'awsregion'
+    aws_region = 'aws_region'
     archive_type = 'zip'
 
     d = order_details.AmazonS3Delivery(
@@ -254,35 +263,27 @@ def test_AmazonS3Delivery_to_dict():
         aws_region,
         archive_type=archive_type)
     details = d.to_dict()
-    expected = {
-        'amazon_s3': {
-            'aws_access_key_id': aws_access_key_id,
-            'aws_secret_access_key': aws_secret_access_key,
-            'bucket': bucket,
-            'aws_region': aws_region
-        },
-        'archive_type': archive_type
-    }
-    assert details == expected
+    assert details == as3_details
 
 
-def test_AzureBlobStorageDelivery_from_dict():
-    test_details = {
+@pytest.fixture
+def abs_details():
+    return {
         'azure_blob_storage': {
             'account': 'account',
             'container': 'container',
             'sas_token': 'sas_token',
             },
         'archive_type': 'zip',
-        'single_archive': True,
-        'archive_filename': TEST_ARCHIVE_FILENAME
     }
 
-    d2 = order_details.AzureBlobStorageDelivery.from_dict(test_details)
+
+def test_AzureBlobStorageDelivery_from_dict(abs_details):
+    d2 = order_details.AzureBlobStorageDelivery.from_dict(abs_details)
     assert d2.sas_token == 'sas_token'
 
 
-def test_AzureBlobStorageDelivery_to_dict():
+def test_AzureBlobStorageDelivery_to_dict(abs_details):
     account = 'account'
     container = 'container'
     sas_token = 'sas_token'
@@ -294,33 +295,26 @@ def test_AzureBlobStorageDelivery_to_dict():
         sas_token,
         archive_type=archive_type)
     details = d.to_dict()
-    expected = {
-        'azure_blob_storage': {
-            'account': account,
-            'container': container,
-            'sas_token': sas_token,
-        },
-        'archive_type': archive_type
-    }
-    assert details == expected
+    assert details == abs_details
 
 
-def test_GoogleCloudStorageDelivery_from_dict():
-    test_details = {
+@pytest.fixture
+def gcs_details():
+    return {
         'google_cloud_storage': {
             'bucket': 'bucket',
             'credentials': 'credentials',
             },
         'archive_type': 'zip',
-        'single_archive': True,
-        'archive_filename': TEST_ARCHIVE_FILENAME
     }
 
-    d2 = order_details.GoogleCloudStorageDelivery.from_dict(test_details)
+
+def test_GoogleCloudStorageDelivery_from_dict(gcs_details):
+    d2 = order_details.GoogleCloudStorageDelivery.from_dict(gcs_details)
     assert d2.credentials == 'credentials'
 
 
-def test_GoogleCloudStorageDelivery_to_dict():
+def test_GoogleCloudStorageDelivery_to_dict(gcs_details):
     bucket = 'bucket'
     credentials = 'credentials'
     archive_type = 'zip'
@@ -330,32 +324,26 @@ def test_GoogleCloudStorageDelivery_to_dict():
         credentials,
         archive_type=archive_type)
     details = d.to_dict()
-    expected = {
-        'google_cloud_storage': {
-            'bucket': bucket,
-            'credentials': credentials,
-        },
-        'archive_type': archive_type
-    }
-    assert details == expected
+    assert details == gcs_details
 
 
-def test_GoogleEarthEngineDelivery_from_dict():
-    test_details = {
+@pytest.fixture
+def gee_details():
+    return {
         'google_earth_engine': {
             'project': 'project',
             'collection': 'collection',
             },
         'archive_type': 'zip',
-        'single_archive': True,
-        'archive_filename': TEST_ARCHIVE_FILENAME
     }
 
-    d2 = order_details.GoogleEarthEngineDelivery.from_dict(test_details)
+
+def test_GoogleEarthEngineDelivery_from_dict(gee_details):
+    d2 = order_details.GoogleEarthEngineDelivery.from_dict(gee_details)
     assert d2.collection == 'collection'
 
 
-def test_GoogleEarthEngineDelivery_to_dict():
+def test_GoogleEarthEngineDelivery_to_dict(gee_details):
     project = 'project'
     collection = 'collection'
     archive_type = 'zip'
@@ -365,14 +353,7 @@ def test_GoogleEarthEngineDelivery_to_dict():
         collection,
         archive_type=archive_type)
     details = d.to_dict()
-    expected = {
-        'google_earth_engine': {
-            'project': project,
-            'collection': collection,
-        },
-        'archive_type': archive_type
-    }
-    assert details == expected
+    assert details == gee_details
 
 
 def test_Tool():


### PR DESCRIPTION
This PR adds a CLI as a thin wrapper around the python api orders client. Functionality was added to the orders client and other modules to support back-compatible CLI functionality while keeping the CLI thin.

One addition to the API is implemented:
Simple management of geojson, via the new `planet/geojson.py` module

Two changes to the python API are implemented:
1. `OrdersClient.create_order()` now returns the entire order description (as returned by the API) instead of just the id.
       This aligns with the rule of "make the client as similar to the REST API as possible" and allows the cli to easily report the details as a json blob that can be processed or viewed via the command line.
2. `Delivery.from_dict()` tries to create a subclass if possible.
        For example, if the dict describes an `AmazonS3Delivery`, it makes an instance of that class. This is necessary because a `Delivery` only holds the minimum delivery information while a subclass holds more information about the specific cloud. This change allows the cli to just call `Delivery.from_dict()` while parsing a file and have the proper information passed into `OrdersClient.create_order()`.

Other than that, the API changes are improved error handling.

Wish list: The cli.py module got huge quick. I would like to break it up into different modules based on api (e.g. `auth` and `orders`). Ticket #288 

Closes #244 
Closes #252 