### PR TITLE
orders client URL generation bugfix

### DIFF
--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -26,7 +26,7 @@ from ..http import Session
 from ..models import Order, Orders, Request, Response, StreamingBody
 
 
-BASE_URL = f'{PLANET_BASE_URL}compute/ops'
+BASE_URL = f'{PLANET_BASE_URL}/compute/ops'
 STATS_PATH = '/stats/orders/v2'
 ORDERS_PATH = '/orders/v2'
 BULK_PATH = '/bulk/orders/v2'


### PR DESCRIPTION
The orders client was creating the api base url improperly (lost a slash) which caused the orders-related SDK functionality to fail. Slash added and it's working again!