### PR TITLE
V2 api error parsing

### DIFF
--- a/planet/auth.py
+++ b/planet/auth.py
@@ -23,13 +23,12 @@ import jwt
 
 from . import constants, http, models
 
-AUTH_URL = constants.PLANET_BASE_URL + 'v0/auth/'
-
-ENV_API_KEY = 'PL_API_KEY'
-
-SECRET_FILE_PATH = os.path.join(os.path.expanduser('~'), '.planet.json')
 
 LOGGER = logging.getLogger(__name__)
+
+BASE_URL = constants.PLANET_BASE_URL
+ENV_API_KEY = 'PL_API_KEY'
+SECRET_FILE_PATH = os.path.join(os.path.expanduser('~'), '.planet.json')
 
 
 class AuthException(Exception):
@@ -162,9 +161,11 @@ class AuthClient():
         Parameters:
             base_url: Alternate authentication api base URL.
         """
-        self._base_url = base_url or AUTH_URL
+        self._base_url = base_url or BASE_URL
         if not self._base_url.endswith('/'):
             self._base_url += '/'
+
+        self._auth_url = self._base_url + 'v0/auth/'
 
     def login(
         self,
@@ -184,7 +185,7 @@ class AuthClient():
              A JSON object containing an `api_key` property with the user's
         API_KEY.
         '''
-        url = self._base_url + 'login'
+        url = self._auth_url + 'login'
         data = {'email': email,
                 'password': password
                 }

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -247,7 +247,7 @@ class OrdersClient():
             Results of the bulk cancel request
 
         Raises:
-            planet.api.exceptions.APIException: On API error.
+            planet.exceptions.APIException: On API error.
         '''
         url = self._bulk_url() + 'cancel'
         cancel_body = {}
@@ -267,7 +267,7 @@ class OrdersClient():
             Aggregated order counts
 
         Raises:
-            planet.api.exceptions.APIException: On API error.
+            planet.exceptions.APIException: On API error.
         '''
         url = self._stats_url()
         req = self._request(url, method='GET')
@@ -295,7 +295,7 @@ class OrdersClient():
             Path to downloaded file.
 
         Raises:
-            planet.api.exceptions.APIException: On API error.
+            planet.exceptions.APIException: On API error.
         """
         req = self._request(location, method='GET')
 
@@ -326,7 +326,7 @@ class OrdersClient():
             Paths to downloaded files.
 
         Raises:
-            planet.api.exceptions.APIException: On API error.
+            planet.exceptions.APIException: On API error.
         """
         order = await self.get_order(order_id)
         locations = order.locations
@@ -408,7 +408,7 @@ class OrdersClient():
             User orders that match the query
 
         Raises:
-            planet.api.exceptions.APIException: On API error.
+            planet.exceptions.APIException: On API error.
         """
         url = self._orders_url()
         if state:

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -18,6 +18,7 @@ import logging
 import os
 import time
 import typing
+import uuid
 
 from .. import constants
 from ..http import Session
@@ -80,8 +81,14 @@ class OrdersClient():
 
     @staticmethod
     def _check_order_id(oid):
-        if not oid or not isinstance(oid, str):
-            raise OrdersClientException(f'Order id ({oid}) is invalid.')
+        msg = f'Order id ({oid}) must be a valid UUID string.'
+        if not isinstance(oid, str):
+            raise OrdersClientException(msg)
+
+        try:
+            uuid.UUID(oid)
+        except ValueError:
+            raise OrdersClientException(msg)
 
     def _orders_url(self):
         return self._base_url + ORDERS_PATH
@@ -90,7 +97,7 @@ class OrdersClient():
         return self._base_url + STATS_PATH
 
     def _order_url(self, order_id):
-        self._check_order_id
+        self._check_order_id(order_id)
         return self._orders_url() + order_id
 
     def _bulk_url(self):

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -15,7 +15,9 @@
 
 class APIException(Exception):
     '''General unexpected response'''
-    pass
+    @property
+    def message(self):
+        return self.args[0]
 
 
 class BadQuery(APIException):
@@ -35,6 +37,11 @@ class NoPermission(APIException):
 
 class MissingResource(APIException):
     '''Request for non existing resource, HTTP 404'''
+    pass
+
+
+class Conflict(APIException):
+    '''Request conflict with current state of the target resource, HTTP 409'''
     pass
 
 

--- a/planet/geojson.py
+++ b/planet/geojson.py
@@ -30,8 +30,9 @@ class WrongTypeException(GeoJSONException):
     pass
 
 
-class DataLossWarning(UserWarning):
-    """Warn that data will be lost."""
+class MultipleFeaturesException(GeoJSONException):
+    '''multiple features when only one is acceptable'''
+    pass
 
 
 def as_geom(data: dict) -> dict:
@@ -80,7 +81,7 @@ def geom_from_geojson(data: dict) -> dict:
     else:
         try:
             # feature
-            ret = as_geom(data["geometry"])
+            ret = as_geom(data['geometry'])
         except KeyError:
             try:
                 # featureclass
@@ -89,9 +90,9 @@ def geom_from_geojson(data: dict) -> dict:
                 raise GeoJSONException('Invalid GeoJSON: {data}')
 
             if len(features) > 1:
-                LOGGER.warning(
-                    'FeatureClass has more than one Feature, using only first'
-                    ' feature.')
+                raise MultipleFeaturesException(
+                    'FeatureClass has multiple features. Only one feature '
+                    'can be used to get geometry.')
 
             ret = as_geom(features[0])
     return ret

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+from http import HTTPStatus
+import logging
+
+import httpx
+import jwt
+import pytest
+import respx
+
+from planet import exceptions
+from planet.auth import AuthClient
+
+
+TEST_URL = 'http://MockNotRealURL/'
+AUTH_URL = TEST_URL + 'v0/auth/'
+
+LOGGER = logging.getLogger(__name__)
+
+
+@respx.mock
+def test_AuthClient_success():
+    login_url = AUTH_URL + 'login'
+
+    payload = {'api_key': 'iamakey'}
+    resp = {'token': jwt.encode(payload, 'key')}
+    mock_resp = httpx.Response(HTTPStatus.OK, json=resp)
+    respx.post(login_url).return_value = mock_resp
+
+    cl = AuthClient(base_url=TEST_URL)
+    auth_data = cl.login('email', 'password')
+
+    assert auth_data == payload
+
+
+@respx.mock
+def test_AuthClient_invalid_email():
+    login_url = AUTH_URL + 'login'
+
+    resp = {
+        "errors": {
+            "email": [
+                "Not a valid email address."
+            ]
+        },
+        "message": "error validating request against UserAuthenticationSchema",
+        "status": 400,
+        "success": False
+    }
+    mock_resp = httpx.Response(400, json=resp)
+    respx.post(login_url).return_value = mock_resp
+
+    cl = AuthClient(base_url=TEST_URL)
+    with pytest.raises(exceptions.APIException,
+                       match='Not a valid email address.'):
+        _ = cl.login('email', 'password')
+
+
+@respx.mock
+def test_AuthClient_invalid_password():
+    login_url = AUTH_URL + 'login'
+
+    resp = {
+        "errors": None,
+        "message": "Invalid email or password",
+        "status": 401,
+        "success": False
+    }
+    mock_resp = httpx.Response(401, json=resp)
+    respx.post(login_url).return_value = mock_resp
+
+    cl = AuthClient(base_url=TEST_URL)
+    with pytest.raises(exceptions.APIException,
+                       match='Incorrect email or password.'):
+        _ = cl.login('email', 'password')

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -40,14 +40,6 @@ async def session():
 
 
 @pytest.fixture
-@pytest.mark.asyncio
-async def client():
-    async with Session() as ps:
-        cl = OrdersClient(session, base_url=TEST_URL)
-        yield cl
-
-
-@pytest.fixture
 def order_descriptions(order_description):
     order1 = order_description
     order1['id'] = 'oid1'
@@ -461,15 +453,17 @@ async def test_poll(oid, order_description, session):
 
 
 @pytest.mark.asyncio
-async def test_poll_invalid_oid(client):
+async def test_poll_invalid_oid(session):
+    cl = OrdersClient(session, base_url=TEST_URL)
     with pytest.raises(clients.orders.OrdersClientException):
-        _ = await client.poll("invalid_oid", wait=0)
+        _ = await cl.poll("invalid_oid", wait=0)
 
 
 @pytest.mark.asyncio
-async def test_poll_invalid_state(oid, client):
+async def test_poll_invalid_state(oid, session):
+    cl = OrdersClient(session, base_url=TEST_URL)
     with pytest.raises(clients.orders.OrdersClientException):
-        _ = await client.poll(oid, state="invalid_state", wait=0)
+        _ = await cl.poll(oid, state="invalid_state", wait=0)
 
 
 @respx.mock

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -45,10 +45,6 @@ def test_geom_from_geojson_success(
     fcgeo = geojson.geom_from_geojson(featureclass_geojson)
     assert_geom_equal(fcgeo, geom_geojson)
 
-    featureclass_geojson['features'].append(feature_geojson)
-    ffcgeo = geojson.geom_from_geojson(featureclass_geojson)
-    assert_geom_equal(ffcgeo, geom_geojson)
-
 
 def test_geom_from_geojson_no_geometry(feature_geojson):
     feature_geojson.pop('geometry')
@@ -66,6 +62,13 @@ def test_geom_from_geojson_missing_type(geom_geojson):
     geom_geojson.pop('type')
     with pytest.raises(geojson.GeoJSONException):
         _ = geojson.geom_from_geojson(geom_geojson)
+
+
+def test_geom_from_geojson_multiple_features(featureclass_geojson):
+    # duplicate the feature
+    featureclass_geojson['features'] = 2 * featureclass_geojson['features']
+    with pytest.raises(geojson.MultipleFeaturesException):
+        _ = geojson.geom_from_geojson(featureclass_geojson)
 
 
 def test_validate_geom_invalid_type(geom_geojson):

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -81,49 +81,6 @@ def test_basesession__raise_for_status(mock_response):
         ))
 
 
-def test_basesession__parse_message(mock_response):
-    create_order_bad_id_msg = {
-        "field": {
-            "Details": [
-                {"message": "Item ID 1 / Item Type PSScene3Band doesn't exist"}
-            ]
-        },
-        "general": [
-            {"message": "Unable to accept order"}
-        ]
-    }
-
-    msg = http.BaseSession._parse_message(mock_response(
-            HTTPStatus.BAD_REQUEST,
-            json=create_order_bad_id_msg
-        ))
-    assert msg == (
-        "Unable to accept order - " +
-        "Item ID 1 / Item Type PSScene3Band doesn't exist"
-    )
-
-    oid = 'f8da0a3e-174f-4359-b088-a961ac76f0e7'
-    id_not_found_msg = {
-        "message": f"Could not load order ID: {oid}."
-    }
-    msg = http.BaseSession._parse_message(mock_response(
-            HTTPStatus.NOT_FOUND,
-            json=id_not_found_msg
-        ))
-    assert msg == f"Could not load order ID: {oid}."
-
-    bad_oid = 'f8da0a3e-174f-4359-b088-a961ac76f0e'
-    bad_id_msg = {
-        "code": 601,
-        "message": f"order_id in path must be of type uuid: \"{bad_oid}\""
-    }
-    msg = http.BaseSession._parse_message(mock_response(
-            HTTPStatus.BAD_REQUEST,
-            json=bad_id_msg
-        ))
-    assert msg == f'order_id in path must be of type uuid: "{bad_oid}"'
-
-
 @pytest.mark.asyncio
 async def test_session_contextmanager():
     async with http.Session():


### PR DESCRIPTION
Move API error parsing into API client to account for different error formats between APIs.

Part of  #289 