### PR TITLE
Remove reported data from stdout for CLI

### DIFF
--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -118,12 +118,11 @@ async def download(ctx, order_id, quiet, overwrite, dest):
         with planet.reporting.StateBar(order_id=order_id,
                                        disable=quiet) as bar:
             await cl.poll(str(order_id), report=bar.update)
-            filenames = await cl.download_order(
+            _ = await cl.download_order(
                     str(order_id),
                     directory=dest,
                     overwrite=overwrite,
                     progress_bar=not quiet)
-    click.echo(f'Downloaded {len(filenames)} files.')
 
 
 def split_id_list(ctx, param, value):

--- a/tests/unit/test_cli_orders.py
+++ b/tests/unit/test_cli_orders.py
@@ -89,8 +89,8 @@ def test_cli_orders_download(runner, patch_ordersclient, oid):
         return
     patch_ordersclient('poll', poll)
 
-    # Number of files in all_test_files
-    expected = 'Downloaded 4 files.\n'
+    # Download should not report anything
+    expected = ''
 
     # allow for some progress reporting
     result = runner.invoke(


### PR DESCRIPTION
**Overview:**
- Previously, the CLI would report the number of files in an order.
- Now, the CLI remains silent in stdout upon a download request. 

**Work done:**
1) Removed `click.echo(f'Downloaded {len(filenames)} files.')` in `planet.cli.orders.download()`, which reported the number of files in an order. The filenames are still communicated in `body.write()` in `models.py` in `LOGGER.debug()` and `LOGGER.info()`.
2) Updated the CLI's test in `tests.unit.test_cli_orders.test_cli_orders_download()` to no longer expect anything communicated to stdout.

Closes #386 