### PR TITLE
Change auth client base url to the api url

### DIFF
--- a/planet/auth.py
+++ b/planet/auth.py
@@ -26,7 +26,7 @@ from . import constants, http, models
 
 LOGGER = logging.getLogger(__name__)
 
-BASE_URL = constants.PLANET_BASE_URL
+BASE_URL = constants.PLANET_BASE_URL + 'v0/auth/'
 ENV_API_KEY = 'PL_API_KEY'
 SECRET_FILE_PATH = os.path.join(os.path.expanduser('~'), '.planet.json')
 
@@ -165,8 +165,6 @@ class AuthClient():
         if not self._base_url.endswith('/'):
             self._base_url += '/'
 
-        self._auth_url = self._base_url + 'v0/auth/'
-
     def login(
         self,
         email: str,
@@ -185,7 +183,7 @@ class AuthClient():
              A JSON object containing an `api_key` property with the user's
         API_KEY.
         '''
-        url = self._auth_url + 'login'
+        url = self._base_url + 'login'
         data = {'email': email,
                 'password': password
                 }

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Planet Labs, Inc.
+# Copyright 2021 Planet Labs, PBC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -24,14 +24,13 @@ from planet.auth import AuthClient
 
 
 TEST_URL = 'http://MockNotRealURL/'
-AUTH_URL = TEST_URL + 'v0/auth/'
 
 LOGGER = logging.getLogger(__name__)
 
 
 @respx.mock
 def test_AuthClient_success():
-    login_url = AUTH_URL + 'login'
+    login_url = TEST_URL + 'login'
 
     payload = {'api_key': 'iamakey'}
     resp = {'token': jwt.encode(payload, 'key')}
@@ -46,7 +45,7 @@ def test_AuthClient_success():
 
 @respx.mock
 def test_AuthClient_invalid_email():
-    login_url = AUTH_URL + 'login'
+    login_url = TEST_URL + 'login'
 
     resp = {
         "errors": {
@@ -69,7 +68,7 @@ def test_AuthClient_invalid_email():
 
 @respx.mock
 def test_AuthClient_invalid_password():
-    login_url = AUTH_URL + 'login'
+    login_url = TEST_URL + 'login'
 
     resp = {
         "errors": None,

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -1,0 +1,55 @@
+# Copyright 2022 Planet Labs, PBC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+import httpx
+import jwt
+import pytest
+import respx
+
+import planet
+from planet.cli import cli
+
+TEST_URL = 'http://MockNotRealURL/'
+
+
+@pytest.fixture(autouse=True)
+def patch_session(monkeypatch):
+    '''Make sure we don't actually make any http calls'''
+    monkeypatch.setattr(planet, 'Session', MagicMock(spec=planet.Session))
+
+
+@respx.mock
+@pytest.mark.asyncio
+def test_cli_auth_init_base_url():
+    '''Test base url option
+
+    Uses the auth init path to ensure the base url is changed to the mocked
+    url. So, ends up testing the auth init path somewhat as well
+    '''
+    login_url = TEST_URL + 'login'
+
+    payload = {'api_key': 'iamakey'}
+    resp = {'token': jwt.encode(payload, 'key')}
+    mock_resp = httpx.Response(HTTPStatus.OK, json=resp)
+    respx.post(login_url).return_value = mock_resp
+
+    result = CliRunner().invoke(
+        cli.main,
+        args=['auth', '--base-url', TEST_URL, 'init'],
+        input='email\npw\n')
+
+    assert not result.exception


### PR DESCRIPTION
Changes:
- change auth client base url to the api url instead of the planet services root url
- update auth api integration test to change in base url
- add integration test for auth cli that confirms base url is changed

Side effect:
- copyright planet labs inc to planet labs pbc


Closes #375 