### PR TITLE
Rename poll to wait, separate wait and download in cli

### DIFF
--- a/examples/orders_create_and_download_multiple_orders.py
+++ b/examples/orders_create_and_download_multiple_orders.py
@@ -75,8 +75,8 @@ async def create_and_download(order_detail, directory, client):
         order = await client.create_order(order_detail)
         reporter.update(state='created', order_id=order.id)
 
-        # poll
-        await client.poll(order.id, report=reporter.update)
+        # wait for completion
+        await client.wait(order.id, report=reporter.update_state)
 
     # download
     await client.download_order(order.id, progress_bar=True)

--- a/planet/cli/cmds.py
+++ b/planet/cli/cmds.py
@@ -52,10 +52,10 @@ def translate_exceptions(func):
     def wrapper(*args, **kwargs):
         try:
             func(*args, **kwargs)
-        except exceptions.APIException as ex:
-            raise click.ClickException(ex)
         except exceptions.AuthException:
             raise click.ClickException(
                 'Auth information does not exist or is corrupted. Initialize '
                 'with `planet auth init`.')
+        except exceptions.PlanetException as ex:
+            raise click.ClickException(ex)
     return wrapper

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -158,7 +158,7 @@ async def wait(ctx, order_id, delay, max_attempts, quiet, state):
                                   state=state,
                                   delay=delay,
                                   max_attempts=max_attempts,
-                                  report=bar.update_state)
+                                  callback=bar.update_state)
     click.echo(state)
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -55,7 +55,7 @@ def orders(ctx, base_url):
 @coro
 @click.option('-s', '--state',
               help='Filter orders to given state.',
-              type=click.Choice(planet.clients.orders.ORDERS_STATES,
+              type=click.Choice(planet.clients.orders.ORDERS_STATES_ALL,
                                 case_sensitive=False))
 @click.option('-l', '--limit', help='Filter orders to given limit.',
               default=None, type=int)

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -123,11 +123,17 @@ def split_list_arg(ctx, param, value):
 @translate_exceptions
 @coro
 @click.argument('order_id', type=click.UUID)
-@click.option('--delay', type=int, default=5,
+@click.option('--delay',
+              type=int,
+              default=5,
               help='Time (in seconds) between polls.')
-@click.option('--max-attempts', type=int, default=5,
+@click.option('--max-attempts',
+              type=int,
+              default=5,
               help='Maximum number of polls. Set to zero for no limit.')
-@click.option('--quiet', is_flag=True, default=False,
+@click.option('--quiet',
+              is_flag=True,
+              default=False,
               help='Disable ANSI control output.')
 @click.option('--state',
               help='State prior to a final state that will end polling.',
@@ -171,9 +177,15 @@ async def wait(ctx, order_id, delay, max_attempts, quiet, state):
 @translate_exceptions
 @coro
 @click.argument('order_id', type=click.UUID)
-@click.option('-q', '--quiet', is_flag=True, default=False,
+@click.option('-q',
+              '--quiet',
+              is_flag=True,
+              default=False,
               help='Disable ANSI control output.')
-@click.option('-o', '--overwrite', is_flag=True, default=False,
+@click.option('-o',
+              '--overwrite',
+              is_flag=True,
+              default=False,
               help=('Overwrite files if they already exist.'))
 @click.option('--dest',
               default='.',
@@ -220,8 +232,12 @@ def read_file_json(ctx, param, value):
 @translate_exceptions
 @coro
 @click.option('--name', required=True)
-@click.option('--id', 'ids', help='One or more comma-separated item IDs',
-              type=click.STRING, callback=split_list_arg, required=True)
+@click.option('--id',
+              'ids',
+              help='One or more comma-separated item IDs',
+              type=click.STRING,
+              callback=split_list_arg,
+              required=True)
 # @click.option('--ids_from_search',
 #               help='Embedded data search')
 @click.option(

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -126,7 +126,7 @@ def split_list_arg(ctx, param, value):
 @click.option('--quiet', is_flag=True, default=False,
               help='Disable ANSI control output.')
 @click.option('--state',
-              help='State prior to a completed state that will end polling.',
+              help='State prior to a final state that will end polling.',
               type=click.Choice(planet.clients.orders.ORDER_STATE_SEQUENCE,
                                 case_sensitive=False))
 async def wait(ctx, order_id, delay, max_attempts, quiet, state):
@@ -136,7 +136,7 @@ async def wait(ctx, order_id, delay, max_attempts, quiet, state):
 
     This function polls the Orders API to determine the order state, with
     the specified delay between each polling attempt, until the
-    order reaches a completed state, or earlier state, if specified.
+    order reaches a final state or earlier state, if specified.
     If the maximum number of attempts is reached before polling is
     complete, an exception is raised. Setting --max-attempts to zero will
     result in no limit on the number of attempts.
@@ -147,7 +147,7 @@ async def wait(ctx, order_id, delay, max_attempts, quiet, state):
     polled asynchronously, consider increasing the delay to avoid
     throttling.
 
-    By default, polling completes when the order reaches a completed state.
+    By default, polling completes when the order reaches a final state.
     If --state is specified, polling will complete when the specified earlier
     state is reached or passed.
     """

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -25,7 +25,6 @@ from ..constants import PLANET_BASE_URL
 from ..http import Session
 from ..models import Order, Orders, Request, Response, StreamingBody
 
-
 BASE_URL = f'{PLANET_BASE_URL}/compute/ops'
 STATS_PATH = '/stats/orders/v2'
 ORDERS_PATH = '/orders/v2'
@@ -339,7 +338,7 @@ class OrdersClient():
 
         Raises:
             planet.exceptions.APIException: On API error.
-            planet.exceptions.ClientError: If the order is not in a completed
+            planet.exceptions.ClientError: If the order is not in a final
                 state.
         """
         order = await self.get_order(order_id)
@@ -352,23 +351,23 @@ class OrdersClient():
 
         locations = order.locations
         LOGGER.info(
-            f'downloading {len(locations)} assets from order {order_id}'
-        )
-        filenames = [await self.download_asset(location,
-                                               directory=directory,
-                                               overwrite=overwrite,
-                                               progress_bar=progress_bar)
-                     for location in locations]
+            f'downloading {len(locations)} assets from order {order_id}')
+
+        filenames = [
+            await self.download_asset(location,
+                                      directory=directory,
+                                      overwrite=overwrite,
+                                      progress_bar=progress_bar)
+            for location in locations
+        ]
         return filenames
 
-    async def wait(
-        self,
-        order_id: str,
-        state: str = None,
-        delay: int = 5,
-        max_attempts: int = 200,
-        callback: typing.Callable[[str], None] = None
-    ) -> str:
+    async def wait(self,
+                   order_id: str,
+                   state: str = None,
+                   delay: int = 5,
+                   max_attempts: int = 200,
+                   callback: typing.Callable[[str], None] = None) -> str:
         """Wait until order reaches desired state.
 
         Returns the state of the order on the last poll.
@@ -436,7 +435,7 @@ class OrdersClient():
                     (state and OrderStates.reached(state, current_state)):
                 break
 
-            sleep_time = max(delay-(time.time()-t), 0)
+            sleep_time = max(delay - (time.time() - t), 0)
             LOGGER.debug(f'sleeping {sleep_time}s')
             await asyncio.sleep(sleep_time)
 
@@ -449,11 +448,10 @@ class OrdersClient():
         return current_state
 
     async def list_orders(
-        self,
-        state: str = None,
-        limit: int = None,
-        as_json: bool = False
-    ) -> typing.Union[typing.List[Order], dict]:
+            self,
+            state: str = None,
+            limit: int = None,
+            as_json: bool = False) -> typing.Union[typing.List[Order], dict]:
         """Get all order requests.
 
         Parameters:

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -363,7 +363,7 @@ class OrdersClient():
         state: str = None,
         delay: int = 5,
         max_attempts: int = 200,
-        report: typing.Callable[[str], None] = None
+        callback: typing.Callable[[str], None] = None
     ) -> str:
         """Wait until order reaches desired state.
 
@@ -425,8 +425,8 @@ class OrdersClient():
 
             LOGGER.debug(state)
 
-            if report:
-                report(order.state)
+            if callback:
+                callback(order.state)
 
             if OrderStates.passed('running', current_state) or \
                     (state and OrderStates.reached(state, current_state)):

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -341,9 +341,9 @@ class OrdersClient():
         order = await self.get_order(order_id)
         if not OrderStates.passed('running', order.state):
             raise exceptions.ClientError(
-                order.state,
-                'Order cannot be downloaded because the order is not in a '
-                'completed state. Consider using wait functionality before '
+                'Order cannot be downloaded because the order state '
+                f'({order.state}) is not a completed state. '
+                'Consider using wait functionality before '
                 'attempting to download.')
 
         locations = order.locations
@@ -366,6 +366,8 @@ class OrdersClient():
         report: typing.Callable[[str], None] = None
     ) -> str:
         """Wait until order reaches desired state.
+
+        Returns the state of the order on the last poll.
 
         This function polls the Orders API to determine the order state, with
         the specified delay between each polling attempt, until the

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -380,9 +380,10 @@ class OrdersClient():
 
         Parameters:
             order_id: The ID of the order
-            states: Order states that will end polling.
+            states: Order states that will end polling. Defaults to all
+                completed states.
             delay: Time (in seconds) between polls.
-            max_attempts: Maximum number of polls.
+            max_attempts: Maximum number of polls. Set to zero for no limit.
             report: Callback function for reporting progress updates.
 
         Returns

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -70,36 +70,16 @@ class InvalidIdentity(APIException):
     pass
 
 
-class RequestCancelled(PlanetException):
-    '''Internal exception when a request is cancelled'''
+class ClientError(PlanetException):
+    """Exceptions thrown client-side"""
     pass
 
 
-class AuthException(PlanetException):
+class AuthException(ClientError):
     '''Exceptions encountered during authentication'''
     pass
 
 
-class OrdersClientError(PlanetException):
-    """Exceptions thrown by OrdersClient"""
+class RequestCancelled(ClientError):
+    '''Internal exception when a request is cancelled'''
     pass
-
-
-class ValueError(PlanetException, ValueError):
-    """Planet ValueError"""
-    pass
-
-
-class MaxAttemptsError(PlanetException):
-    """Maximum number of attempts was reached."""
-    def __init__(self, max_num):
-        message = f'Maximum number of attempts ({max_num}) reached.'
-        super().__init__(message)
-
-
-class StateError(PlanetException):
-    """Resource is not in the right state for operation."""
-    def __init__(self, state, message=''):
-        self.state = state
-        msg = f'Invalid state ({state}) for operation. {message}'
-        super().__init__(msg)

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -93,5 +93,13 @@ class ValueError(PlanetException, ValueError):
 class MaxAttemptsError(PlanetException):
     """Maximum number of attempts was reached."""
     def __init__(self, max_num):
-        self.message = f'Maximum number of attempts ({max_num}) reached.'
-        super().__init__(self.message)
+        message = f'Maximum number of attempts ({max_num}) reached.'
+        super().__init__(message)
+
+
+class StateError(PlanetException):
+    """Resource is not in the right state for operation."""
+    def __init__(self, state, message=''):
+        self.state = state
+        msg = f'Invalid state ({state}) for operation. {message}'
+        super().__init__(msg)

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -78,3 +78,20 @@ class RequestCancelled(PlanetException):
 class AuthException(PlanetException):
     '''Exceptions encountered during authentication'''
     pass
+
+
+class OrdersClientError(PlanetException):
+    """Exceptions thrown by OrdersClient"""
+    pass
+
+
+class ValueError(PlanetException, ValueError):
+    """Planet ValueError"""
+    pass
+
+
+class MaxAttemptsError(PlanetException):
+    """Maximum number of attempts was reached."""
+    def __init__(self, max_num):
+        self.message = f'Maximum number of attempts ({max_num}) reached.'
+        super().__init__(self.message)

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -83,19 +83,11 @@ class StateBar(ProgressBar):
     def desc(self):
         return f'order {self.order_id}'
 
-<<<<<<< HEAD
     def update_state(self, state: str):
         """Simple function to be used as a callback for state reporting"""
         self.update(state=state)
 
-    def update(
-        self,
-        state: str = None,
-        order_id: str = None
-    ):
-=======
     def update(self, state: str = None, order_id: str = None):
->>>>>>> v2
         if state:
             self.state = state
             try:

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -83,14 +83,16 @@ class StateBar(ProgressBar):
     def desc(self):
         return f'order {self.order_id}'
 
+    def update_state(self, state: str):
+        """Simple function to be used as a callback for state reporting"""
+        self.update(state=state)
+
     def update(
         self,
         state: str = None,
         order_id: str = None
     ):
         if state:
-            if state != self.state:
-                LOGGER.info('{order_id} state: {state}')
             self.state = state
             self.bar.postfix[1] = self.state
 
@@ -99,5 +101,3 @@ class StateBar(ProgressBar):
             self.bar.set_description_str(self.desc, refresh=False)
 
         self.bar.refresh()
-
-        LOGGER.debug(str(self.bar))

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -92,7 +92,6 @@ class StateBar(ProgressBar):
         state: str = None,
         order_id: str = None
     ):
-        # if not self.disable:
         if state:
             self.state = state
             try:

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -92,9 +92,15 @@ class StateBar(ProgressBar):
         state: str = None,
         order_id: str = None
     ):
+        # if not self.disable:
         if state:
             self.state = state
-            self.bar.postfix[1] = self.state
+            try:
+                self.bar.postfix[1] = self.state
+            except AttributeError:
+                # If the bar is disabled, attempting to access self.bar.postfix
+                # will result in an error. In this case, just skip it.
+                pass
 
         if order_id:
             self.order_id = order_id

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -149,7 +149,7 @@ async def test_list_orders_state(order_descriptions, session):
 async def test_list_orders_state_invalid_state(session):
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         await cl.list_orders(state='invalidstate')
 
 
@@ -288,7 +288,7 @@ async def test_get_order(oid, order_description, session):
 @pytest.mark.asyncio
 async def test_get_order_invalid_id(session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         await cl.get_order('-')
 
 
@@ -328,7 +328,7 @@ async def test_cancel_order(oid, order_description, session):
 @pytest.mark.asyncio
 async def test_cancel_order_invalid_id(session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         await cl.cancel_order('invalid_order_id')
 
 
@@ -407,7 +407,7 @@ async def test_cancel_orders_by_ids(session, oid):
 @pytest.mark.asyncio
 async def test_cancel_orders_by_ids_invalid_id(session, oid):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         _ = await cl.cancel_orders([oid, "invalid_oid"])
 
 
@@ -518,7 +518,7 @@ async def test_wait_max_attempts_enabled(oid, order_description, session):
     ]
 
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.MaxAttemptsError):
+    with pytest.raises(exceptions.ClientError):
         await cl.wait(oid, max_attempts=1, delay=0)
 
 
@@ -541,14 +541,14 @@ async def test_wait_max_attempts_disabled(oid, order_description, session):
 @pytest.mark.asyncio
 async def test_wait_invalid_oid(session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         await cl.wait("invalid_oid", delay=0)
 
 
 @pytest.mark.asyncio
 async def test_wait_invalid_state(oid, session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ValueError):
+    with pytest.raises(exceptions.ClientError):
         await cl.wait(oid, state="invalid_state", delay=0)
 
 
@@ -694,7 +694,7 @@ async def test_download_order_state(
     respx.get(get_url).return_value = mock_resp
 
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.StateError):
+    with pytest.raises(exceptions.ClientError):
         await cl.download_order(oid, directory=str(tmpdir))
 
 

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -459,7 +459,7 @@ async def test_wait_default(oid, order_description, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_wait_reporter(oid, order_description, session):
+async def test_wait_callback(oid, order_description, session):
     get_url = f'{TEST_ORDERS_URL}/{oid}'
 
     order_description2 = copy.deepcopy(order_description)
@@ -475,14 +475,14 @@ async def test_wait_reporter(oid, order_description, session):
     ]
 
     mock_bar = create_autospec(reporting.StateBar)
-    mock_report = mock_bar.update_state
+    mock_callback = mock_bar.update_state
 
     cl = OrdersClient(session, base_url=TEST_URL)
-    await cl.wait(oid, delay=0, report=mock_report)
+    await cl.wait(oid, delay=0, callback=mock_callback)
 
-    # check state was sent to reporter as expected
+    # check state was sent to callback as expected
     expected = [call(s) for s in ['queued', 'running', 'success']]
-    mock_report.assert_has_calls(expected)
+    mock_callback.assert_has_calls(expected)
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -664,11 +664,12 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_download_order_state(
-        tmpdir, order_description, oid, session):
+async def test_download_order_state(tmpdir, order_description, oid, session):
     dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
     order_description['_links']['results'] = [
-        {'location': dl_url1},
+        {
+            'location': dl_url1
+        },
     ]
 
     get_url = f'{TEST_ORDERS_URL}/{oid}'

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -24,8 +24,7 @@ import httpx
 import pytest
 import respx
 
-from planet import OrdersClient, clients, exceptions, reporting
-# from planet.clients.orders import BULK_PATH, ORDERS_PATH, STATS_PATH
+from planet import OrdersClient, exceptions, reporting
 
 TEST_URL = 'http://www.MockNotRealURL.com/api/path'
 TEST_BULK_CANCEL_URL = f'{TEST_URL}/bulk/orders/v2/cancel'
@@ -136,8 +135,8 @@ async def test_list_orders_state(order_descriptions, session):
 async def test_list_orders_state_invalid_state(session):
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    with pytest.raises(clients.orders.OrdersClientException):
-        _ = await cl.list_orders(state='invalidstate')
+    with pytest.raises(exceptions.ValueError):
+        await cl.list_orders(state='invalidstate')
 
 
 @respx.mock
@@ -275,8 +274,8 @@ async def test_get_order(oid, order_description, session):
 @pytest.mark.asyncio
 async def test_get_order_invalid_id(session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(clients.orders.OrdersClientException):
-        _ = await cl.get_order('-')
+    with pytest.raises(exceptions.ValueError):
+        await cl.get_order('-')
 
 
 @respx.mock
@@ -315,8 +314,8 @@ async def test_cancel_order(oid, order_description, session):
 @pytest.mark.asyncio
 async def test_cancel_order_invalid_id(session):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(clients.orders.OrdersClientException):
-        _ = await cl.cancel_order('invalid_order_id')
+    with pytest.raises(exceptions.ValueError):
+        await cl.cancel_order('invalid_order_id')
 
 
 @respx.mock
@@ -394,7 +393,7 @@ async def test_cancel_orders_by_ids(session, oid):
 @pytest.mark.asyncio
 async def test_cancel_orders_by_ids_invalid_id(session, oid):
     cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(clients.orders.OrdersClientException):
+    with pytest.raises(exceptions.ValueError):
         _ = await cl.cancel_orders([oid, "invalid_oid"])
 
 

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -378,7 +378,7 @@ def test_cli_orders_download_state(invoke, order_description, oid):
     result = invoke(['download', oid], runner=runner)
 
     assert result.exception
-    assert 'Invalid state (running) for operation.' in result.output
+    assert 'order state (running) is not a completed state.' in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -221,9 +221,7 @@ def test_cli_orders_wait_max_attempts(invoke, order_description, oid):
     order_description3['state'] = 'success'
 
     route = respx.get(get_url)
-    route.side_effect = [
-        httpx.Response(HTTPStatus.OK, json=order_description)
-    ]
+    route.side_effect = [httpx.Response(HTTPStatus.OK, json=order_description)]
 
     runner = CliRunner()
     result = invoke(['wait', '--delay', '0', '--max-attempts', '1', oid],
@@ -240,9 +238,7 @@ def test_cli_orders_wait_quiet(invoke, order_description, oid):
     order_description['state'] = 'success'
 
     route = respx.get(get_url)
-    route.side_effect = [
-        httpx.Response(HTTPStatus.OK, json=order_description)
-    ]
+    route.side_effect = [httpx.Response(HTTPStatus.OK, json=order_description)]
 
     runner = CliRunner()
     result = invoke(['wait', '--delay', '0', '--quiet', oid], runner=runner)
@@ -427,11 +423,15 @@ def test_cli_orders_create_basic_item_type_invalid(invoke):
 def test_cli_orders_create_id_empty(invoke):
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile'
-        ])
+        '--name',
+        'test',
+        '--id',
+        '',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile'
+    ])
     assert result.exit_code
     assert 'Entry cannot be an empty string.' in result.output
 

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -378,7 +378,7 @@ def test_cli_orders_download_state(invoke, order_description, oid):
     result = invoke(['download', oid], runner=runner)
 
     assert result.exception
-    assert 'order state (running) is not a completed state.' in result.output
+    assert 'order state (running) is not a final state.' in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -12,11 +12,13 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 '''Test Orders CLI'''
+import copy
 from http import HTTPStatus
 import json
 from pathlib import Path
 from unittest.mock import Mock
 
+import click
 from click.testing import CliRunner
 import httpx
 import pytest
@@ -39,6 +41,15 @@ def invoke():
         args = ['orders', '--base-url', TEST_URL] + extra_args
         return runner.invoke(cli.main, args=args)
     return _invoke
+
+
+def test_split_list_arg_empty_string():
+    with pytest.raises(click.exceptions.BadParameter):
+        cli.orders.split_list_arg(None, None, '')
+
+
+def test_split_list_arg_None():
+    assert cli.orders.split_list_arg(None, None, None) is None
 
 
 @respx.mock
@@ -192,10 +203,68 @@ def test_cli_orders_cancel_id_not_found(invoke, oid):
     assert 'Error: A descriptive error message\n' == result.output
 
 
+@respx.mock
+def test_cli_orders_wait_default(invoke, order_description, oid):
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+
+    order_description2 = copy.deepcopy(order_description)
+    order_description2['state'] = 'success'
+
+    route = respx.get(get_url)
+    route.side_effect = [
+        httpx.Response(HTTPStatus.OK, json=order_description),
+        httpx.Response(HTTPStatus.OK, json=order_description2)
+    ]
+
+    runner = CliRunner()
+    result = invoke(['wait', '--delay', '0', oid], runner=runner)
+    assert not result.exception
+    assert result.output.endswith('success\n')
+
+
+@respx.mock
+def test_cli_orders_wait_max_attempts(invoke, order_description, oid):
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+
+    order_description2 = copy.deepcopy(order_description)
+    order_description2['state'] = 'running'
+    order_description3 = copy.deepcopy(order_description)
+    order_description3['state'] = 'success'
+
+    route = respx.get(get_url)
+    route.side_effect = [
+        httpx.Response(HTTPStatus.OK, json=order_description)
+    ]
+
+    runner = CliRunner()
+    result = invoke(['wait', '--delay', '0', '--max-attempts', '1', oid],
+                    runner=runner)
+    assert result.exception
+    assert result.output.endswith(
+        'Error: Maximum number of attempts (1) reached.\n')
+
+
+@respx.mock
+def test_cli_orders_wait_quiet(invoke, order_description, oid):
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+
+    order_description['state'] = 'success'
+
+    route = respx.get(get_url)
+    route.side_effect = [
+        httpx.Response(HTTPStatus.OK, json=order_description)
+    ]
+
+    runner = CliRunner()
+    result = invoke(['wait', '--delay', '0', '--quiet', oid], runner=runner)
+    assert not result.exception
+    assert result.output == 'success\n'
+
+
 @pytest.fixture
 def mock_download_response(oid, order_description):
     def _func():
-        # Mock an HTTP response for polling and download
+        # Mock an HTTP response for download
         order_description['state'] = 'success'
         dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
         dl_url2 = TEST_DOWNLOAD_URL + '/2?token=IAmAnotherToken'
@@ -229,7 +298,7 @@ def mock_download_response(oid, order_description):
 
 
 @respx.mock
-def test_cli_orders_download(invoke, mock_download_response, oid):
+def test_cli_orders_download_default(invoke, mock_download_response, oid):
     mock_download_response()
 
     runner = CliRunner()
@@ -237,8 +306,8 @@ def test_cli_orders_download(invoke, mock_download_response, oid):
         result = invoke(['download', oid], runner=runner)
         assert not result.exception
 
-        # no message, output is only progress reporting
-        assert result.output.startswith('\r00:00 - order')
+        # basic check of progress reporting
+        assert 'm1.json' in result.output
 
         # Check that the files were downloaded and have the correct contents
         f1_path = Path(folder) / 'm1.json'
@@ -287,19 +356,29 @@ def test_cli_orders_download_overwrite(
         assert json.load(open(filepath)) == {'key': 'value'}
 
 
-@pytest.mark.skip('https://github.com/planetlabs/planet-client-python/issues/352') # noqa
 @respx.mock
 def test_cli_orders_download_quiet(invoke, mock_download_response, oid):
     mock_download_response()
 
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = invoke(['download', '-q', oid], runner=runner)
+        result = invoke(['download', '--quiet', oid], runner=runner)
         assert not result.exception
 
-        # no progress reporting, just the message
-        message = 'Downloaded 2 files.\n'
-        assert message == result.output
+
+@respx.mock
+def test_cli_orders_download_state(invoke, order_description, oid):
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+
+    order_description['state'] = 'running'
+    mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
+    respx.get(get_url).return_value = mock_resp
+
+    runner = CliRunner()
+    result = invoke(['download', oid], runner=runner)
+
+    assert result.exception
+    assert 'Invalid state (running) for operation.' in result.output
 
 
 @pytest.mark.parametrize(
@@ -354,10 +433,10 @@ def test_cli_orders_create_id_empty(invoke):
         '--name', 'test',
         '--id', '',
         '--bundle', 'analytic',
-        '--item-type', 'invalid'
+        '--item-type', 'PSOrthoTile'
         ])
     assert result.exit_code
-    assert 'id cannot be empty string.' in result.output
+    assert 'Entry cannot be an empty string.' in result.output
 
 
 @respx.mock

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -39,6 +39,9 @@ def test_StateBar___init___disabled():
     with reporting.StateBar(disable=True) as bar:
         assert bar.bar.disable
 
+        # just make sure this doesn't error out
+        bar.update(order_id='1', state='init')
+
 
 def test_StateBar_update():
     with reporting.StateBar() as bar:

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -32,7 +32,7 @@ def test_StateBar___init___default():
 def test_StateBar___init___stateandorder():
     with reporting.StateBar(order_id='1', state='init') as bar:
         expected_init = '..:.. - order 1 - state: init'
-        assert(re.fullmatch(expected_init, str(bar)))
+        assert (re.fullmatch(expected_init, str(bar)))
 
 
 def test_StateBar___init___disabled():
@@ -47,11 +47,11 @@ def test_StateBar_update():
     with reporting.StateBar() as bar:
         expected_update = '..:.. - order 1 - state: init'
         bar.update(order_id='1', state='init')
-        assert(re.fullmatch(expected_update, str(bar)))
+        assert (re.fullmatch(expected_update, str(bar)))
 
 
 def test_StateBar_update_state():
     with reporting.StateBar() as bar:
         expected_update = '..:.. - order  - state: init'
         bar.update_state('init')
-        assert(re.fullmatch(expected_update, str(bar)))
+        assert (re.fullmatch(expected_update, str(bar)))

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -19,7 +19,7 @@ from planet import reporting
 LOGGER = logging.getLogger(__name__)
 
 
-def test_StateBar_enabled():
+def test_StateBar___init___default():
     with reporting.StateBar() as bar:
         expected_init = '..:.. - order  - state: '
         assert(re.fullmatch(expected_init, str(bar)))
@@ -29,6 +29,26 @@ def test_StateBar_enabled():
         assert(re.fullmatch(expected_update, str(bar)))
 
 
-def test_StateBar_disabled():
+def test_StateBar___init___stateandorder():
+    with reporting.StateBar(order_id='1', state='init') as bar:
+        expected_init = '..:.. - order 1 - state: init'
+        assert(re.fullmatch(expected_init, str(bar)))
+
+
+def test_StateBar___init___disabled():
     with reporting.StateBar(disable=True) as bar:
         assert bar.bar.disable
+
+
+def test_StateBar_update():
+    with reporting.StateBar() as bar:
+        expected_update = '..:.. - order 1 - state: init'
+        bar.update(order_id='1', state='init')
+        assert(re.fullmatch(expected_update, str(bar)))
+
+
+def test_StateBar_update_state():
+    with reporting.StateBar() as bar:
+        expected_update = '..:.. - order  - state: init'
+        bar.update_state('init')
+        assert(re.fullmatch(expected_update, str(bar)))


### PR DESCRIPTION
This PR implements the following:
- rename `OrdersClient.poll()` to `OrdersClient.wait()`
- in `OrdersClient.wait()`, add `max-attempts` parameter and rename `wait` parameter to `delay`.
- `OrdersClient.wait()` now checks if a specified state has been reached **or passed**. This requires introducing the concept of state sequence and is handled with `orders.ORDER_STATE_SEQUENCE` and `orders.OrderStates`
- in `OrdersClient.wait()`, `report` parameter renamed to `callback`. `callback` no longer takes a keyword argument, state is a required positional argument.  Add `update()` function to `reporting.StateReporter` that fits this pattern.
- add new `planet orders wait` cli command and remove polling/waiting from `planet orders download`
- fix bug in `reporting.StateReporter` when bar is disabled
- all exceptions are either `APIException` or `ClientError`

Closes #381 and #352 