### PR TITLE
Change polling output to a progress bar

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,4 +16,8 @@
     rendering:
       show_root_full_path: false
 
+## ::: planet.reporting
+    rendering:
+      show_root_full_path: false
+
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,29 +8,27 @@ The recommended way to use a `Session` is as a context manager. This will
 provide for automatic clean up of connections when the context is left.
 
 ```python
->>> import asyncio
->>> import os
->>> from planet import Session
->>>
->>> async def main():
-...     async with Session() as sess:
-...         # perform operations here
-...         pass
-...
->>> asyncio.run(main())
+import asyncio
+import os
+from planet import Session
 
+async def main():
+    async with Session() as sess:
+        # perform operations here
+        pass
+
+asyncio.run(main())
 ```
 
 Alternatively, use `await Session.aclose()` to close a `Session` explicitly:
 
 ```python
->>> async def main():
-...     sess = Session()
-...     # perform operations here
-...     await sess.aclose()
-...
->>> asyncio.run(main())
+async def main():
+    sess = Session()
+    # perform operations here
+    await sess.aclose()
 
+asyncio.run(main())
 ```
 
 ### Authentication
@@ -53,13 +51,12 @@ It can also be accessed, e.g. to store in an environment variable, as
 For example, to obtain and store authentication information:
 
 ```python
->>> import getpass
->>> from planet import Auth
->>>
->>> pw = getpass.getpass()
->>> auth = Auth.from_login('user', 'pw')
->>> auth.write()
+import getpass
+from planet import Auth
 
+pw = getpass.getpass()
+auth = Auth.from_login('user', 'pw')
+auth.write()
 ```
 
 When a `Session` is created, by default, authentication is read from the secret
@@ -74,18 +71,17 @@ respective functions. For example, authentication can be read from a custom
 environment variable:
 
 ```python
->>> import asyncio
->>> import os
->>> from planet import Auth, Session
->>>
->>> auth = Auth.from_env('ALTERNATE_VAR')
->>> async def main():
-...     async with Session(auth=auth) as sess:
-...         # perform operations here
-...         pass
-...
->>> asyncio.run(main())
+import asyncio
+import os
+from planet import Auth, Session
 
+auth = Auth.from_env('ALTERNATE_VAR')
+async def main():
+    async with Session(auth=auth) as sess:
+        # perform operations here
+        pass
+
+asyncio.run(main())
 ```
 
 ### Orders Client
@@ -96,15 +92,14 @@ with the only difference being the addition of the ability to poll for when an
 order is completed and to download an entire order.
 
 ```python
->>> from planet import OrdersClient
->>>
->>> async def main():
-...     async with Session() as sess:
-...         client = OrdersClient(sess)
-...         # perform operations here
-...
->>> asyncio.run(main())
+from planet import OrdersClient
 
+async def main():
+    async with Session() as sess:
+        client = OrdersClient(sess)
+        # perform operations here
+
+asyncio.run(main())
 ```
 
 #### Creating an Order
@@ -116,77 +111,105 @@ as a JSON blob. This JSON blob can be built up manually or by using the
 An example of creating the request JSON with `build_request`:
 
 ```python
->>> from planet import order_request
->>> products = [
-...     order_request.product(['20170614_113217_3163208_RapidEye-5'],
-...                           'analytic', 'REOrthoTile')
-... ]
-...
->>> tools = [
-...     order_request.toar_tool(scale_factor=10000),
-...     order_request.reproject_tool(projection='WSG84', kernel='cubic'),
-...     order_request.tile_tool(1232, origin_x=-180, origin_y=-90,
-...               pixel_size=0.000027056277056,
-...               name_template='C1232_30_30_{tilex:04d}_{tiley:04d}')
-... ]
-...
->>> request = order_request.build_request(
-...     'test_order', products, tools)
-...
+from planet import order_request
+products = [
+    order_request.product(['20170614_113217_3163208_RapidEye-5'],
+                          'analytic', 'REOrthoTile')
+]
 
+tools = [
+    order_request.toar_tool(scale_factor=10000),
+    order_request.reproject_tool(projection='WSG84', kernel='cubic'),
+    order_request.tile_tool(1232, origin_x=-180, origin_y=-90,
+              pixel_size=0.000027056277056,
+              name_template='C1232_30_30_{tilex:04d}_{tiley:04d}')
+]
+
+request = order_request.build_request(
+    'test_order', products, tools)
 ```
 
 The same thing, expressed as a `JSON` blob:
 
 ```python
->>> request = {
-...   "name": "test_order",
-...   "products": [
-...     {
-...       "item_ids": [
-...         "20170614_113217_3163208_RapidEye-5"
-...       ],
-...       "item_type": "REOrthoTile",
-...       "product_bundle": "analytic"
-...     }
-...   ],
-...   "tools": [
-...     {
-...       "toar": {
-...         "scale_factor": 10000
-...       }
-...     },
-...     {
-...       "reproject": {
-...         "projection": "WSG84",
-...         "kernel": "cubic"
-...       }
-...     },
-...     {
-...       "tile": {
-...         "tile_size": 1232,
-...         "origin_x": -180,
-...         "origin_y": -90,
-...         "pixel_size": 2.7056277056e-05,
-...         "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
-...       }
-...     }
-...   ]
-... }
-
+request = {
+  "name": "test_order",
+  "products": [
+    {
+      "item_ids": [
+        "20170614_113217_3163208_RapidEye-5"
+      ],
+      "item_type": "REOrthoTile",
+      "product_bundle": "analytic"
+    }
+  ],
+  "tools": [
+    {
+      "toar": {
+        "scale_factor": 10000
+      }
+    },
+    {
+      "reproject": {
+        "projection": "WSG84",
+        "kernel": "cubic"
+      }
+    },
+    {
+      "tile": {
+        "tile_size": 1232,
+        "origin_x": -180,
+        "origin_y": -90,
+        "pixel_size": 2.7056277056e-05,
+        "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
+      }
+    }
+  ]
+}
 ```
 
 Once the order request is built up, creating an order is done within
 the context of a `Session` with the `OrdersClient`:
 
 ```python
->>> async def main():
-...     async with Session() as sess:
-...         cl = OrdersClient(sess)
-...         order_id = await cl.create_order(request)
-...
->>> asyncio.run(main())
+async def main():
+    async with Session() as sess:
+        cl = OrdersClient(sess)
+        order_id = await cl.create_order(request)
 
+asyncio.run(main())
+```
+
+#### Polling and Downloading an Order
+
+Once an order is created, the Orders API takes some time to create the order
+and thus we must wait a while before downloading the order.
+We can use polling to watch the order creation process and find out when the 
+order is created successfully and ready to download.
+
+With polling and download, it is often desired to track progress as these 
+processes can take a long time. Therefore, in this example, we use a progress
+bar from the `reporting` module to report poll status. `download_order` has
+reporting built in.
+
+```python
+from planet import reporting
+
+async def create_poll_and_download():
+    async with Session() as sess:
+        cl = OrdersClient(sess)
+        with reporting.StateBar(state='creating') as bar:
+            # create order
+            order = await cl.create_order(request)
+            bar.update(state='created', order_id=order.id)
+
+            # poll
+            await cl.poll(order.id, report=bar.update)
+
+        # download
+        await cl.download_order(order.id)
+
+asyncio.run(create_poll_and_download())
 ```
 
 ## CLI
@@ -228,7 +251,7 @@ the options and format given in
 An example would be:
 
 Example: `cloudconfig.json`
-```
+```python
 {
     "amazon_s3": {
         "aws_access_key_id": "aws_access_key_id",
@@ -246,7 +269,7 @@ It can be a Polygon geometry, a Feature, or a FeatureClass. If it is a FeatureCl
 only the first Feature is used for the clip geometry.
 
 Example: `aoi.geojson`
-```
+```python
 {
     "type": "Polygon",
     "coordinates": [
@@ -283,7 +306,7 @@ and format are given in
 [Creating Toolchains](https://developers.planet.com/docs/orders/tools-toolchains/#creating-toolchains).
 
 Example: `tools.json`
-```
+```python
 [
     {
         "toar": {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -64,7 +64,7 @@ For example, to obtain and store authentication information:
 
 When a `Session` is created, by default, authentication is read from the secret
 file created with `Auth.write()`. This behavior can be modified by specifying
-`Auth` explicitely using the methods `Auth.from_file()` and `Auth.from_env()`.
+`Auth` explicitly using the methods `Auth.from_file()` and `Auth.from_env()`.
 While `Auth.from_key()` and `Auth.from_login` can be used, it is recommended
 that those functions be used in authentication initialization and the
 authentication information be stored using `Auth.write()`.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -8,27 +8,29 @@ The recommended way to use a `Session` is as a context manager. This will
 provide for automatic clean up of connections when the context is left.
 
 ```python
-import asyncio
-import os
-from planet import Session
+>>> import asyncio
+>>> import os
+>>> from planet import Session
+>>>
+>>> async def main():
+...     async with Session() as sess:
+...         # perform operations here
+...         pass
+...
+>>> asyncio.run(main())
 
-async def main():
-    async with Session() as sess:
-        # perform operations here
-        pass
-
-asyncio.run(main())
 ```
 
 Alternatively, use `await Session.aclose()` to close a `Session` explicitly:
 
 ```python
-async def main():
-    sess = Session()
-    # perform operations here
-    await sess.aclose()
+>>> async def main():
+...     sess = Session()
+...     # perform operations here
+...     await sess.aclose()
+...
+>>> asyncio.run(main())
 
-asyncio.run(main())
 ```
 
 ### Authentication
@@ -51,12 +53,13 @@ It can also be accessed, e.g. to store in an environment variable, as
 For example, to obtain and store authentication information:
 
 ```python
-import getpass
-from planet import Auth
+>>> import getpass
+>>> from planet import Auth
+>>>
+>>> pw = getpass.getpass()
+>>> auth = Auth.from_login('user', 'pw')
+>>> auth.write()
 
-pw = getpass.getpass()
-auth = Auth.from_login('user', 'pw')
-auth.write()
 ```
 
 When a `Session` is created, by default, authentication is read from the secret
@@ -71,17 +74,18 @@ respective functions. For example, authentication can be read from a custom
 environment variable:
 
 ```python
-import asyncio
-import os
-from planet import Auth, Session
+>>> import asyncio
+>>> import os
+>>> from planet import Auth, Session
+>>>
+>>> auth = Auth.from_env('ALTERNATE_VAR')
+>>> async def main():
+...     async with Session(auth=auth) as sess:
+...         # perform operations here
+...         pass
+...
+>>> asyncio.run(main())
 
-auth = Auth.from_env('ALTERNATE_VAR')
-async def main():
-    async with Session(auth=auth) as sess:
-        # perform operations here
-        pass
-
-asyncio.run(main())
 ```
 
 ### Orders Client
@@ -92,14 +96,15 @@ with the only difference being the addition of the ability to poll for when an
 order is completed and to download an entire order.
 
 ```python
-from planet import OrdersClient
+>>> from planet import OrdersClient
+>>>
+>>> async def main():
+...     async with Session() as sess:
+...         client = OrdersClient(sess)
+...         # perform operations here
+...
+>>> asyncio.run(main())
 
-async def main():
-    async with Session() as sess:
-        client = OrdersClient(sess)
-        # perform operations here
-
-asyncio.run(main())
 ```
 
 #### Creating an Order
@@ -111,83 +116,87 @@ as a JSON blob. This JSON blob can be built up manually or by using the
 An example of creating the request JSON with `build_request`:
 
 ```python
-from planet import order_request
-products = [
-    order_request.product(['20170614_113217_3163208_RapidEye-5'],
-                          'analytic', 'REOrthoTile')
-]
+>>> from planet import order_request
+>>> products = [
+...     order_request.product(['20170614_113217_3163208_RapidEye-5'],
+...                           'analytic', 'REOrthoTile')
+... ]
+...
+>>> tools = [
+...     order_request.toar_tool(scale_factor=10000),
+...     order_request.reproject_tool(projection='WSG84', kernel='cubic'),
+...     order_request.tile_tool(1232, origin_x=-180, origin_y=-90,
+...               pixel_size=0.000027056277056,
+...               name_template='C1232_30_30_{tilex:04d}_{tiley:04d}')
+... ]
+...
+>>> request = order_request.build_request(
+...     'test_order', products, tools)
+...
 
-tools = [
-    order_request.toar_tool(scale_factor=10000),
-    order_request.reproject_tool(projection='WSG84', kernel='cubic'),
-    order_request.tile_tool(1232, origin_x=-180, origin_y=-90,
-              pixel_size=0.000027056277056,
-              name_template='C1232_30_30_{tilex:04d}_{tiley:04d}')
-]
-
-request = order_request.build_request(
-    'test_order', products, tools)
 ```
 
 The same thing, expressed as a `JSON` blob:
 
 ```python
-request = {
-  "name": "test_order",
-  "products": [
-    {
-      "item_ids": [
-        "20170614_113217_3163208_RapidEye-5"
-      ],
-      "item_type": "REOrthoTile",
-      "product_bundle": "analytic"
-    }
-  ],
-  "tools": [
-    {
-      "toar": {
-        "scale_factor": 10000
-      }
-    },
-    {
-      "reproject": {
-        "projection": "WSG84",
-        "kernel": "cubic"
-      }
-    },
-    {
-      "tile": {
-        "tile_size": 1232,
-        "origin_x": -180,
-        "origin_y": -90,
-        "pixel_size": 2.7056277056e-05,
-        "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
-      }
-    }
-  ]
-}
+>>> request = {
+...   "name": "test_order",
+...   "products": [
+...     {
+...       "item_ids": [
+...         "20170614_113217_3163208_RapidEye-5"
+...       ],
+...       "item_type": "REOrthoTile",
+...       "product_bundle": "analytic"
+...     }
+...   ],
+...   "tools": [
+...     {
+...       "toar": {
+...         "scale_factor": 10000
+...       }
+...     },
+...     {
+...       "reproject": {
+...         "projection": "WSG84",
+...         "kernel": "cubic"
+...       }
+...     },
+...     {
+...       "tile": {
+...         "tile_size": 1232,
+...         "origin_x": -180,
+...         "origin_y": -90,
+...         "pixel_size": 2.7056277056e-05,
+...         "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
+...       }
+...     }
+...   ]
+... }
+
 ```
 
 Once the order request is built up, creating an order is done within
 the context of a `Session` with the `OrdersClient`:
 
 ```python
-async def main():
-    async with Session() as sess:
-        cl = OrdersClient(sess)
-        order_id = await cl.create_order(request)
+>>> async def main():
+...     async with Session() as sess:
+...         cl = OrdersClient(sess)
+...         order_id = await cl.create_order(request)
+...
+>>> asyncio.run(main())
 
-asyncio.run(main())
 ```
 
 #### Polling and Downloading an Order
 
 Once an order is created, the Orders API takes some time to create the order
 and thus we must wait a while before downloading the order.
-We can use polling to watch the order creation process and find out when the 
+We can use polling to watch the order creation process and find out when the
 order is created successfully and ready to download.
 
-With polling and download, it is often desired to track progress as these 
+With polling and download, it is often desired to track progress as these
 processes can take a long time. Therefore, in this example, we use a progress
 bar from the `reporting` module to report poll status. `download_order` has
 reporting built in.
@@ -195,21 +204,21 @@ reporting built in.
 ```python
 from planet import reporting
 
-async def create_poll_and_download():
-    async with Session() as sess:
-        cl = OrdersClient(sess)
-        with reporting.StateBar(state='creating') as bar:
-            # create order
-            order = await cl.create_order(request)
-            bar.update(state='created', order_id=order.id)
-
-            # poll
-            await cl.poll(order.id, report=bar.update)
-
-        # download
-        await cl.download_order(order.id)
-
-asyncio.run(create_poll_and_download())
+>>> async def create_poll_and_download():
+...     async with Session() as sess:
+...         cl = OrdersClient(sess)
+...         with reporting.StateBar(state='creating') as bar:
+...             # create order
+...             order = await cl.create_order(request)
+...             bar.update(state='created', order_id=order.id)
+...
+...             # poll
+...             await cl.poll(order.id, report=bar.update)
+...
+...         # download
+...         await cl.download_order(order.id)
+...
+>>> asyncio.run(create_poll_and_download())
 ```
 
 ## CLI
@@ -251,7 +260,7 @@ the options and format given in
 An example would be:
 
 Example: `cloudconfig.json`
-```python
+```
 {
     "amazon_s3": {
         "aws_access_key_id": "aws_access_key_id",
@@ -269,7 +278,7 @@ It can be a Polygon geometry, a Feature, or a FeatureClass. If it is a FeatureCl
 only the first Feature is used for the clip geometry.
 
 Example: `aoi.geojson`
-```python
+```
 {
     "type": "Polygon",
     "coordinates": [
@@ -306,7 +315,7 @@ and format are given in
 [Creating Toolchains](https://developers.planet.com/docs/orders/tools-toolchains/#creating-toolchains).
 
 Example: `tools.json`
-```python
+```
 [
     {
         "toar": {

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from .http import Session
 from .models import Order
-from . import order_request
+from . import order_request, reporting
 from .__version__ import __version__  # NOQA
 from .auth import Auth
 from .clients import OrdersClient
@@ -24,5 +24,6 @@ __all__ = [
     OrdersClient,
     Order,
     order_request,
+    reporting,
     Auth,
 ]

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -346,17 +346,22 @@ class OrdersClient():
         self,
         order_id: str,
         state: str = None,
-        wait: int = 10,
+        wait: int = 1,
         report=None
     ) -> str:
         """Poll for order status until order reaches desired state, optionally
         reporting status.
 
+        By default, the Orders API is polled every 1 second for status updates.
+        The API rate limit for this endpoint is 10 requests per second.
+        If many orders are being polled asynchronously, consider
+        increasing the wait to avoid throttling.
+
         Example:
             ```python
             from planet.reporting import StateBar
 
-            with StateBar as bar:
+            with StateBar() as bar:
                 await poll(order_id, report=bar.update)
             ```
 

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -301,6 +301,7 @@ class OrdersClient():
         async with self._session.stream(req) as resp:
             body = StreamingBody(resp)
             dl_path = os.path.join(directory or '.', filename or body.name)
+
             await body.write(dl_path,
                              overwrite=overwrite,
                              progress_bar=progress_bar)
@@ -344,27 +345,28 @@ class OrdersClient():
         order_id: str,
         state: str = None,
         wait: int = 10,
-        verbose: bool = False
+        report=None
     ) -> str:
-        """Poll for order status until order reaches desired state.
+        """Poll for order status until order reaches desired state, optionally
+        reporting status.
 
         Parameters:
             order_id: The ID of the order
             state: State to poll until. If multiple, use list. Defaults to
                 any completed state.
             wait: Time (in seconds) between polls.
-            verbose: Print current state at each poll
+            report: Callback function for progress updates. Invoked with
+                keyword arguments `state` (poll state) and `logger`
+                (callback for logging progress bar status).
 
         Returns
-            Completed state of the order
+            Completed state of the order.
 
         Raises:
             planet.exceptions.APIException: On API error.
             OrdersClientException: If order_id is not valid or state is not
                 supported.
         """
-        completed = False
-
         if state:
             if state not in ORDERS_STATES:
                 raise OrdersClientException(
@@ -374,19 +376,20 @@ class OrdersClient():
         else:
             states = ORDERS_STATES_COMPLETE
 
+        completed = False
         while not completed:
             t = time.time()
+
             order = await self.get_order(order_id)
             state = order.state
-            msg = f'order {order_id} state: {state}'
-            LOGGER.info(msg)
-            if verbose:
-                print(msg)
+
+            if report:
+                report(state=order.state, logger=LOGGER.info)
 
             completed = state in states
             if not completed:
                 sleep_time = max(wait-(time.time()-t), 0)
-                LOGGER.info(f'sleeping {sleep_time}s')
+                LOGGER.debug(f'sleeping {sleep_time}s')
                 await asyncio.sleep(sleep_time)
         return state
 

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -304,7 +304,6 @@ class OrdersClient():
         async with self._session.stream(req) as resp:
             body = StreamingBody(resp)
             dl_path = os.path.join(directory or '.', filename or body.name)
-
             await body.write(dl_path,
                              overwrite=overwrite,
                              progress_bar=progress_bar)

--- a/planet/models.py
+++ b/planet/models.py
@@ -22,8 +22,8 @@ import re
 import string
 
 import httpx
+from tqdm.asyncio import tqdm
 
-from . import reporting
 
 LOGGER = logging.getLogger(__name__)
 
@@ -172,30 +172,50 @@ class StreamingBody():
         async for c in self.response.aiter_bytes():
             yield c
 
-    async def write(
-        self,
-        filename: str,
-        overwrite: bool = True,
-        progress_bar: bool = True
-    ):
-        '''Write the body to a file, optionally reporting status.
-
-        Parameters:
-            filename: Name to assign to downloaded file.
-            overwrite: Overwrite any existing files. Defaults to True
-            progress_bar: Show progress bar during download. Defaults to
+    async def write(self, filename, overwrite=True, progress_bar=True):
+        '''Write the body to a file.
+        :param filename: Name to assign to downloaded file.
+        :type filename: str
+        :param overwrite: Overwrite any existing files. Defaults to True
+        :type overwrite: boolean, optional
+        :param progress_bar: Show progress bar during download. Defaults to
             True.
+        :type progress_bar: boolean, optional
         '''
+        class _LOG():
+            def __init__(self, total, unit, filename, disable):
+                self.total = total
+                self.unit = unit
+                self.disable = disable
+                self.previous = 0
+                self.filename = filename
+
+                if not self.disable:
+                    LOGGER.debug(f'writing to {self.filename}')
+
+            def update(self, new):
+                if new-self.previous > self.unit and not self.disable:
+                    # LOGGER.debug(f'{new-self.previous}')
+                    perc = int(100 * new / self.total)
+                    LOGGER.debug(f'{self.filename}: '
+                                 f'wrote {perc}% of {self.total}')
+                    self.previous = new
+
+        unit = 1024*1024
+
         mode = 'wb' if overwrite else 'xb'
         try:
             with open(filename, mode) as fp:
-                with reporting.FileDownloadBar(filename, self.size) as bar:
+                _log = _LOG(self.size, 16*unit, filename, disable=progress_bar)
+                with tqdm(total=self.size, unit_scale=True,
+                          unit_divisor=unit, unit='B',
+                          desc=filename, disable=not progress_bar) as progress:
                     previous = self.num_bytes_downloaded
                     async for chunk in self.aiter_bytes():
                         fp.write(chunk)
                         new = self.num_bytes_downloaded
-                        if progress_bar:
-                            bar.update(new-previous, logger=LOGGER.debug)
+                        _log.update(new)
+                        progress.update(new-previous)
                         previous = new
         except FileExistsError:
             LOGGER.info(f'File {filename} exists, not overwriting')

--- a/planet/models.py
+++ b/planet/models.py
@@ -24,7 +24,6 @@ import string
 import httpx
 from tqdm.asyncio import tqdm
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -174,6 +173,7 @@ class StreamingBody():
 
     async def write(self, filename, overwrite=True, progress_bar=True):
         '''Write the body to a file.
+
         :param filename: Name to assign to downloaded file.
         :type filename: str
         :param overwrite: Overwrite any existing files. Defaults to True

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Planet Labs, Inc.
+# Copyright 2021 Planet Labs, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -20,6 +20,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ProgressBar():
+    """Abstract base class for progress bar reporters."""
     def __init__(self):
         self.bar = None
 
@@ -58,10 +59,8 @@ class StateBar(ProgressBar):
         """Initialize the object.
 
         Parameters:
-            filename: Name of file to display.
-            size: File size in bytes.
-            unit: Value to scale number of report iterations.
-                (e.g. 1024*1024 scales to reporting in Megabytes.)
+            order_id: Id of the order.
+            state: State of the order.
         """
 
         self.state = state or ''
@@ -78,7 +77,11 @@ class StateBar(ProgressBar):
     def desc(self):
         return f'order {self.order_id}'
 
-    def update(self, state=None, order_id=None):
+    def update(
+        self,
+        state: str = None,
+        order_id: str = None
+    ):
         if state:
             if state != self.state:
                 LOGGER.info('{order_id} state: {state}')
@@ -91,51 +94,4 @@ class StateBar(ProgressBar):
 
         self.bar.refresh()
 
-        LOGGER.debug(str(self.bar))
-
-
-class FileDownloadBar(ProgressBar):
-    """Bar reporter of file download progress.
-
-    Example:
-        ```python
-        from planet import reporting
-
-        with reporting.FileDownloadBar('img.tif', 100000) as bar:
-            bar.update(1000)
-            ...
-        ```
-    """
-    def __init__(
-        self,
-        filename: str,
-        size: int,
-        unit: int = None,
-        disable: bool = False
-    ):
-        """Initialize the object.
-
-        Parameters:
-            filename: Name of file to display.
-            size: File size in bytes.
-            unit: Value to scale number of report iterations.
-                (e.g. 1024*1024 scales to reporting in Megabytes.)
-        """
-        self.filename = filename
-        self.size = size
-        self.unit = unit or 1024*1024
-        super().__init__()
-
-    def open_bar(self):
-        """Initialize and start the progress bar."""
-        self.bar = tqdm(
-            total=self.size,
-            unit_scale=True,
-            unit_divisor=self.unit,
-            unit='B',
-            desc=self.filename,
-            disable=self.disable)
-
-    def update(self, downloaded_amt, logger=None):
-        self.bar.update(downloaded_amt)
         LOGGER.debug(str(self.bar))

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -1,0 +1,135 @@
+# Copyright 2020 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""Functionality for reporting progress."""
+from tqdm.asyncio import tqdm
+
+
+class ProgressBar():
+    def __init__(self):
+        self.bar = None
+
+    def __str__(self):
+        return str(self.bar)
+
+    def __enter__(self):
+        self.open_bar()
+        return self
+
+    def __exit__(self, *args):
+        self.bar.close()
+
+    def open_bar(self):
+        return NotImplementedError
+
+
+class StateBar(ProgressBar):
+    def __init__(self, order_id=None, state=None):
+        self.state = state or ''
+        self.order_id = order_id or ''
+        super().__init__()
+
+    def open_bar(self):
+        self.bar = tqdm(
+            bar_format="{elapsed} - {desc} - {postfix[0]}: {postfix[1]}",
+            desc=self.desc, postfix=["state", self.state])
+
+    @property
+    def desc(self):
+        return f'order {self.order_id}'
+
+    def update(self, state=None, order_id=None, logger=None):
+        if state:
+            self.state = state
+            self.bar.postfix[1] = self.state
+
+        if order_id:
+            self.order_id = order_id
+            self.bar.set_description_str(self.desc, refresh=False)
+
+        self.bar.refresh()
+
+        if logger:
+            logger(str(self.bar))
+
+
+class FileDownloadBar(ProgressBar):
+    def __init__(self, filename, size, unit=None):
+        self.filename = filename
+        self.size = size
+        self.unit = unit or 1024*1024
+        super().__init__()
+
+    def open_bar(self):
+        self.bar = tqdm(
+            total=self.size,
+            unit_scale=True,
+            unit_divisor=self.unit,
+            unit='B',
+            desc=self.filename)
+
+    def update(self, downloaded_amt, logger=None):
+        self.bar.update(downloaded_amt)
+
+        if logger:
+            logger(str(self.bar))
+
+
+class OrderDownloadBar(ProgressBar):
+    def __init__(self, order_id=None, num_files=None):
+        self.order_id = order_id or ''
+        self.num_files = num_files or 0
+        super().__init__()
+
+        self.file_bars = []
+
+    def open_bar(self):
+        self.bar = tqdm(
+            range(self.num_files),
+            desc=self.order_id)
+
+    @property
+    def desc(self):
+        return f'order {self.order_id}'
+
+    def update(
+        self,
+        order_id=None,
+        num_files=None,
+        add_file=False,
+        logger=None
+    ):
+        if order_id:
+            self.order_id = order_id
+            self.bar.set_description_str(self.desc, refresh=False)
+
+        if num_files:
+            self.bar.total = num_files
+
+        self.bar.refresh()
+
+        if logger:
+            logger(str(self.bar))
+
+    #     if add_file:
+    #         self.file_bars.append(
+    #         return self.create_file_reporter
+    #
+    # from contextlib import contextmanager
+    # @contextmanager
+    # def create_file_reporter(self, filename, size, unit=None):
+    #     new_bar = FileDownloadBar(filename, size, unit)
+    #     new_bar.open()
+    #
+    #     with FileDownloadBar(filename, size, unit) as bar:
+    #         yield bar.update

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -21,8 +21,12 @@ LOGGER = logging.getLogger(__name__)
 
 class ProgressBar():
     """Abstract base class for progress bar reporters."""
-    def __init__(self):
+    def __init__(
+        self,
+        disable: bool = False
+    ):
         self.bar = None
+        self.disable = disable
 
     def __str__(self):
         return str(self.bar)
@@ -54,7 +58,8 @@ class StateBar(ProgressBar):
     def __init__(
         self,
         order_id: str = None,
-        state: str = None
+        state: str = None,
+        disable: bool = False,
     ):
         """Initialize the object.
 
@@ -65,13 +70,14 @@ class StateBar(ProgressBar):
 
         self.state = state or ''
         self.order_id = order_id or ''
-        super().__init__()
+        super().__init__(disable=disable)
 
     def open_bar(self):
         """Initialize and start the progress bar."""
         self.bar = tqdm(
             bar_format="{elapsed} - {desc} - {postfix[0]}: {postfix[1]}",
-            desc=self.desc, postfix=["state", self.state])
+            desc=self.desc, postfix=["state", self.state],
+            disable=self.disable)
 
     @property
     def desc(self):

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -30,16 +30,42 @@ class ProgressBar():
         self.bar.close()
 
     def open_bar(self):
+        """Initialize and start the progress bar."""
         return NotImplementedError
 
 
 class StateBar(ProgressBar):
-    def __init__(self, order_id=None, state=None):
+    """Bar reporter of order state.
+
+    Example:
+        ```python
+        from planet import reporting
+
+        with reporting.StateBar(state='creating') as bar:
+            bar.update(state='created', order_id='oid')
+            ...
+        ```
+    """
+    def __init__(
+        self,
+        order_id: str = None,
+        state: str = None
+    ):
+        """Initialize the object.
+
+        Parameters:
+            filename: Name of file to display.
+            size: File size in bytes.
+            unit: Value to scale number of report iterations.
+                (e.g. 1024*1024 scales to reporting in Megabytes.)
+        """
+
         self.state = state or ''
         self.order_id = order_id or ''
         super().__init__()
 
     def open_bar(self):
+        """Initialize and start the progress bar."""
         self.bar = tqdm(
             bar_format="{elapsed} - {desc} - {postfix[0]}: {postfix[1]}",
             desc=self.desc, postfix=["state", self.state])
@@ -64,13 +90,39 @@ class StateBar(ProgressBar):
 
 
 class FileDownloadBar(ProgressBar):
-    def __init__(self, filename, size, unit=None):
+    """Bar reporter of file download progress.
+
+    Example:
+        ```python
+        from planet import reporting
+
+        with reporting.FileDownloadBar('img.tif', 100000) as bar:
+            bar.update(1000)
+            ...
+        ```
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        size: int,
+        unit: int = None
+    ):
+        """Initialize the object.
+
+        Parameters:
+            filename: Name of file to display.
+            size: File size in bytes.
+            unit: Value to scale number of report iterations.
+                (e.g. 1024*1024 scales to reporting in Megabytes.)
+        """
         self.filename = filename
         self.size = size
         self.unit = unit or 1024*1024
         super().__init__()
 
     def open_bar(self):
+        """Initialize and start the progress bar."""
         self.bar = tqdm(
             total=self.size,
             unit_scale=True,
@@ -86,7 +138,11 @@ class FileDownloadBar(ProgressBar):
 
 
 class OrderDownloadBar(ProgressBar):
-    def __init__(self, order_id=None, num_files=None):
+    def __init__(
+        self,
+        order_id: str = None,
+        num_files: int = None
+    ):
         self.order_id = order_id or ''
         self.num_files = num_files or 0
         super().__init__()
@@ -94,6 +150,7 @@ class OrderDownloadBar(ProgressBar):
         self.file_bars = []
 
     def open_bar(self):
+        """Initialize and start the progress bar."""
         self.bar = tqdm(
             range(self.num_files),
             desc=self.order_id)
@@ -104,9 +161,9 @@ class OrderDownloadBar(ProgressBar):
 
     def update(
         self,
-        order_id=None,
-        num_files=None,
-        add_file=False,
+        order_id: str = None,
+        num_files: int = None,
+        add_file: bool = False,
         logger=None
     ):
         if order_id:

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -209,7 +209,7 @@ async def cancel(ctx, order_id):
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
     async with orders_client(ctx) as cl:
-        with planet.reporting.StateBar(disable=quiet) as bar:
+        with planet.reporting.StateBar(order_id=order_id, disable=quiet) as bar:
             await cl.poll(str(order_id), report=bar.update)
             filenames = await cl.download_order(
                     str(order_id),

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -209,12 +209,13 @@ async def cancel(ctx, order_id):
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
     async with orders_client(ctx) as cl:
-        await cl.poll(str(order_id), verbose=True)
-        filenames = await cl.download_order(
-                str(order_id),
-                directory=dest,
-                overwrite=overwrite,
-                progress_bar=not quiet)
+        with planet.reporting.StateBar(disable=quiet) as bar:
+            await cl.poll(str(order_id), report=bar.update)
+            filenames = await cl.download_order(
+                    str(order_id),
+                    directory=dest,
+                    overwrite=overwrite,
+                    progress_bar=not quiet)
     click.echo(f'Downloaded {len(filenames)} files.')
 
 

--- a/planet/scripts/cli.py
+++ b/planet/scripts/cli.py
@@ -209,7 +209,8 @@ async def cancel(ctx, order_id):
 async def download(ctx, order_id, quiet, overwrite, dest):
     '''Download order by order ID.'''
     async with orders_client(ctx) as cl:
-        with planet.reporting.StateBar(order_id=order_id, disable=quiet) as bar:
+        with planet.reporting.StateBar(order_id=order_id,
+                                       disable=quiet) as bar:
             await cl.poll(str(order_id), report=bar.update)
             filenames = await cl.download_order(
                     str(order_id),

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -18,14 +18,14 @@ import logging
 import math
 import os
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import create_autospec
 
 
 import httpx
 import pytest
 import respx
 
-from planet import OrdersClient, clients, exceptions
+from planet import OrdersClient, clients, exceptions, reporting
 
 
 TEST_URL = 'http://MockNotRealURL/'
@@ -438,7 +438,8 @@ async def test_poll(oid, order_description, session):
         httpx.Response(HTTPStatus.OK, json=order_description3)
     ]
 
-    mock_report = Mock()
+    mock_bar = create_autospec(reporting.StateBar)
+    mock_report = mock_bar.update
     state = await cl.poll(oid, wait=0, report=mock_report)
     assert state == 'success'
 

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -18,6 +18,7 @@ import logging
 import math
 import os
 from pathlib import Path
+from unittest.mock import Mock
 
 
 import httpx
@@ -436,8 +437,15 @@ async def test_poll(oid, order_description, session):
         httpx.Response(HTTPStatus.OK, json=order_description2),
         httpx.Response(HTTPStatus.OK, json=order_description3)
     ]
-    state = await cl.poll(oid, wait=0)
+
+    mock_report = Mock()
+    state = await cl.poll(oid, wait=0, report=mock_report)
     assert state == 'success'
+
+    # check state was reported as expected
+    assert mock_report.call_count == 3
+    states = [c[2]['state'] for c in mock_report.mock_calls]
+    assert ['queued', 'running', 'success'] == states
 
     route = respx.get(get_url)
     route.side_effect = [

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -145,8 +145,15 @@ def test_cli_orders_download(runner, monkeypatch, oid):
     result = runner.invoke(
         cli, ['orders', 'download', oid])
     assert not result.exception
-    # assert "file1" in result.output
-    assert 'Downloaded 1 files.\n' == result.output
+    expected = 'Downloaded 1 files.\n'
+    # allow for some progress reporting
+    assert expected in result.output
+
+    # test quiet option, should be no progress reporting
+    result = runner.invoke(
+        cli, ['orders', 'download', '-q', oid])
+    assert not result.exception
+    assert expected == result.output
 
 
 class AsyncMock(Mock):

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -19,7 +19,7 @@ from planet import reporting
 LOGGER = logging.getLogger(__name__)
 
 
-def test_StateBar():
+def test_StateBar_enabled():
     with reporting.StateBar() as bar:
         expected_init = '..:.. - order  - state: '
         assert(re.fullmatch(expected_init, str(bar)))
@@ -27,3 +27,8 @@ def test_StateBar():
         expected_update = '..:.. - order 1 - state: init'
         bar.update(order_id='1', state='init')
         assert(re.fullmatch(expected_update, str(bar)))
+
+
+def test_StateBar_disabled():
+    with reporting.StateBar(disable=True) as bar:
+        assert bar.bar.disable

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Planet Labs, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+import logging
+import re
+
+from planet import reporting
+
+LOGGER = logging.getLogger(__name__)
+
+
+def test_StateBar():
+    with reporting.StateBar() as bar:
+        expected_init = '..:.. - order  - state: '
+        assert(re.fullmatch(expected_init, str(bar)))
+
+        expected_update = '..:.. - order 1 - state: init'
+        bar.update(order_id='1', state='init')
+        assert(re.fullmatch(expected_update, str(bar)))


### PR DESCRIPTION
This PR makes the following changes:
- Introduces a new module, `reporting`, which implements the status progress bar
- Changes spec of `OrdersClient.poll`: removes `verbose` (bool) and adds `report` (callback fcn)
- Fixes a bug in `create_order` where it fails on parsing an error message when there is no field
- Docs:
  - Adds `reporting` to API reference
  - Adds section in the user guide on downloading and polling an order with an example
  - Removes leading `>>> ` and `... ` symbols from user guide code examples to allow copy/paste

Closes #310

Usage:
```python
import asyncio
from planet import reporting, Session, OrdersClient

async def create_poll_and_download():
    async with Session() as sess:
        cl = OrdersClient(sess)
        with reporting.StateBar(state='creating') as bar:
            # create order
            order = await cl.create_order(request)
            bar.update(state='created', order_id=order.id)

            # poll
            await cl.poll(order.id, report=bar.update)

        # download
        await cl.download_order(order.id, progress_bar=True)

asyncio.run(create_poll_and_download())
```

REF: Example `request` for testing:
```python
request = {
  "name": "psorthotile_analytic",
  "products": [
    {
      "item_ids": [
        "4500474_2133707_2021-05-20_2419"
      ],
      "item_type": "PSOrthoTile",
      "product_bundle": "ANALYTIC"
    }
  ],
  "delivery": {
    "single_archive": true,
    "archive_type": "zip",
    "archive_filename": "string"
  },
  "tools": [
    {"file_format": {"format": "COG"}},
    {"toar": {"scale_factor": 10000}}
  ]
}
```