### PR TITLE
Planet orders download default to not overwrite files

### DIFF
--- a/examples/orders_create_and_download_multiple_orders.py
+++ b/examples/orders_create_and_download_multiple_orders.py
@@ -82,9 +82,9 @@ async def create_and_download(order_detail, directory, client):
 
     # download
     print(f'Downloading {oid} to {directory}.')
-    filenames, NUM_DOWNLOADS, NUM_DOWNLOADS_SKIPPED = await client.download_order(oid, directory, progress_bar=True)
-    print(f'Downloaded {oid}: '
-          f'{NUM_DOWNLOADS} files downloaded to {directory}. {NUM_DOWNLOADS_SKIPPED} skipped downloads (not overwritten).')
+    filenames = await client.download_order(oid, directory, progress_bar=True)
+    for i in range(len(filenames)):
+        print(filenames[i])
 
 
 async def main():

--- a/examples/orders_create_and_download_multiple_orders.py
+++ b/examples/orders_create_and_download_multiple_orders.py
@@ -82,9 +82,9 @@ async def create_and_download(order_detail, directory, client):
 
     # download
     print(f'Downloading {oid} to {directory}.')
-    filenames = await client.download_order(oid, directory, progress_bar=True)
+    filenames, NUM_DOWNLOADS, NUM_DOWNLOADS_SKIPPED = await client.download_order(oid, directory, progress_bar=True)
     print(f'Downloaded {oid}: '
-          f'{len(filenames)} files downloaded to {directory}.')
+          f'{NUM_DOWNLOADS} files downloaded to {directory}. {NUM_DOWNLOADS_SKIPPED} skipped downloads (not overwritten).')
 
 
 async def main():

--- a/examples/orders_create_and_download_multiple_orders.py
+++ b/examples/orders_create_and_download_multiple_orders.py
@@ -83,8 +83,8 @@ async def create_and_download(order_detail, directory, client):
     # download
     print(f'Downloading {oid} to {directory}.')
     filenames = await client.download_order(oid, directory, progress_bar=True)
-    for i in range(len(filenames)):
-        print(filenames[i])
+    for f in filenames:
+        print(f)
 
 
 async def main():

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -297,12 +297,11 @@ class OrdersClient():
         Raises:
             planet.exceptions.APIException: On API error.
         """
-
         req = self._request(location, method='GET')
 
         async with self._session.stream(req) as resp:
             body = StreamingBody(resp)
-            dl_path = os.path.join(directory, filename or body.name)
+            dl_path = os.path.join(directory or '.', filename or body.name)
             await body.write(dl_path,
                              overwrite=overwrite,
                              progress_bar=progress_bar)
@@ -335,9 +334,6 @@ class OrdersClient():
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}'
         )
-
-        # If a directory wasn't provided, choose current working directory
-        directory = directory or '.'
 
         filenames = [await self.download_asset(location,
                                                directory=directory,

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -305,7 +305,6 @@ class OrdersClient():
             await body.write(dl_path,
                              overwrite=overwrite,
                              progress_bar=progress_bar)
-
         return dl_path
 
     async def download_order(
@@ -334,13 +333,11 @@ class OrdersClient():
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}'
         )
-
         filenames = [await self.download_asset(location,
                                                directory=directory,
                                                overwrite=overwrite,
                                                progress_bar=progress_bar)
                      for location in locations]
-
         return filenames
 
     async def poll(

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -292,7 +292,7 @@ class OrdersClient():
             progress_bar: Show progress bar during download.
 
         Returns:
-            All files in an order.
+            Path to downloaded file.
 
         Raises:
             planet.exceptions.APIException: On API error.
@@ -314,7 +314,7 @@ class OrdersClient():
         order_id: str,
         directory: str = None,
         overwrite: bool = False,
-        progress_bar: bool = False,
+        progress_bar: bool = False
     ) -> typing.List[str]:
         """Download all assets in an order.
 
@@ -326,8 +326,6 @@ class OrdersClient():
 
         Returns:
             Paths to downloaded files.
-            Number of downloaded files.
-            Number of skipped downloads.
 
         Raises:
             planet.exceptions.APIException: On API error.

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -30,6 +30,7 @@ STATS_PATH = 'stats/orders/v2/'
 ORDERS_PATH = 'orders/v2/'
 BULK_PATH = 'bulk/orders/v2/'
 
+# Order states: https://developers.planet.com/docs/orders/ordering/#order-states
 ORDERS_STATES_COMPLETE = ['success', 'partial', 'cancelled', 'failed']
 ORDERS_STATES_IN_PROGRESS = ['queued', 'running']
 ORDERS_STATES = ORDERS_STATES_IN_PROGRESS + ORDERS_STATES_COMPLETE
@@ -278,7 +279,7 @@ class OrdersClient():
         location: str,
         filename: str = None,
         directory: str = None,
-        overwrite: bool = True,
+        overwrite: bool = False,
         progress_bar: bool = True
     ) -> str:
         """Download ordered asset.
@@ -301,16 +302,25 @@ class OrdersClient():
         async with self._session.stream(req) as resp:
             body = StreamingBody(resp)
             dl_path = os.path.join(directory or '.', filename or body.name)
-            await body.write(dl_path,
-                             overwrite=overwrite,
-                             progress_bar=progress_bar)
+            is_dl_path = os.path.isfile(dl_path)
+            # File doesn't exist or overwrite requested OR file doesn't exist and do not overwrite
+            if (overwrite or not is_dl_path) or (not overwrite and not is_dl_path):
+                await body.write(dl_path,
+                                overwrite=overwrite,
+                                progress_bar=progress_bar)
+            # File exists and do not overwrite it
+            else:
+                # Log something -> didn't download image vecause already existed
+                # Maybe even write something on the terminal?
+                pass
+            
         return dl_path
 
     async def download_order(
         self,
         order_id: str,
         directory: str = None,
-        overwrite: bool = True,
+        overwrite: bool = False,
         progress_bar: bool = False
     ) -> typing.List[str]:
         """Download all assets in an order.

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -314,8 +314,8 @@ class OrdersClient():
         order_id: str,
         directory: str = None,
         overwrite: bool = False,
-        progress_bar: bool = False
-    ) -> list[str]:
+        progress_bar: bool = False,
+    ) -> typing.List[str]:
         """Download all assets in an order.
 
         Parameters:
@@ -337,8 +337,9 @@ class OrdersClient():
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}'
         )
-
-        directory = self._set_path(order_id=order_id, directory=directory)
+        
+        # If a directory wasn't provided, choose current working directory
+        directory = directory or '.'
 
         filenames = [await self.download_asset(location,
                                                directory=directory,
@@ -439,35 +440,6 @@ class OrdersClient():
         return Orders(request, self._do_request, limit=limit)
 
     @staticmethod
-
-    def _set_path(
-        order_id: str,
-        directory: str
-    ) -> str:
-        """Ensures that the user downloads their data to a directory named by the Order ID.
-           This is consistent with our order delivery layout https://developers.planet.com/docs/orders/delivery/ 
-
-            Parameters:
-                order_id: The ID of the order
-                directory: Directory to ensure exists.
-
-            Returns:
-                Directory to downloaded files.
-
-            Raises:
-                planet.api.exceptions.APIException: On API error.
-        """
-
-        # If a directory wasn't provided, choose current working directory
-        directory = directory or '.'
-
-        if directory.split("/")[-1] != order_id:
-            directory = os.path.join(directory, order_id)
-        
-        if not os.path.isdir(directory):
-            os.mkdir(directory)
-
-        return directory
 
     def _check_state(state):
         if state not in ORDERS_STATES:

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -30,7 +30,7 @@ STATS_PATH = 'stats/orders/v2/'
 ORDERS_PATH = 'orders/v2/'
 BULK_PATH = 'bulk/orders/v2/'
 
-# Order states: https://developers.planet.com/docs/orders/ordering/#order-states
+# Order states https://developers.planet.com/docs/orders/ordering/#order-states
 ORDERS_STATES_COMPLETE = ['success', 'partial', 'cancelled', 'failed']
 ORDERS_STATES_IN_PROGRESS = ['queued', 'running']
 ORDERS_STATES = ORDERS_STATES_IN_PROGRESS + ORDERS_STATES_COMPLETE
@@ -75,7 +75,7 @@ class OrdersClient():
                 base url.
         """
         self._session = session
-        
+
         self._base_url = base_url or BASE_URL
         if not self._base_url.endswith('/'):
             self._base_url += '/'
@@ -304,9 +304,9 @@ class OrdersClient():
             body = StreamingBody(resp)
             dl_path = os.path.join(directory, filename or body.name)
             await body.write(dl_path,
-                            overwrite=overwrite,
-                            progress_bar=progress_bar)
-            
+                             overwrite=overwrite,
+                             progress_bar=progress_bar)
+
         return dl_path
 
     async def download_order(
@@ -337,7 +337,7 @@ class OrdersClient():
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}'
         )
-        
+
         # If a directory wasn't provided, choose current working directory
         directory = directory or '.'
 
@@ -346,7 +346,7 @@ class OrdersClient():
                                                overwrite=overwrite,
                                                progress_bar=progress_bar)
                      for location in locations]
-        
+
         return filenames
 
     async def poll(
@@ -440,7 +440,6 @@ class OrdersClient():
         return Orders(request, self._do_request, limit=limit)
 
     @staticmethod
-
     def _check_state(state):
         if state not in ORDERS_STATES:
             raise OrdersClientException(

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -17,7 +17,6 @@ from functools import wraps
 import json
 import logging
 import sys
-import os
 
 import click
 

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -219,8 +219,8 @@ async def download(ctx, order_id, quiet, overwrite, dest):
                 progress_bar=not quiet)
 
     # Tell user all files that exist in order
-    for i in range(len(filenames)):
-        click.echo(filenames[i])
+    for f in filenames:
+        click.echo(f)
 
 
 def split_id_list(ctx, param, value):

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -206,14 +206,13 @@ async def cancel(ctx, order_id):
               help=('Directory to download files to.'),
               type=click.Path(exists=True, resolve_path=True,
                               writable=True, file_okay=False))
-                              
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
 
-    # Download the user's order            
+    # Download the user's order
     async with orders_client(ctx) as cl:
         await cl.poll(str(order_id), verbose=True)
-        filenames= await cl.download_order(
+        filenames = await cl.download_order(
                 str(order_id),
                 directory=dest,
                 overwrite=overwrite,
@@ -222,6 +221,7 @@ async def download(ctx, order_id, quiet, overwrite, dest):
     # Tell user all files that exist in order
     for i in range(len(filenames)):
         click.echo(filenames[i])
+
 
 def split_id_list(ctx, param, value):
     # split list by ',' and remove whitespace

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -207,22 +207,43 @@ async def cancel(ctx, order_id):
               help=('Directory to download files to.'),
               type=click.Path(exists=True, resolve_path=True,
                               writable=True, file_okay=False))
+                              
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
-    async with orders_client(ctx) as cl:
-        await cl.poll(str(order_id), verbose=True)
-        filenames = await cl.download_order(
-                str(order_id),
-                directory=dest,
-                overwrite=overwrite,
-                progress_bar=not quiet)
-    
-    # If all files for order aready exist, do not download.
-    if all([os.path.isfile(file) for file in filenames]):
-        click.echo(f'Files for the order already exist in the designated directory, {dest}, and download skipped. '
-                   'Please include the overwrite flag, "-o" or "--overwrite", to overwrite files for the order.')
-    else:
-        click.echo(f'Downloaded {len(filenames)} files.')
+
+    if overwrite:
+        # Explicity ask the user if they want to overwrite their data
+        overwrite_decision = click.prompt(f'You have selected to overwrite your data. Proceed? [y/n]', type=str).lower()
+        if (overwrite_decision != 'y') and (overwrite_decision != 'n'):
+            raise click.ClickException('Select either [y] (yes) or [n] (no).')
+
+    # Download the user's order            
+    if (overwrite and overwrite_decision == 'y') or (not overwrite):
+        async with orders_client(ctx) as cl:
+            await cl.poll(str(order_id), verbose=True)
+            filenames, NUM_DOWNLOADS, NUM_DOWNLOADS_SKIPPED = await cl.download_order(
+                    str(order_id),
+                    directory=dest,
+                    overwrite=overwrite,
+                    progress_bar=not quiet)
+    # Do not download the user's order
+    elif overwrite_decision == 'n':
+        filenames = 0
+        NUM_DOWNLOADS = 0
+        NUM_DOWNLOADS_SKIPPED = 0
+        pass
+
+    # Tell the user how much data and what data was downloaded
+    click.echo(f'Downloaded {NUM_DOWNLOADS} files.')
+    for i in range(NUM_DOWNLOADS):
+        click.echo(f'Downloaded: {filenames[i]}')
+    if NUM_DOWNLOADS_SKIPPED > 0:
+        click.echo(f'Skipped {NUM_DOWNLOADS_SKIPPED} files.')
+        for i in range(NUM_DOWNLOADS_SKIPPED):
+            click.echo(f'Skipped: {filenames[i]}')
+        click.echo(f'These files already exist. '
+                    'Please include the overwrite flag, "-o" or "--overwrite", to overwrite files for the order. '
+                    'For example: planet orders download --overwrite my-order-id')
 
 def split_id_list(ctx, param, value):
     # split list by ',' and remove whitespace

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -17,6 +17,7 @@ from functools import wraps
 import json
 import logging
 import sys
+import os
 
 import click
 
@@ -200,7 +201,7 @@ async def cancel(ctx, order_id):
 @click.argument('order_id', type=click.UUID)
 @click.option('-q', '--quiet', is_flag=True, default=False,
               help=('Disable ANSI control output.'))
-@click.option('-o', '--overwrite', is_flag=True, default=True,
+@click.option('-o', '--overwrite', is_flag=True, default=False,
               help=('Overwrite files if they already exist.'))
 @click.option('--dest', default='.',
               help=('Directory to download files to.'),
@@ -215,8 +216,13 @@ async def download(ctx, order_id, quiet, overwrite, dest):
                 directory=dest,
                 overwrite=overwrite,
                 progress_bar=not quiet)
-    click.echo(f'Downloaded {len(filenames)} files.')
-
+    
+    # If all files for order aready exist, do not download.
+    if all([os.path.isfile(file) for file in filenames]):
+        click.echo(f'Files for the order already exist in the designated directory, {dest}, and download skipped. '
+                   'Please include the overwrite flag, "-o" or "--overwrite", to overwrite files for the order.')
+    else:
+        click.echo(f'Downloaded {len(filenames)} files.')
 
 def split_id_list(ctx, param, value):
     # split list by ',' and remove whitespace

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -617,12 +617,10 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
         })
     respx.get(dl_url2).return_value = mock_resp2
 
-    # Create Orders client
     cl = OrdersClient(session, base_url=TEST_URL)
-    # Download order and return the filenames of the downloaded files
     filenames = await cl.download_order(oid, directory=str(tmpdir))
 
-    # Check there are as many files as expected
+    # Check there are as many files as expected, given in order_description
     assert len(filenames) == 2
 
     # Check that the downloaded files have the correct filename and contents
@@ -642,15 +640,12 @@ async def test_download_order_overwrite_true_preexisting_data(
     overwrite flag set to True.
     '''
 
-    # Save JSON to out_file in tmpdir
+    # Save JSON to a temporary file
     with open(Path(tmpdir, 'file.json'), "a") as out_file:
         json.dump(original_content, out_file)
 
-    # Create mock response for downloading
     create_download_mock()
-    # Create Orders client
     cl = OrdersClient(session, base_url=TEST_URL)
-    # Download order and overwrite data
     _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
 
     # Check that the data downloaded has overwritten the original data
@@ -666,15 +661,12 @@ async def test_download_order_overwrite_false_preexisting_data(
     data with overwrite flag set to False.
     '''
 
-    # Save JSON to out_file in tmpdir
+    # Save JSON to a temporary file
     with open(Path(tmpdir, 'file.json'), "a") as out_file:
         json.dump(original_content, out_file)
 
-    # Create mock response for downloading
     create_download_mock()
-    # Create Orders client
     cl = OrdersClient(session, base_url=TEST_URL)
-    # Download order and overwrite data
     _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
 
     # Check that the original data has not been overwritten
@@ -690,14 +682,11 @@ async def test_download_order_overwrite_true_nonexisting_data(
     set to true without pre-existing data.
     '''
 
-    # Save JSON to out_file in tmpdir
     create_download_mock()
-    # Create Orders client
     cl = OrdersClient(session, base_url=TEST_URL)
-    # Download order and overwrite data
     _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
 
-    # Check that the data downloaded has the correct contents
+    # Check that the was data downloaded and has the correct contents
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content
 
 
@@ -710,12 +699,9 @@ async def test_download_order_overwrite_false_nonexisting_data(
     set to false without pre-existing data.
     '''
 
-    # Save JSON to out_file in tmpdir
     create_download_mock()
-    # Create Orders client
     cl = OrdersClient(session, base_url=TEST_URL)
-    # Download order and overwrite data
     _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
 
-    # Check that the data downloaded has the correct contents
+    # Check that the was data downloaded and has the correct contents
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -150,11 +150,9 @@ def test_cli_orders_download(runner, monkeypatch, oid):
 
     # Check the output is as expected (list all files downloaded line-by-line)
     # Add a new line character (\n) for each test filename
-    all_test_files_newline = [s + '\n' for s in all_test_files]
-    # Add all strings together (remove all commas in the list)
-    all_test_files_newline_squashed = ''.join(all_test_files_newline)
+    all_test_files_newline = '\n'.join(all_test_files) + '\n'
     # Expect output to look like 'file1\nfile2\n...fileN\n'
-    assert all_test_files_newline_squashed == result.output
+    assert all_test_files_newline == result.output
 
 
 class AsyncMock(Mock):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -147,7 +147,7 @@ def test_cli_orders_download(runner, monkeypatch, oid):
     result = runner.invoke(
         cli, ['orders', 'download', oid])
     assert not result.exception
-    
+
     # Check the output is as expected (list all files downloaded line-by-line)
     # Add a new line character (\n) for each test filename
     all_test_files_newline = [s + '\n' for s in all_test_files]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -134,8 +134,10 @@ def test_cli_orders_cancel(runner, monkeypatch, order_description, oid):
 
 
 def test_cli_orders_download(runner, monkeypatch, oid):
+    all_test_files = ['file1.json', 'file2.zip', 'file3.tiff', 'file4.jpg']
+
     async def do(*arg, **kwarg):
-        return ['file1']
+        return all_test_files
     monkeypatch.setattr(planet.scripts.cli.OrdersClient, 'download_order', do)
 
     async def poll(*arg, **kwarg):
@@ -145,8 +147,14 @@ def test_cli_orders_download(runner, monkeypatch, oid):
     result = runner.invoke(
         cli, ['orders', 'download', oid])
     assert not result.exception
-    # assert "file1" in result.output
-    assert 'Downloaded 1 files.\n' == result.output
+    
+    # Check the output is as expected (list all files downloaded line-by-line)
+    # Add a new line character (\n) for each test filename
+    all_test_files_newline = [s + '\n' for s in all_test_files]
+    # Add all strings together (remove all commas in the list)
+    all_test_files_newline_squashed = ''.join(all_test_files_newline)
+    # Expect output to look like 'file1\nfile2\n...fileN\n'
+    assert all_test_files_newline_squashed == result.output
 
 
 class AsyncMock(Mock):


### PR DESCRIPTION
- Added option on whether or not to overwrite data in CLI
- Added overwriting logic in orders module
- Made the files download under a directory named after the order ID, consistent with our docs (https://developers.planet.com/docs/orders/delivery/)
- Updated downloading info echoed back to the user
- Updated an example to work with updated orders module