### PR TITLE
Handle mix of single target items and source lists when printing the listing of mosaics in feeds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,9 @@
 # Changes.txt
+
+Next (TBD)
+
+- Fix: handle FeedSource array in analytics API.
+
 1.4.9 (2021-12-07)
 
 - New: analytic_8b_udm2 asset

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -405,15 +405,9 @@ def list_feeds(pretty, limit, stats):
     echo_json_response(response, pretty, limit)
 
 
-@feeds.command('list-mosaics')
-@click.argument('feed_id')
-def get_mosaic_list_for_feed(feed_id):
-    """List mosaics linked to feed."""
-    cl = clientv1()
-    feed_info = cl.get_feed_info(feed_id).get()
-
+def print_feed_mosaic_list(feed_info, client):
+    """Print the listing of mosaics for a feed."""
     for type_ in ["target", "source"]:
-
         feed_image_conf = feed_info.get(type_, None)
         if not feed_image_conf:
             continue
@@ -429,9 +423,18 @@ def get_mosaic_list_for_feed(feed_id):
 
             click.echo("{} mosaics:".format(type_))
             mosaic_series = conf_item["config"]["series_id"]
-            mosaics = cl.get_mosaics_for_series(mosaic_series)
+            mosaics = client.get_mosaics_for_series(mosaic_series)
             for mosaic in mosaics.get()["mosaics"]:
                 click.echo("\t{}".format(mosaic["name"]))
+
+
+@feeds.command('list-mosaics')
+@click.argument('feed_id')
+def get_mosaic_list_for_feed(feed_id):
+    """List mosaics linked to feed."""
+    cl = clientv1()
+    feed_info = cl.get_feed_info(feed_id).get()
+    print_feed_mosaic_list(feed_info, cl)
 
 
 @feeds.command('describe')
@@ -470,24 +473,7 @@ def get_mosaic_list_for_subscription(subscription_id):
     cl = clientv1()
     sub_info = cl.get_subscription_info(subscription_id).get()
     feed_info = cl.get_feed_info(sub_info['feedID']).get()
-
-    for type_ in ['target', 'source']:
-        feed_image_conf = feed_info.get(type_)
-
-        if feed_image_conf['type'] != 'mosaic':
-            # Unsure about the following lines. The exception is not
-            # raised.
-            msg_format = 'The {} for this feed is not a mosaic type.'
-            click.ClickException(msg_format.format(type_))
-            continue
-
-        mosaic_series = feed_image_conf['config']['series_id']
-
-        mosaics = cl.get_mosaics_for_series(mosaic_series)
-
-        click.echo('{} mosaics:'.format(type_))
-        for mosaic in mosaics.get()['mosaics']:
-            click.echo('\t{}'.format(mosaic['name']))
+    print_feed_mosaic_list(feed_info, cl)
 
 
 @subscriptions.command('describe')
@@ -523,22 +509,7 @@ def get_mosaic_list_for_collection(subscription_id):
     cl = clientv1()
     sub_info = cl.get_subscription_info(subscription_id).get()
     feed_info = cl.get_feed_info(sub_info['feedID']).get()
-
-    for type_ in ['target', 'source']:
-        feed_image_conf = feed_info.get(type_)
-
-        if feed_image_conf['type'] != 'mosaic':
-            msg_format = 'The {} for this feed is not a mosaic type.'
-            click.ClickException(msg_format.format(type_))
-            continue
-
-        mosaic_series = feed_image_conf['config']['series_id']
-
-        mosaics = cl.get_mosaics_for_series(mosaic_series)
-
-        click.echo('{} mosaics:'.format(type_))
-        for mosaic in mosaics.get()['mosaics']:
-            click.echo('\t{}'.format(mosaic['name']))
+    print_feed_mosaic_list(feed_info, cl)
 
 
 @collections.command('describe')

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -408,36 +408,28 @@ def list_feeds(pretty, limit, stats):
 @feeds.command('list-mosaics')
 @click.argument('feed_id')
 def get_mosaic_list_for_feed(feed_id):
-    '''List mosaics linked to feed'''
+    """List mosaics linked to feed."""
     cl = clientv1()
     feed_info = cl.get_feed_info(feed_id).get()
 
-    for type_ in ['target', 'source']:
+    for type_ in ["target", "source"]:
+        click.echo("{} mosaics:".format(type_))
+
         feed_image_conf = feed_info.get(type_)
 
-        # "target" type appears to have a single dict, but "source" type
-        # seems to give a list of dicts. API change or something else?
-        if isinstance(feed_image_conf, list):
-            feed_image_conf = feed_image_conf[0]
+        # "target" type has a single dict, "source" type has a list of
+        # dicts. We normalize to a list.
+        if not isinstance(feed_image_conf, list):
+            feed_image_conf = [feed_image_conf]
 
-        try:
-            if feed_image_conf['type'] != 'mosaic':
-                # Unsure about the following lines. Why create an
-                # exception if we don't raise it?
-                msg_format = 'The {} for this feed is not a mosaic type.'
-                click.ClickException(msg_format.format(type_))
+        for conf_item in feed_image_conf:
+            if conf_item["type"] != "mosaic":
                 continue
-        except:
-            import pdb; pdb.set_trace()
-            raise
 
-        mosaic_series = feed_image_conf['config']['series_id']
-
-        mosaics = cl.get_mosaics_for_series(mosaic_series)
-
-        click.echo('{} mosaics:'.format(type_))
-        for mosaic in mosaics.get()['mosaics']:
-            click.echo('\t{}'.format(mosaic['name']))
+            mosaic_series = conf_item["config"]["series_id"]
+            mosaics = cl.get_mosaics_for_series(mosaic_series)
+            for mosaic in mosaics.get()["mosaics"]:
+                click.echo("\t{}".format(mosaic["name"]))
 
 
 @feeds.command('describe')

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -413,9 +413,10 @@ def get_mosaic_list_for_feed(feed_id):
     feed_info = cl.get_feed_info(feed_id).get()
 
     for type_ in ["target", "source"]:
-        click.echo("{} mosaics:".format(type_))
 
-        feed_image_conf = feed_info.get(type_)
+        feed_image_conf = feed_info.get(type_, None)
+        if not feed_image_conf:
+            continue
 
         # "target" type has a single dict, "source" type has a list of
         # dicts. We normalize to a list.
@@ -426,6 +427,7 @@ def get_mosaic_list_for_feed(feed_id):
             if conf_item["type"] != "mosaic":
                 continue
 
+            click.echo("{} mosaics:".format(type_))
             mosaic_series = conf_item["config"]["series_id"]
             mosaics = cl.get_mosaics_for_series(mosaic_series)
             for mosaic in mosaics.get()["mosaics"]:

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -421,9 +421,10 @@ def print_feed_mosaic_list(feed_info, client):
             if conf_item["type"] != "mosaic":
                 continue
 
-            click.echo("{} mosaics:".format(type_))
             mosaic_series = conf_item["config"]["series_id"]
             mosaics = client.get_mosaics_for_series(mosaic_series)
+            click.echo("{} mosaics:".format(type_))
+
             for mosaic in mosaics.get()["mosaics"]:
                 click.echo("\t{}".format(mosaic["name"]))
 

--- a/planet/scripts/v1.py
+++ b/planet/scripts/v1.py
@@ -415,10 +415,21 @@ def get_mosaic_list_for_feed(feed_id):
     for type_ in ['target', 'source']:
         feed_image_conf = feed_info.get(type_)
 
-        if feed_image_conf['type'] != 'mosaic':
-            msg_format = 'The {} for this feed is not a mosaic type.'
-            click.ClickException(msg_format.format(type_))
-            continue
+        # "target" type appears to have a single dict, but "source" type
+        # seems to give a list of dicts. API change or something else?
+        if isinstance(feed_image_conf, list):
+            feed_image_conf = feed_image_conf[0]
+
+        try:
+            if feed_image_conf['type'] != 'mosaic':
+                # Unsure about the following lines. Why create an
+                # exception if we don't raise it?
+                msg_format = 'The {} for this feed is not a mosaic type.'
+                click.ClickException(msg_format.format(type_))
+                continue
+        except:
+            import pdb; pdb.set_trace()
+            raise
 
         mosaic_series = feed_image_conf['config']['series_id']
 
@@ -470,6 +481,8 @@ def get_mosaic_list_for_subscription(subscription_id):
         feed_image_conf = feed_info.get(type_)
 
         if feed_image_conf['type'] != 'mosaic':
+            # Unsure about the following lines. The exception is not
+            # raised.
             msg_format = 'The {} for this feed is not a mosaic type.'
             click.ClickException(msg_format.format(type_))
             continue

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,7 @@ with open('planet/api/__version__.py') as f:
             continue
 
 
-test_requires = [
-    'mock',
-    'pytest',
-    'requests-mock',
-]
+test_requires = ['mock', 'pytest', 'pytz', 'requests-mock', 'tox']
 
 dev_requires = [
     'flake8',

--- a/tests/fixtures/feeds.json
+++ b/tests/fixtures/feeds.json
@@ -24,12 +24,12 @@
         "args": {},
         "namespace": "{{ .Namespace }}"
       },
-      "source": {
+      "source": [{
         "config": {
           "series_id": "mosaic_series_id"
         },
         "type": "mosaic"
-      },
+      }],
       "status": "active",
       "target": {
         "type": "collection"


### PR DESCRIPTION
The "target" type appears to have a single dict, but "source" type seems to give a list of dicts. API change or something else? I'm new to the project :smile: 