### PR TITLE
Added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+*.coverage.*
 
 # OS X
 .DS_Store
@@ -25,5 +26,6 @@ coverage.xml
 *.png
 *.tif*
 *.geojson
-*.vscode
-*.coverage.*
+
+# Editors
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ coverage.xml
 *.tif*
 *.geojson
 *.vscode
-*.coverage
+*.coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ coverage.xml
 *.jpg
 *.jpeg
 *.png
+*.tif*
 *.geojson
 *.vscode
+*.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage.xml
 *.jpeg
 *.png
 *.geojson
+*.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*.coverage.*
+.coverage.*
 
 # OS X
 .DS_Store


### PR DESCRIPTION
**Added:**
- `.coverage.*` for coverage reports, which are created in addition to `coverage.xml` on OS X
- `*.tif*` for all .tif and .tiff images.
- `.vscode/` for those who use the editor [VS Code](https://code.visualstudio.com/)