### PR TITLE
Added compatible pip install -e command for Zsh.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,13 @@ environments and works well with pyenv. To install the local, dynamic version
 of the Planet Python Client and required development packages into the virtual
 environment use:
 
+- Bash
 ```console
     $ pip install -e .[dev]
+```
+- Zsh
+```console
+    $ pip install -e .'[dev]'
 ```
 
 ## Testing


### PR DESCRIPTION
As title implies. I've added the compatible pip command for Zsh in the CONTRIBUTING doc.

Closing #321 