### PR TITLE
Bug fix: httpx / httpcore exception resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('planet/__version__.py') as f:
 
 install_requires = [
     'click>=8.0.0',
-    'httpx==0.16.1',
+    'httpx==0.18.2',
     'shapely>=1.7.1',
     'pyjwt>=2.1',
     'tqdm>=4.56',


### PR DESCRIPTION
- For some reason, `httpx==0.16.1` was letting an `httpcore` exception bubble up every so often
- Upgrading `httpx` from version `0.16.1` to `0.18.2` seems to have resolved the bug found in `httpx==0.16.1`
- `httpx==0.19` (latest version) is still incompatible, as it breaks and returns the following error message:`httpx.ResponseNotRead: Attempted to access streaming response content, without having called 'read()'.`
- To upgrade to the latest version of httpx, we'll have to consider the latest changes (see https://github.com/encode/httpx/releases/tag/0.19.0)

This PR resolves #312 