### PR TITLE
add yapf linting with one modifier

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,2 @@
+# do not lint hidden directories
+.*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,13 @@
-# Development
+# Contributing
 
-For development, installing all Python versions supported by this repo is
-recommended. One way of achieving this is with
-[pyenv](https://github.com/pyenv/pyenv).
+Thank you for your interest in contributing to the Planet SDK for Python! This
+document explains how to contribute successfully.
 
-[Nox](https://nox.thea.codes/) is used to automate all checks and build
-documentation. Nox manages virtual environments for you, specifying Python
-versions and installing the the local, dynamic version of the Planet Python
-Client and required development packages.
+## Tools
 
-Where Nox is not used, a virtual environment is highly recommended.
-[pyenvwrapper](https://github.com/pyenv/pyenv-virtualenv) manages virtual
-environments and works well with pyenv. To install the local, dynamic version
-of the Planet Python Client and required development packages into the virtual
-environment use:
-
-- Bash
-```console
-    $ pip install -e .[dev]
-```
-- Zsh
-```console
-    $ pip install -e .'[dev]'
-```
-
-## Testing
-
-[Nox](https://nox.thea.codes/) automates all testing and linting. By default,
-Nox runs all fast tests and lints the code.
+This repository uses two primary tools for development:
+* [Nox](https://nox.thea.codes/) to automate testing
+* [YAPF](https://github.com/google/yapf) to enforce style guidelines
 
 Install Nox in your local dev environment:
 
@@ -35,17 +15,125 @@ Install Nox in your local dev environment:
     $ pip install nox
 ```
 
-Run nox:
+Install YAPF in your local dev environment:
+
+```console
+    $ pip install yapf
+```
+
+### Nox
+
+In this repository, Nox is used to automate testing, linting, and to build
+documentation. Nox manages virtual environments for you, specifying Python
+versions and installing the the local, dynamic version of the Plant SDK for
+Python and required development packages.
+
+Run Nox:
 
 ```console
     $ nox
 ```
 
-This will run tests against multiple Python versions and will lint the code.
+If no changes have been made to the Nox environment since it was last run,
+speed up the run by reusing the environment:
+
+```console
+    $ nox -r
+```
+
+The configuration for Nox is given in `noxfile.py`. See the Nox link above for
+advanced usage.
+
+##### Alternative to Nox
+Nox is the recommended way to manage local testing. With Nox it is not necessary
+to install the Planet SDK for Python on the local machine for testing.
+However, Nox is not necessary for local testing. Where Nox is not used, a
+virtual environment is highly recommended.
+[pyenvwrapper](https://github.com/pyenv/pyenv-virtualenv) manages virtual
+environments and works well with pyenv. To install the local, dynamic version
+of the Planet SDK for Python and required development packages into the virtual
+environment use:
+
+```console
+    $ pip install -e .[dev]
+```
+
+### YAPF
+
+Code in this repository follows the
+[PEP8](https://www.python.org/dev/peps/pep-0008/) style guide and uses
+[YAPF](https://github.com/google/yapf) to enforce and automate formatting.
+Linting in Nox will fail if YAPF would reformat a portion of the code.
+Helpfully, YAPF can be used to automatically reformat the code for you so you
+don't have to worry about formatting issues. WIN!
+
+To see how YAPF would reformat a file:
+
+```console
+    $ yapf --diff [file]
+```
+
+To reformat the file:
+
+```console
+    $ yapf --in-place [file]
+```
+
+The configuration for YAPF is given in `setup.cfg` and `.yapfignore`.
+See the YAPF link above for advanced usage.
+
+##### Alternative to YAPF
+
+YAPF is not required to follow the style and formatting guidelines. You can
+perform all formatting on your own using the linting output as a guild. Painful,
+maybe, but possible!
+
+## Testing
+
+When a Pull Request (PR) is created, the Continuous Integration (CI) runs all
+tests with Nox on all supported versions of Python. Before a PR can be
+considered, all tests must pass. To minimize the feedback loop, we recommend
+running Nox on your local machine. By default, Nox runs all fast tests and
+lints the code.
+
+Installing all supported Python versions locally is recommended. This allows
+Nox to fully reproduce the CI tests.
+One way of achieving this is with [pyenv](https://github.com/pyenv/pyenv).
 If a specific Python version isn't available on your development machine,
-Nox will just skip that version. While that version is skipped for local tests,
-the tests will be run on all versions with Continuous Integration (CI) when a
-pull request is initiated on the repository.
+Nox will just skip that version in the local tests.
+
+Testing is performed with [pytest](https://docs.pytest.org/) and
+[pytest-cov](https://pytest-cov.readthedocs.io/). The configuration for these
+packages is given in `setup.cfg`.
+
+Command-line arguments can be passed to pytest within Nox. For example, to only
+run the tests on a certain file, use:
+
+```console
+    $ nox -- [file]
+```
+
+By default, Nox runs tests on all supported Python versions along with linting.
+However, Nox can run a test on a single Python version, as well.
+
+To run tests on python 3.7:
+
+```console
+    $ nox -s test-3.7
+```
+
+## Linting
+
+In addition to running tests, the CI also lints the code. Again, this is done
+using Nox. Linting is performed using [flake8](https://flake8.pycqa.org/)
+and YAPF (mentioned above). By default, Nox runs tests along with linting.
+However, Nox can run linting alone.
+
+To run linting:
+
+```console
+    $ nox -s lint
+```
 
 ### Testing Documentation
 
@@ -83,7 +171,6 @@ To test the examples, run the Nox `examples` session:
 ```console
     $ nox -s examples
 ```
-
 
 This will test all scripts within the `examples` directory.
 To only test one script:

--- a/examples/orders_create_and_download_multiple_orders.py
+++ b/examples/orders_create_and_download_multiple_orders.py
@@ -11,7 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-
 """Example of creating and downloading multiple orders.
 
 This is an example of submitting two orders, waiting for them to complete, and
@@ -29,44 +28,32 @@ import planet
 DOWNLOAD_DIR = os.getenv('TEST_DOWNLOAD_DIR', '.')
 
 iowa_aoi = {
-    "type": "Polygon",
-    "coordinates": [[
-        [-91.198465, 42.893071],
-        [-91.121931, 42.893071],
-        [-91.121931, 42.946205],
-        [-91.198465, 42.946205],
-        [-91.198465, 42.893071]]]
+    "type":
+    "Polygon",
+    "coordinates": [[[-91.198465, 42.893071], [-91.121931, 42.893071],
+                     [-91.121931, 42.946205], [-91.198465, 42.946205],
+                     [-91.198465, 42.893071]]]
 }
 
-iowa_images = [
-    '20200925_161029_69_2223',
-    '20200925_161027_48_2223'
-]
+iowa_images = ['20200925_161029_69_2223', '20200925_161027_48_2223']
 iowa_order = planet.order_request.build_request(
     'iowa_order',
     [planet.order_request.product(iowa_images, 'analytic', 'PSScene4Band')],
-    tools=[planet.order_request.clip_tool(iowa_aoi)]
-)
+    tools=[planet.order_request.clip_tool(iowa_aoi)])
 
 oregon_aoi = {
-    "type": "Polygon",
-    "coordinates": [[
-        [-117.558734, 45.229745],
-        [-117.452447, 45.229745],
-        [-117.452447, 45.301865],
-        [-117.558734, 45.301865],
-        [-117.558734, 45.229745]]]
+    "type":
+    "Polygon",
+    "coordinates": [[[-117.558734, 45.229745], [-117.452447, 45.229745],
+                     [-117.452447, 45.301865], [-117.558734, 45.301865],
+                     [-117.558734, 45.229745]]]
 }
 
-oregon_images = [
-    '20200909_182525_1014',
-    '20200909_182524_1014'
-]
+oregon_images = ['20200909_182525_1014', '20200909_182524_1014']
 oregon_order = planet.order_request.build_request(
     'oregon_order',
     [planet.order_request.product(oregon_images, 'analytic', 'PSScene4Band')],
-    tools=[planet.order_request.clip_tool(oregon_aoi)]
-)
+    tools=[planet.order_request.clip_tool(oregon_aoi)])
 
 
 async def create_and_download(order_detail, directory, client):

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -29,11 +29,12 @@ import pytest
 
 LOGGER = logging.getLogger(__name__)
 
-
 # All python files in the current directory except this one
 # ref: https://stackoverflow.com/a/56813896
-SCRIPTS = [s for s in Path(__file__).parent.resolve().glob('*.py')
-           if s.name != Path(__file__).name]
+SCRIPTS = [
+    s for s in Path(__file__).parent.resolve().glob('*.py')
+    if s.name != Path(__file__).name
+]
 
 
 # use the script name in the test name
@@ -47,9 +48,10 @@ def idfn(script_path):
 def test_example_script_execution(script, tmpdir):
     completed = subprocess.run(
         [sys.executable, str(script)],
-        env={'TEST_DOWNLOAD_DIR': str(tmpdir),
-             'PL_API_KEY':  os.getenv('PL_API_KEY')
-             },
+        env={
+            'TEST_DOWNLOAD_DIR': str(tmpdir),
+            'PL_API_KEY': os.getenv('PL_API_KEY')
+        },
         stderr=subprocess.PIPE  # capture stdout for reporting
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,7 @@ def lint(session):
     session.install("-e", ".[lint]")
 
     session.run("flake8", *source_files)
+    session.run('yapf', '--diff', '-r', *source_files)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,10 +34,16 @@ def docs_test(session):
 
     # Because these doc examples can be long-running, output
     # the INFO and above log messages so we know what's happening
-    session.run('pytest', '--doctest-glob', '*.md', '--no-cov',
-                '--ignore', 'examples/',
-                '--ignore', 'tests/',
-                '--log-cli-level=INFO', *options)
+    session.run('pytest',
+                '--doctest-glob',
+                '*.md',
+                '--no-cov',
+                '--ignore',
+                'examples/',
+                '--ignore',
+                'tests/',
+                '--log-cli-level=INFO',
+                *options)
 
 
 @nox.session

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -18,7 +18,6 @@ from .__version__ import __version__  # NOQA
 from .auth import Auth
 from .clients import OrdersClient
 
-
 __all__ = [
     Session,
     OrdersClient,

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -33,10 +33,9 @@ ENV_API_KEY = 'PL_API_KEY'
 
 class Auth(metaclass=abc.ABCMeta):
     '''Handle authentication information for use with Planet APIs.'''
+
     @staticmethod
-    def from_key(
-        key: str
-    ) -> Auth:
+    def from_key(key: str) -> Auth:
         '''Obtain authentication from api key.
 
         Parameters:
@@ -47,9 +46,7 @@ class Auth(metaclass=abc.ABCMeta):
         return auth
 
     @staticmethod
-    def from_file(
-        filename: str = None
-    ) -> Auth:
+    def from_file(filename: str = None) -> Auth:
         '''Create authentication from secret file.
 
         The secret file is named `.planet.json` and is stored in the user
@@ -74,9 +71,7 @@ class Auth(metaclass=abc.ABCMeta):
         return auth
 
     @staticmethod
-    def from_env(
-        variable_name: str = None
-    ) -> Auth:
+    def from_env(variable_name: str = None) -> Auth:
         '''Create authentication from environment variable.
 
         Reads the `PL_API_KEY` environment variable
@@ -96,11 +91,7 @@ class Auth(metaclass=abc.ABCMeta):
         return auth
 
     @staticmethod
-    def from_login(
-        email: str,
-        password: str,
-        base_url: str = None
-    ) -> Auth:
+    def from_login(email: str, password: str, base_url: str = None) -> Auth:
         '''Create authentication from login email and password.
 
         Note: To keep your password secure, the use of `getpass` is
@@ -122,10 +113,7 @@ class Auth(metaclass=abc.ABCMeta):
 
     @classmethod
     @abc.abstractmethod
-    def from_dict(
-        cls,
-        data: dict
-    ) -> Auth:
+    def from_dict(cls, data: dict) -> Auth:
         pass
 
     @property
@@ -133,10 +121,7 @@ class Auth(metaclass=abc.ABCMeta):
     def value(self):
         pass
 
-    def write(
-        self,
-        filename: str = None
-    ):
+    def write(self, filename: str = None):
         '''Write authentication information.
 
         Parameters:
@@ -148,10 +133,8 @@ class Auth(metaclass=abc.ABCMeta):
 
 
 class AuthClient():
-    def __init__(
-        self,
-        base_url: str = None
-    ):
+
+    def __init__(self, base_url: str = None):
         """
         Parameters:
             base_url: The base URL to use. Defaults to production
@@ -161,11 +144,7 @@ class AuthClient():
         if self._base_url.endswith('/'):
             self._base_url = self._base_url[:-1]
 
-    def login(
-        self,
-        email: str,
-        password: str
-    ) -> dict:
+    def login(self, email: str, password: str) -> dict:
         '''Login using email identity and credentials.
 
         Note: To keep your password secure, the use of `getpass` is
@@ -180,9 +159,7 @@ class AuthClient():
         API_KEY.
         '''
         url = f'{self._base_url}/login'
-        data = {'email': email,
-                'password': password
-                }
+        data = {'email': email, 'password': password}
 
         sess = http.AuthSession()
         req = models.Request(url, method='POST', json=data)
@@ -206,10 +183,7 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
     '''Planet API Key authentication.'''
     DICT_KEY = 'key'
 
-    def __init__(
-        self,
-        key: str
-    ):
+    def __init__(self, key: str):
         '''Initialize APIKeyAuth.
 
         Parameters:
@@ -224,10 +198,7 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
         super().__init__(self._key, '')
 
     @classmethod
-    def from_dict(
-        cls,
-        data: dict
-    ) -> APIKeyAuth:
+    def from_dict(cls, data: dict) -> APIKeyAuth:
         '''Instantiate APIKeyAuth from a dict.'''
         api_key = data[cls.DICT_KEY]
         return cls(api_key)
@@ -242,13 +213,11 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
 
 
 class _SecretFile():
+
     def __init__(self, path):
         self.path = path
 
-    def write(
-        self,
-        contents: dict
-    ):
+    def write(self, contents: dict):
         try:
             secrets_to_write = self.read()
             secrets_to_write.update(contents)
@@ -257,10 +226,7 @@ class _SecretFile():
 
         self._write(secrets_to_write)
 
-    def _write(
-        self,
-        contents: dict
-    ):
+    def _write(self, contents: dict):
         LOGGER.debug(f'Writing to {self.path}')
         with open(self.path, 'w') as fp:
             fp.write(json.dumps(contents))

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -24,7 +24,8 @@ LOGGER = logging.getLogger(__name__)
 
 @click.group()
 @click.pass_context
-@click.option('-u', '--base-url',
+@click.option('-u',
+              '--base-url',
               default=None,
               help='Assign custom base Auth API URL.')
 def auth(ctx, base_url):
@@ -35,12 +36,14 @@ def auth(ctx, base_url):
 @auth.command()
 @click.pass_context
 @translate_exceptions
-@click.option('--email', default=None, prompt=True, help=(
-    'The email address associated with your Planet credentials.'
-))
-@click.password_option('--password', confirmation_prompt=False, help=(
-    'Account password. Will not be saved.'
-))
+@click.option(
+    '--email',
+    default=None,
+    prompt=True,
+    help=('The email address associated with your Planet credentials.'))
+@click.password_option('--password',
+                       confirmation_prompt=False,
+                       help=('Account password. Will not be saved.'))
 def init(ctx, email, password):
     '''Obtain and store authentication information'''
     base_url = ctx.obj['BASE_URL']

--- a/planet/cli/cli.py
+++ b/planet/cli/cli.py
@@ -26,7 +26,9 @@ LOGGER = logging.getLogger(__name__)
 
 @click.group()
 @click.pass_context
-@click.option('-v', '--verbose', count=True,
+@click.option('-v',
+              '--verbose',
+              count=True,
               help=('Specify verbosity level of between 0 and 2 corresponding '
                     'to log levels warning, info, and debug respectively.'))
 @click.version_option(version=planet.__version__)
@@ -42,11 +44,11 @@ def main(ctx, verbose):
 def _configure_logging(verbosity):
     '''configure logging via verbosity level of between 0 and 2 corresponding
     to log levels warning, info and debug respectfully.'''
-    log_level = max(logging.DEBUG, logging.WARNING - logging.DEBUG*verbosity)
+    log_level = max(logging.DEBUG, logging.WARNING - logging.DEBUG * verbosity)
     logging.basicConfig(
-        stream=sys.stderr, level=log_level,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    )
+        stream=sys.stderr,
+        level=log_level,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 
 main.add_command(auth.auth)

--- a/planet/cli/cmds.py
+++ b/planet/cli/cmds.py
@@ -30,9 +30,11 @@ def coro(func):
     Returns:
         wrapper function
     """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         return asyncio.run(func(*args, **kwargs))
+
     return wrapper
 
 
@@ -48,6 +50,7 @@ def translate_exceptions(func):
     Raises:
         ClickException
     """
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -58,4 +61,5 @@ def translate_exceptions(func):
             raise click.ClickException(
                 'Auth information does not exist or is corrupted. Initialize '
                 'with `planet auth init`.')
+
     return wrapper

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -25,7 +25,6 @@ from ..constants import PLANET_BASE_URL
 from ..http import Session
 from ..models import Order, Orders, Request, Response, StreamingBody
 
-
 BASE_URL = f'{PLANET_BASE_URL}/compute/ops'
 STATS_PATH = '/stats/orders/v2'
 ORDERS_PATH = '/orders/v2'
@@ -61,11 +60,8 @@ class OrdersClient():
 
         ```
     """
-    def __init__(
-        self,
-        session: Session,
-        base_url: str = None
-    ):
+
+    def __init__(self, session: Session, base_url: str = None):
         """
         Parameters:
             session: Open session connected to server.
@@ -98,10 +94,7 @@ class OrdersClient():
     def _request(self, url, method, data=None, params=None, json=None):
         return Request(url, method=method, data=data, params=params, json=json)
 
-    async def _do_request(
-        self,
-        request: Request
-    ) -> Response:
+    async def _do_request(self, request: Request) -> Response:
         '''Submit a request and get response.
 
         Parameters:
@@ -109,10 +102,7 @@ class OrdersClient():
         '''
         return await self._session.request(request)
 
-    async def create_order(
-        self,
-        request: dict
-    ) -> str:
+    async def create_order(self, request: dict) -> str:
         '''Create an order request.
 
         Example:
@@ -165,10 +155,7 @@ class OrdersClient():
         order = Order(resp.json())
         return order
 
-    async def get_order(
-        self,
-        order_id: str
-    ) -> Order:
+    async def get_order(self, order_id: str) -> Order:
         '''Get order details by Order ID.
 
         Parameters:
@@ -196,10 +183,7 @@ class OrdersClient():
         order = Order(resp.json())
         return order
 
-    async def cancel_order(
-        self,
-        order_id: str
-    ) -> Response:
+    async def cancel_order(self, order_id: str) -> Response:
         '''Cancel a queued order.
 
         **Note:** According to the API docs, cancel order should return the
@@ -230,10 +214,7 @@ class OrdersClient():
             msg = json.loads(ex.message)['message']
             raise exceptions.MissingResource(msg)
 
-    async def cancel_orders(
-        self,
-        order_ids: typing.List[str] = None
-    ) -> dict:
+    async def cancel_orders(self, order_ids: typing.List[str] = None) -> dict:
         '''Cancel queued orders in bulk.
 
         Parameters:
@@ -271,14 +252,12 @@ class OrdersClient():
         resp = await self._do_request(req)
         return resp.json()
 
-    async def download_asset(
-        self,
-        location: str,
-        filename: str = None,
-        directory: str = None,
-        overwrite: bool = False,
-        progress_bar: bool = True
-    ) -> str:
+    async def download_asset(self,
+                             location: str,
+                             filename: str = None,
+                             directory: str = None,
+                             overwrite: bool = False,
+                             progress_bar: bool = True) -> str:
         """Download ordered asset.
 
         Parameters:
@@ -304,13 +283,11 @@ class OrdersClient():
                              progress_bar=progress_bar)
         return dl_path
 
-    async def download_order(
-        self,
-        order_id: str,
-        directory: str = None,
-        overwrite: bool = False,
-        progress_bar: bool = False
-    ) -> typing.List[str]:
+    async def download_order(self,
+                             order_id: str,
+                             directory: str = None,
+                             overwrite: bool = False,
+                             progress_bar: bool = False) -> typing.List[str]:
         """Download all assets in an order.
 
         Parameters:
@@ -328,22 +305,21 @@ class OrdersClient():
         order = await self.get_order(order_id)
         locations = order.locations
         LOGGER.info(
-            f'downloading {len(locations)} assets from order {order_id}'
-        )
-        filenames = [await self.download_asset(location,
-                                               directory=directory,
-                                               overwrite=overwrite,
-                                               progress_bar=progress_bar)
-                     for location in locations]
+            f'downloading {len(locations)} assets from order {order_id}')
+        filenames = [
+            await self.download_asset(location,
+                                      directory=directory,
+                                      overwrite=overwrite,
+                                      progress_bar=progress_bar)
+            for location in locations
+        ]
         return filenames
 
-    async def poll(
-        self,
-        order_id: str,
-        state: str = None,
-        wait: int = 1,
-        report=None
-    ) -> str:
+    async def poll(self,
+                   order_id: str,
+                   state: str = None,
+                   wait: int = 1,
+                   report=None) -> str:
         """Poll for order status until order reaches desired state, optionally
         reporting status.
 
@@ -381,8 +357,7 @@ class OrdersClient():
         if state:
             if state not in ORDERS_STATES:
                 raise OrdersClientException(
-                    f'{state} should be one of'
-                    f'{ORDERS_STATES}')
+                    f'{state} should be one of: {ORDERS_STATES}')
             states = [state]
         else:
             states = ORDERS_STATES_COMPLETE
@@ -401,17 +376,16 @@ class OrdersClient():
 
             completed = state in states
             if not completed:
-                sleep_time = max(wait-(time.time()-t), 0)
+                sleep_time = max(wait - (time.time() - t), 0)
                 LOGGER.debug(f'sleeping {sleep_time}s')
                 await asyncio.sleep(sleep_time)
         return state
 
     async def list_orders(
-        self,
-        state: str = None,
-        limit: int = None,
-        as_json: bool = False
-    ) -> typing.Union[typing.List[Order], dict]:
+            self,
+            state: str = None,
+            limit: int = None,
+            as_json: bool = False) -> typing.Union[typing.List[Order], dict]:
         """Get all order requests.
 
         Parameters:
@@ -450,5 +424,4 @@ class OrdersClient():
         if state not in ORDERS_STATES:
             raise OrdersClientException(
                 f'Order state (\'{state}\') should be one of: '
-                f'{ORDERS_STATES}'
-            )
+                f'{ORDERS_STATES}')

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -20,6 +20,7 @@ class PlanetException(Exception):
 
 class APIException(PlanetException):
     '''General unexpected API response'''
+
     @property
     def message(self):
         return self.args[0]

--- a/planet/geojson.py
+++ b/planet/geojson.py
@@ -16,7 +16,6 @@ import logging
 
 import shapely.geometry as sgeom
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -108,11 +107,9 @@ def validate_geom(data: dict):
         GeoJSONException: If data is not a valid GeoJSON geometry.
     """
     if 'type' not in data:
-        raise GeoJSONException(
-            'Missing \'type\' key.')
+        raise GeoJSONException('Missing \'type\' key.')
     elif 'coordinates' not in data:
-        raise GeoJSONException(
-            'Missing \'coordinates\' key.')
+        raise GeoJSONException('Missing \'coordinates\' key.')
 
     try:
         sgeom.shape(data)

--- a/planet/http.py
+++ b/planet/http.py
@@ -11,7 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-
 """Functionality to perform HTTP requests"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
 import asyncio
@@ -36,6 +35,7 @@ class SessionException(Exception):
 
 
 class BaseSession():
+
     @staticmethod
     def _get_user_agent():
         return 'planet-client-python/' + __version__
@@ -47,9 +47,8 @@ class BaseSession():
     @staticmethod
     def _log_response(response):
         request = response.request
-        LOGGER.info(
-            f'{request.method} {request.url} - '
-            f'Status {response.status_code}')
+        LOGGER.info(f'{request.method} {request.url} - '
+                    f'Status {response.status_code}')
 
     @classmethod
     def _raise_for_status(cls, response):
@@ -118,10 +117,7 @@ class Session(BaseSession):
     ```
     '''
 
-    def __init__(
-        self,
-        auth: Auth = None
-    ):
+    def __init__(self, auth: Auth = None):
         """Initialize a Session.
 
         Parameters:
@@ -143,8 +139,7 @@ class Session(BaseSession):
 
         self._client.event_hooks['request'] = [alog_request]
         self._client.event_hooks['response'] = [
-            alog_response,
-            araise_for_status
+            alog_response, araise_for_status
         ]
         self.retry_wait_time = RETRY_WAIT_TIME
         self.retry_count = RETRY_COUNT
@@ -182,11 +177,9 @@ class Session(BaseSession):
                     await asyncio.sleep(wait_time)
         raise SessionException('Too many throttles, giving up.')
 
-    async def request(
-        self,
-        request: models.Request,
-        stream: bool = False
-    ) -> models.Response:
+    async def request(self,
+                      request: models.Request,
+                      stream: bool = False) -> models.Response:
         '''Submit a request with retry.
 
         Parameters:
@@ -209,10 +202,7 @@ class Session(BaseSession):
                                             stream=stream)
         return models.Response(request, http_resp)
 
-    def stream(
-        self,
-        request: models.Request
-    ) -> Stream:
+    def stream(self, request: models.Request) -> Stream:
         '''Submit a request and get the response as a stream context manager.
 
         Parameters:
@@ -220,14 +210,12 @@ class Session(BaseSession):
         Returns:
             Context manager providing the body as a stream.
         '''
-        return Stream(
-            session=self,
-            request=request
-        )
+        return Stream(session=self, request=request)
 
 
 class AuthSession(BaseSession):
     '''Synchronous connection to the Planet Auth service.'''
+
     def __init__(self):
         """Initialize an AuthSession.
         """
@@ -235,8 +223,7 @@ class AuthSession(BaseSession):
         self._client.headers.update({'User-Agent': self._get_user_agent()})
         self._client.event_hooks['request'] = [self._log_request]
         self._client.event_hooks['response'] = [
-            self._log_response,
-            self._raise_for_status
+            self._log_response, self._raise_for_status
         ]
 
     def request(self, request):
@@ -256,11 +243,8 @@ class AuthSession(BaseSession):
 
 class Stream():
     '''Context manager for asynchronous response stream from Planet server.'''
-    def __init__(
-        self,
-        session: Session,
-        request: models.Request
-    ):
+
+    def __init__(self, session: Session, request: models.Request):
         """
         Parameters:
             session: Open session to Planet server.

--- a/planet/models.py
+++ b/planet/models.py
@@ -48,19 +48,19 @@ class Request():
     :raises RequestException: When provided `body_type` is not a subclass of
         :py:class:`planet.api.models.Body`
     '''
+
     def __init__(self, url, params=None, data=None, json=None, method='GET'):
         if data or json:
             headers = {'Content-Type': 'application/json'}
         else:
             headers = None
 
-        self.http_request = httpx.Request(
-            method,
-            url,
-            params=params,
-            data=data,
-            json=json,
-            headers=headers)
+        self.http_request = httpx.Request(method,
+                                          url,
+                                          params=params,
+                                          data=data,
+                                          json=json,
+                                          headers=headers)
 
     @property
     def url(self):
@@ -84,6 +84,7 @@ class Response():
     :param http_response: Response that was received from the server
     :type http_response: :py:Class:`requests.models.Response`
     '''
+
     def __init__(self, request, http_response):
         self.request = request
         self.http_response = http_response
@@ -118,6 +119,7 @@ class StreamingBody():
     :param response: Response that was received from the server
     :type response: :py:Class:`requests.models.Response`
         '''
+
     def __init__(self, response):
         self.response = response.http_response
         self.url = response.request.url
@@ -132,9 +134,8 @@ class StreamingBody():
         :returns: name of this resource
         :rtype: str
         '''
-        name = (_get_filename_from_headers(self.response.headers) or
-                _get_filename_from_url(self.url) or
-                _get_random_filename(
+        name = (_get_filename_from_headers(self.response.headers)
+                or _get_filename_from_url(self.url) or _get_random_filename(
                     self.response.headers.get('content-type')))
         return name
 
@@ -181,7 +182,9 @@ class StreamingBody():
             True.
         :type progress_bar: boolean, optional
         '''
+
         class _LOG():
+
             def __init__(self, total, unit, filename, disable):
                 self.total = total
                 self.unit = unit
@@ -193,28 +196,34 @@ class StreamingBody():
                     LOGGER.debug(f'writing to {self.filename}')
 
             def update(self, new):
-                if new-self.previous > self.unit and not self.disable:
+                if new - self.previous > self.unit and not self.disable:
                     # LOGGER.debug(f'{new-self.previous}')
                     perc = int(100 * new / self.total)
                     LOGGER.debug(f'{self.filename}: '
                                  f'wrote {perc}% of {self.total}')
                     self.previous = new
 
-        unit = 1024*1024
+        unit = 1024 * 1024
 
         mode = 'wb' if overwrite else 'xb'
         try:
             with open(filename, mode) as fp:
-                _log = _LOG(self.size, 16*unit, filename, disable=progress_bar)
-                with tqdm(total=self.size, unit_scale=True,
-                          unit_divisor=unit, unit='B',
-                          desc=filename, disable=not progress_bar) as progress:
+                _log = _LOG(self.size,
+                            16 * unit,
+                            filename,
+                            disable=progress_bar)
+                with tqdm(total=self.size,
+                          unit_scale=True,
+                          unit_divisor=unit,
+                          unit='B',
+                          desc=filename,
+                          disable=not progress_bar) as progress:
                     previous = self.num_bytes_downloaded
                     async for chunk in self.aiter_bytes():
                         fp.write(chunk)
                         new = self.num_bytes_downloaded
                         _log.update(new)
-                        progress.update(new-previous)
+                        progress.update(new - previous)
                         previous = new
         except FileExistsError:
             LOGGER.info(f'File {filename} exists, not overwriting')
@@ -239,7 +248,7 @@ def _get_filename_from_url(url):
     :rtype: str or None
     """
     path = url.path
-    name = path[path.rfind('/')+1:]
+    name = path[path.rfind('/') + 1:]
     return name or None
 
 
@@ -322,7 +331,7 @@ class Paged():
         yield page
 
         next_url = self._next_link(page)
-        while(next_url):
+        while (next_url):
             LOGGER.debug('getting next page')
             request.url = next_url
             resp = await self._do_request(request)

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -21,15 +21,13 @@ from . import geojson, specs
 LOGGER = logging.getLogger(__name__)
 
 
-def build_request(
-        name: str,
-        products: List[dict],
-        subscription_id: int = 0,
-        delivery: dict = None,
-        notifications: dict = None,
-        order_type: str = None,
-        tools: List[dict] = None
-) -> dict:
+def build_request(name: str,
+                  products: List[dict],
+                  subscription_id: int = 0,
+                  delivery: dict = None,
+                  notifications: dict = None,
+                  order_type: str = None,
+                  tools: List[dict] = None) -> dict:
     '''Prepare an order request.
 
     ```python
@@ -69,10 +67,7 @@ def build_request(
         planet.specs.SpecificationException: If order_type is not a valid
             order type.
     '''
-    details = {
-        'name': name,
-        'products': products
-    }
+    details = {'name': name, 'products': products}
 
     if subscription_id:
         details['subscription_id'] = subscription_id
@@ -93,12 +88,10 @@ def build_request(
     return details
 
 
-def product(
-    item_ids: List[str],
-    product_bundle: str,
-    item_type: str,
-    fallback_bundle: str = None
-) -> dict:
+def product(item_ids: List[str],
+            product_bundle: str,
+            item_type: str,
+            fallback_bundle: str = None) -> dict:
     '''Product description for an order detail.
 
     Parameters:
@@ -131,11 +124,9 @@ def product(
     return product_dict
 
 
-def notifications(
-    email: bool = None,
-    webhook_url: str = None,
-    webhook_per_order: bool = None
-) -> dict:
+def notifications(email: bool = None,
+                  webhook_url: str = None,
+                  webhook_per_order: bool = None) -> dict:
     '''Notifications description for an order detail.
 
     Parameters:
@@ -147,12 +138,10 @@ def notifications(
     return dict((k, v) for k, v in locals().items() if v)
 
 
-def delivery(
-    archive_type: str = None,
-    single_archive: bool = False,
-    archive_filename: str = None,
-    cloud_config: dict = None
-) -> dict:
+def delivery(archive_type: str = None,
+             single_archive: bool = False,
+             archive_filename: str = None,
+             cloud_config: dict = None) -> dict:
     '''Order delivery configuration.
 
     Example:
@@ -196,13 +185,11 @@ def delivery(
     return config
 
 
-def amazon_s3(
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-    bucket: str,
-    aws_region: str,
-    path_prefix: str = None
-) -> dict:
+def amazon_s3(aws_access_key_id: str,
+              aws_secret_access_key: str,
+              bucket: str,
+              aws_region: str,
+              path_prefix: str = None) -> dict:
     '''Amazon S3 Cloud configuration.
 
     Parameters:
@@ -227,13 +214,11 @@ def amazon_s3(
     return {'amazon_s3': cloud_details}
 
 
-def azure_blob_storage(
-    account: str,
-    container: str,
-    sas_token: str,
-    storage_endpoint_suffix: str = None,
-    path_prefix: str = None
-) -> dict:
+def azure_blob_storage(account: str,
+                       container: str,
+                       sas_token: str,
+                       storage_endpoint_suffix: str = None,
+                       path_prefix: str = None) -> dict:
     '''Azure Blob Storage configuration.
 
     Parameters:
@@ -261,11 +246,9 @@ def azure_blob_storage(
     return {'azure_blob_storage': cloud_details}
 
 
-def google_cloud_storage(
-    bucket: str,
-    credentials: str,
-    path_prefix: str = None
-) -> dict:
+def google_cloud_storage(bucket: str,
+                         credentials: str,
+                         path_prefix: str = None) -> dict:
     '''Google Cloud Storage configuration.
 
     Parameters:
@@ -286,10 +269,7 @@ def google_cloud_storage(
     return {'google_cloud_storage': cloud_details}
 
 
-def google_earth_engine(
-    project: str,
-    collection: str
-) -> dict:
+def google_earth_engine(project: str, collection: str) -> dict:
     '''Google Earth Engine configuration.
 
     Parameters:
@@ -380,11 +360,9 @@ def file_format_tool(file_format: str) -> dict:
     return _tool('file_format', {'format': file_format})
 
 
-def reproject_tool(
-    projection: str,
-    resolution: float = None,
-    kernel: str = None
-) -> dict:
+def reproject_tool(projection: str,
+                   resolution: float = None,
+                   kernel: str = None) -> dict:
     '''Create the API spec representation of a reproject tool.
 
     Parameters:
@@ -403,14 +381,12 @@ def reproject_tool(
     return _tool('reproject', parameters)
 
 
-def tile_tool(
-    tile_size: int,
-    origin_x: float = None,
-    origin_y: float = None,
-    pixel_size: float = None,
-    name_template: str = None,
-    conformal_x_scaling: bool = None
-) -> dict:
+def tile_tool(tile_size: int,
+              origin_x: float = None,
+              origin_y: float = None,
+              pixel_size: float = None,
+              name_template: str = None,
+              conformal_x_scaling: bool = None) -> dict:
     '''Create the API spec representation of a reproject tool.
 
     Parameters:
@@ -431,9 +407,7 @@ def tile_tool(
     return _tool('tile', parameters)
 
 
-def toar_tool(
-    scale_factor: int = None,
-) -> dict:
+def toar_tool(scale_factor: int = None, ) -> dict:
     '''Create the API spec representation of a TOAR tool.
 
     Parameters:

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -21,10 +21,8 @@ LOGGER = logging.getLogger(__name__)
 
 class ProgressBar():
     """Abstract base class for progress bar reporters."""
-    def __init__(
-        self,
-        disable: bool = False
-    ):
+
+    def __init__(self, disable: bool = False):
         self.bar = None
         self.disable = disable
 
@@ -55,6 +53,7 @@ class StateBar(ProgressBar):
             ...
         ```
     """
+
     def __init__(
         self,
         order_id: str = None,
@@ -76,18 +75,15 @@ class StateBar(ProgressBar):
         """Initialize and start the progress bar."""
         self.bar = tqdm(
             bar_format="{elapsed} - {desc} - {postfix[0]}: {postfix[1]}",
-            desc=self.desc, postfix=["state", self.state],
+            desc=self.desc,
+            postfix=["state", self.state],
             disable=self.disable)
 
     @property
     def desc(self):
         return f'order {self.order_id}'
 
-    def update(
-        self,
-        state: str = None,
-        order_id: str = None
-    ):
+    def update(self, state: str = None, order_id: str = None):
         if state:
             if state != self.state:
                 LOGGER.info('{order_id} state: {state}')

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -17,11 +17,19 @@ import logging
 import os
 from pathlib import Path
 
-
 DATA_DIR = 'data'
 PRODUCT_BUNDLE_SPEC_NAME = 'orders_product_bundle_2020_03_10.json'
-SUPPORTED_TOOLS = ['band_math', 'clip', 'composite', 'coregister',
-                   'file_format', 'reproject', 'tile', 'toar', 'harmonize']
+SUPPORTED_TOOLS = [
+    'band_math',
+    'clip',
+    'composite',
+    'coregister',
+    'file_format',
+    'reproject',
+    'tile',
+    'toar',
+    'harmonize'
+]
 SUPPORTED_ORDER_TYPES = ['full', 'partial']
 SUPPORTED_ARCHIVE_TYPES = ['zip']
 SUPPORTED_FILE_FORMATS = ['COG', 'PL_NITF']
@@ -51,8 +59,9 @@ def validate_order_type(order_type):
 
 
 def validate_archive_type(archive_type):
-    return _validate_field(
-        archive_type, SUPPORTED_ARCHIVE_TYPES, 'archive_type')
+    return _validate_field(archive_type,
+                           SUPPORTED_ARCHIVE_TYPES,
+                           'archive_type')
 
 
 def validate_tool(tool):
@@ -66,8 +75,8 @@ def validate_file_format(file_format):
 def _validate_field(value, supported, field_name=None):
     try:
         value = get_match(value, supported)
-    except(NoMatchException):
-        opts = ', '.join(["'"+s+"'" for s in supported])
+    except (NoMatchException):
+        opts = ', '.join(["'" + s + "'" for s in supported])
         msg = f'\'{value}\' is not one of {opts}.'
         if field_name:
             msg = f'{field_name} - ' + msg
@@ -89,7 +98,7 @@ def get_match(test_entry, spec_entries):
     try:
         match = next(t for t in spec_entries
                      if t.lower() == test_entry.lower())
-    except(StopIteration):
+    except (StopIteration):
         raise NoMatchException
 
     return match

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,7 @@ branch = True
 [coverage:report]
 skip_covered = True
 show_missing = True
+
+[yapf]
+based_on_style = pep8
+split_all_top_level_comma_separated_values=true

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 from pathlib import Path
 from setuptools import setup, find_packages
 
-
 with open('planet/__version__.py') as f:
     for line in f:
         if line.find("__version__") >= 0:
@@ -22,7 +21,6 @@ with open('planet/__version__.py') as f:
             version = version.strip('"')
             version = version.strip("'")
             continue
-
 
 install_requires = [
     'click>=8.0.0',
@@ -33,16 +31,10 @@ install_requires = [
 ]
 
 test_requires = [
-    'pytest',
-    'pytest-asyncio==0.16',
-    'pytest-cov',
-    'respx==0.16.3'
+    'pytest', 'pytest-asyncio==0.16', 'pytest-cov', 'respx==0.16.3'
 ]
 
-lint_requires = [
-    'flake8',
-    'yapf'
-]
+lint_requires = ['flake8', 'yapf']
 
 doc_requires = [
     'mkdocs==1.1',
@@ -51,11 +43,12 @@ doc_requires = [
     'mkdocstrings==0.15.0'
 ]
 
-setup(name='planet',
-      version=version,
-      description=u"Planet SDK for Python",
-      long_description=Path("README.md").read_text("utf-8"),
-      classifiers=[
+setup(
+    name='planet',
+    version=version,
+    description=u"Planet SDK for Python",
+    long_description=Path("README.md").read_text("utf-8"),
+    classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Console',
         'Intended Audience :: Developers',
@@ -65,26 +58,27 @@ setup(name='planet',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development',
         'Topic :: Utilities'
-      ],
-      keywords='planet api sdk client',
-      author='Jennifer Reiber Kyle',
-      author_email='jennifer.kyle@planet.com',
-      url='https://github.com/planetlabs/planet-client-python',
-      license='Apache 2.0',
-      packages=find_packages(exclude=['examples', 'tests']),
-      data_files=[('', ['LICENSE'])],
-      include_package_data=True,
-      zip_safe=False,
-      python_requires='>=3.7',
-      install_requires=install_requires,
-      extras_require={
-          'test': test_requires,
-          'lint': lint_requires,
-          'docs': doc_requires,
-          'dev': test_requires + lint_requires + doc_requires},
-      entry_points={
-          'console_scripts': [
-              'planet=planet.cli.cli:main',
-          ],
-        },
-      )
+    ],
+    keywords='planet api sdk client',
+    author='Jennifer Reiber Kyle',
+    author_email='jennifer.kyle@planet.com',
+    url='https://github.com/planetlabs/planet-client-python',
+    license='Apache 2.0',
+    packages=find_packages(exclude=['examples', 'tests']),
+    data_files=[('', ['LICENSE'])],
+    include_package_data=True,
+    zip_safe=False,
+    python_requires='>=3.7',
+    install_requires=install_requires,
+    extras_require={
+        'test': test_requires,
+        'lint': lint_requires,
+        'docs': doc_requires,
+        'dev': test_requires + lint_requires + doc_requires
+    },
+    entry_points={
+        'console_scripts': [
+            'planet=planet.cli.cli:main',
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ test_requires = [
 
 lint_requires = [
     'flake8',
+    'yapf'
 ]
 
 doc_requires = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ import pytest
 
 from planet.auth import _SecretFile
 
-
 _here = Path(os.path.abspath(os.path.dirname(__file__)))
 _test_data_path = _here / 'data'
 
@@ -27,6 +26,7 @@ _test_data_path = _here / 'data'
 @pytest.fixture(autouse=True, scope='module')
 def test_secretfile_read():
     '''Returns valid auth results as if reading a secret file'''
+
     def mockreturn(self):
         return {'key': 'testkey'}
 
@@ -74,11 +74,13 @@ def oid():
 
 @pytest.fixture
 def write_to_tmp_json_file(tmp_path):
+
     def write(data, filename):
         cc = tmp_path / filename
         with open(cc, 'w') as fp:
             json.dump(data, fp)
         return cc
+
     return write
 
 
@@ -87,54 +89,30 @@ def geom_geojson():
     # these need to be tuples, not list, or they will be changed
     # by shapely
     return {
-        "type": "Polygon",
-        "coordinates": [[
-            [
-                37.791595458984375,
-                14.84923123791421
-                ],
-            [
-                37.90214538574219,
-                14.84923123791421
-                ],
-            [
-                37.90214538574219,
-                14.945448293647944
-                ],
-            [
-                37.791595458984375,
-                14.945448293647944
-                ],
-            [
-                37.791595458984375,
-                14.84923123791421
-                ]
-        ]]
-      }
+        "type":
+        "Polygon",
+        "coordinates":
+        [[[37.791595458984375, 14.84923123791421],
+          [37.90214538574219, 14.84923123791421],
+          [37.90214538574219, 14.945448293647944],
+          [37.791595458984375, 14.945448293647944],
+          [37.791595458984375, 14.84923123791421]]]
+    }  # yapf: disable
 
 
 @pytest.fixture
 def feature_geojson(geom_geojson):
-    return {
-      "type": "Feature",
-      "properties": {},
-      "geometry": geom_geojson}
+    return {"type": "Feature", "properties": {}, "geometry": geom_geojson}
 
 
 @pytest.fixture
 def featureclass_geojson(feature_geojson):
-    return {
-          "type": "FeatureCollection",
-          "features": [feature_geojson]
-        }
+    return {"type": "FeatureCollection", "features": [feature_geojson]}
 
 
 @pytest.fixture
 def point_geom_geojson():
     return {
         "type": "Point",
-        "coordinates": [
-                37.791595458984375,
-                14.84923123791421
-                ]
-        }
+        "coordinates": [37.791595458984375, 14.84923123791421]
+    }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,10 +29,12 @@ async def session():
 @pytest.fixture
 def match_pytest_raises():
     '''this is like pytest.raises but does a full string match'''
+
     @contextlib.contextmanager
     def cm(ex, msg):
         with pytest.raises(ex, match=f'^{msg}$') as pt:
             yield pt
+
     return cm
 
 

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -22,7 +22,6 @@ import respx
 from planet import exceptions
 from planet.auth import AuthClient
 
-
 TEST_URL = 'http://MockNotRealURL/api/path'
 TEST_LOGIN_URL = f'{TEST_URL}/login'
 
@@ -46,9 +45,7 @@ def test_AuthClient_success():
 def test_AuthClient_invalid_email():
     resp = {
         "errors": {
-            "email": [
-                "Not a valid email address."
-            ]
+            "email": ["Not a valid email address."]
         },
         "message": "error validating request against UserAuthenticationSchema",
         "status": 400,

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -58,10 +58,9 @@ def test_cli_auth_init_success(redirect_secretfile):
     mock_resp = httpx.Response(HTTPStatus.OK, json=resp)
     respx.post(TEST_LOGIN_URL).return_value = mock_resp
 
-    result = CliRunner().invoke(
-            cli.main,
-            args=['auth', '--base-url', TEST_URL, 'init'],
-            input='email\npw\n')
+    result = CliRunner().invoke(cli.main,
+                                args=['auth', '--base-url', TEST_URL, 'init'],
+                                input='email\npw\n')
 
     # we would get a 'url not mocked' exception if the base url wasn't
     # changed to the mocked url
@@ -72,17 +71,18 @@ def test_cli_auth_init_success(redirect_secretfile):
 
 @respx.mock
 def test_cli_auth_init_bad_pw(redirect_secretfile):
-    resp = {"errors": None,
-            "message": "Invalid email or password",
-            "status": 401,
-            "success": False}
+    resp = {
+        "errors": None,
+        "message": "Invalid email or password",
+        "status": 401,
+        "success": False
+    }
     mock_resp = httpx.Response(401, json=resp)
     respx.post(TEST_LOGIN_URL).return_value = mock_resp
 
-    result = CliRunner().invoke(
-            cli.main,
-            args=['auth', '--base-url', TEST_URL, 'init'],
-            input='email\npw\n')
+    result = CliRunner().invoke(cli.main,
+                                args=['auth', '--base-url', TEST_URL, 'init'],
+                                input='email\npw\n')
 
     assert result.exception
     assert 'Error: Incorrect email or password.\n' in result.output

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -56,20 +56,23 @@ def create_download_mock(downloaded_content, order_description, oid):
         # Create mock HTTP response
         dl_url = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
         order_description['_links']['results'] = [
-            {'location': dl_url},
+            {
+                'location': dl_url
+            },
         ]
 
         get_url = f'{TEST_ORDERS_URL}/{oid}'
         mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
         respx.get(get_url).return_value = mock_resp
 
-        mock_resp = httpx.Response(
-            HTTPStatus.OK,
-            json=downloaded_content,
-            headers={
-                'Content-Type': 'application/json',
-                'Content-Disposition': 'attachment; filename="file.json"'
-            })
+        mock_resp = httpx.Response(HTTPStatus.OK,
+                                   json=downloaded_content,
+                                   headers={
+                                       'Content-Type':
+                                       'application/json',
+                                       'Content-Disposition':
+                                       'attachment; filename="file.json"'
+                                   })
         respx.get(dl_url).return_value = mock_resp
 
     return f
@@ -84,18 +87,14 @@ async def test_list_orders_basic(order_descriptions, session):
 
     page1_response = {
         "_links": {
-            "_self": "string",
-            "next": next_page_url},
+            "_self": "string", "next": next_page_url
+        },
         "orders": [order1, order2]
     }
     mock_resp1 = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp1
 
-    page2_response = {
-        "_links": {
-            "_self": next_page_url},
-        "orders": [order3]
-    }
+    page2_response = {"_links": {"_self": next_page_url}, "orders": [order3]}
     mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
     respx.get(next_page_url).return_value = mock_resp2
 
@@ -116,8 +115,7 @@ async def test_list_orders_state(order_descriptions, session):
     page1_response = {
         "_links": {
             "_self": "string"
-        },
-        "orders": [order1, order2]
+        }, "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(list_url).return_value = mock_resp
@@ -149,8 +147,8 @@ async def test_list_orders_limit(order_descriptions, session):
 
     page1_response = {
         "_links": {
-            "_self": "string",
-            "next": nono_page_url},
+            "_self": "string", "next": nono_page_url
+        },
         "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
@@ -171,10 +169,7 @@ async def test_list_orders_limit(order_descriptions, session):
 async def test_list_orders_asjson(order_descriptions, session):
     order1, order2, order3 = order_descriptions
 
-    page1_response = {
-        "_links": {"_self": "string"},
-        "orders": [order1]
-    }
+    page1_response = {"_links": {"_self": "string"}, "orders": [order1]}
     mock_resp1 = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp1
 
@@ -200,18 +195,14 @@ async def test_create_order(oid, order_description, order_request, session):
 async def test_create_order_bad_item_type(order_request, session):
     resp = {
         "field": {
-            "Products": [
-                {
-                    "message": ("Bad item type 'invalid' for bundle type " +
-                                "'analytic'")
-                }
-            ]
+            "Products": [{
+                "message":
+                ("Bad item type 'invalid' for bundle type " + "'analytic'")
+            }]
         },
-        "general": [
-            {
-                "message": "Unable to accept order"
-            }
-        ]
+        "general": [{
+            "message": "Unable to accept order"
+        }]
     }
     mock_resp = httpx.Response(400, json=resp)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -228,22 +219,19 @@ async def test_create_order_bad_item_type(order_request, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_create_order_item_id_does_not_exist(
-        order_request, session, match_pytest_raises):
+async def test_create_order_item_id_does_not_exist(order_request,
+                                                   session,
+                                                   match_pytest_raises):
     resp = {
         "field": {
-            "Details": [
-                {
-                    "message": ("Item ID 4500474_2133707_2021-05-20_2419 / " +
-                                "Item Type PSScene3Band doesn't exist")
-                }
-            ]
+            "Details": [{
+                "message": ("Item ID 4500474_2133707_2021-05-20_2419 / " +
+                            "Item Type PSScene3Band doesn't exist")
+            }]
         },
-        "general": [
-            {
-                "message": "Unable to accept order"
-            }
-        ]
+        "general": [{
+            "message": "Unable to accept order"
+        }]
     }
     mock_resp = httpx.Response(400, json=resp)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -281,14 +269,11 @@ async def test_get_order_invalid_id(session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_get_order_id_doesnt_exist(
-        oid, session, match_pytest_raises):
+async def test_get_order_id_doesnt_exist(oid, session, match_pytest_raises):
     get_url = f'{TEST_ORDERS_URL}/{oid}'
 
     msg = f'Could not load order ID: {oid}.'
-    resp = {
-        "message": msg
-    }
+    resp = {"message": msg}
     mock_resp = httpx.Response(404, json=resp)
     respx.get(get_url).return_value = mock_resp
 
@@ -321,14 +306,11 @@ async def test_cancel_order_invalid_id(session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_cancel_order_id_doesnt_exist(
-        oid, session, match_pytest_raises):
+async def test_cancel_order_id_doesnt_exist(oid, session, match_pytest_raises):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
 
     msg = f'No such order ID: {oid}.'
-    resp = {
-        "message": msg
-    }
+    resp = {"message": msg}
     mock_resp = httpx.Response(404, json=resp)
     respx.put(cancel_url).return_value = mock_resp
 
@@ -340,14 +322,13 @@ async def test_cancel_order_id_doesnt_exist(
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_cancel_order_id_cannot_be_cancelled(
-        oid, session, match_pytest_raises):
+async def test_cancel_order_id_cannot_be_cancelled(oid,
+                                                   session,
+                                                   match_pytest_raises):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
 
     msg = 'Order not in a cancellable state'
-    resp = {
-        "message": msg
-    }
+    resp = {"message": msg}
     mock_resp = httpx.Response(409, json=resp)
     respx.put(cancel_url).return_value = mock_resp
 
@@ -364,15 +345,16 @@ async def test_cancel_orders_by_ids(session, oid):
     test_ids = [oid, oid2]
     example_result = {
         "result": {
-            "succeeded": {"count": 1},
+            "succeeded": {
+                "count": 1
+            },
             "failed": {
-                "count": 1,
-                "failures": [
-                    {
-                        "order_id": oid2,
-                        "message": "Order not in a cancellable state",
-                    }
-                ]
+                "count":
+                1,
+                "failures": [{
+                    "order_id": oid2,
+                    "message": "Order not in a cancellable state",
+                }]
             }
         }
     }
@@ -384,9 +366,7 @@ async def test_cancel_orders_by_ids(session, oid):
 
     assert res == example_result
 
-    expected_body = {
-            "order_ids": test_ids
-    }
+    expected_body = {"order_ids": test_ids}
     actual_body = json.loads(respx.calls.last.request.content)
     assert actual_body == expected_body
 
@@ -403,10 +383,10 @@ async def test_cancel_orders_by_ids_invalid_id(session, oid):
 async def test_cancel_orders_all(session):
     example_result = {
         "result": {
-            "succeeded": {"count": 2},
-            "failed": {
-                "count": 0,
-                "failures": []
+            "succeeded": {
+                "count": 2
+            }, "failed": {
+                "count": 0, "failures": []
             }
         }
     }
@@ -480,12 +460,10 @@ async def test_poll_invalid_state(oid, session):
 async def test_aggegated_order_stats(session):
     example_stats = {
         "organization": {
-            "queued_orders": 0,
-            "running_orders": 6
+            "queued_orders": 0, "running_orders": 6
         },
         "user": {
-            "queued_orders": 0,
-            "running_orders": 0
+            "queued_orders": 0, "running_orders": 0
         }
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=example_stats)
@@ -533,13 +511,14 @@ async def test_download_asset_img(tmpdir, open_test_img, session):
         v = memoryview(data)
 
         chunksize = 100
-        for i in range(math.ceil(len(v)/(chunksize))):
-            yield v[i*chunksize:min((i+1)*chunksize, len(v))]
+        for i in range(math.ceil(len(v) / (chunksize))):
+            yield v[i * chunksize:min((i + 1) * chunksize, len(v))]
 
     # populate request parameter to avoid respx cloning, which throws
     # an error caused by respx and not this code
     # https://github.com/lundberg/respx/issues/130
-    mock_resp = httpx.Response(HTTPStatus.OK, stream=_stream_img(),
+    mock_resp = httpx.Response(HTTPStatus.OK,
+                               stream=_stream_img(),
                                headers=img_headers,
                                request='donotcloneme')
     respx.get(dl_url).return_value = mock_resp
@@ -562,31 +541,34 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
     # Mock an HTTP response for download
     dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
     dl_url2 = TEST_DOWNLOAD_URL + '/2?token=IAmAnotherToken'
-    order_description['_links']['results'] = [
-        {'location': dl_url1},
-        {'location': dl_url2}
-    ]
+    order_description['_links']['results'] = [{
+        'location': dl_url1
+    }, {
+        'location': dl_url2
+    }]
 
     get_url = f'{TEST_ORDERS_URL}/{oid}'
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.get(get_url).return_value = mock_resp
 
-    mock_resp1 = httpx.Response(
-        HTTPStatus.OK,
-        json={'key': 'value'},
-        headers={
-            'Content-Type': 'application/json',
-            'Content-Disposition': 'attachment; filename="m1.json"'
-        })
+    mock_resp1 = httpx.Response(HTTPStatus.OK,
+                                json={'key': 'value'},
+                                headers={
+                                    'Content-Type':
+                                    'application/json',
+                                    'Content-Disposition':
+                                    'attachment; filename="m1.json"'
+                                })
     respx.get(dl_url1).return_value = mock_resp1
 
-    mock_resp2 = httpx.Response(
-        HTTPStatus.OK,
-        json={'key2': 'value2'},
-        headers={
-            'Content-Type': 'application/json',
-            'Content-Disposition': 'attachment; filename="m2.json"'
-        })
+    mock_resp2 = httpx.Response(HTTPStatus.OK,
+                                json={'key2': 'value2'},
+                                headers={
+                                    'Content-Type':
+                                    'application/json',
+                                    'Content-Disposition':
+                                    'attachment; filename="m2.json"'
+                                })
     respx.get(dl_url2).return_value = mock_resp2
 
     cl = OrdersClient(session, base_url=TEST_URL)
@@ -605,7 +587,11 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
 @respx.mock
 @pytest.mark.asyncio
 async def test_download_order_overwrite_true_preexisting_data(
-        tmpdir, oid, session, create_download_mock, original_content,
+        tmpdir,
+        oid,
+        session,
+        create_download_mock,
+        original_content,
         downloaded_content):
     '''
     Test if download_order() overwrites pre-existing data with

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -28,16 +28,17 @@ TEST_URL = 'http://MockNotRealURL/api/path'
 TEST_DOWNLOAD_URL = f'{TEST_URL}/download'
 TEST_ORDERS_URL = f'{TEST_URL}/orders/v2'
 
-
 # NOTE: These tests use a lot of the same mocked responses as test_orders_api.
 
 
 @pytest.fixture
 def invoke():
+
     def _invoke(extra_args, runner=None):
         runner = runner or CliRunner()
         args = ['orders', '--base-url', TEST_URL] + extra_args
         return runner.invoke(cli.main, args=args)
+
     return _invoke
 
 
@@ -48,18 +49,14 @@ def test_cli_orders_list_basic(invoke, order_descriptions):
 
     page1_response = {
         "_links": {
-            "_self": "string",
-            "next": next_page_url},
+            "_self": "string", "next": next_page_url
+        },
         "orders": [order1, order2]
     }
     mock_resp1 = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp1
 
-    page2_response = {
-        "_links": {
-            "_self": next_page_url},
-        "orders": [order3]
-    }
+    page2_response = {"_links": {"_self": next_page_url}, "orders": [order3]}
     mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
     respx.get(next_page_url).return_value = mock_resp2
 
@@ -70,12 +67,7 @@ def test_cli_orders_list_basic(invoke, order_descriptions):
 
 @respx.mock
 def test_cli_orders_list_empty(invoke):
-    page1_response = {
-        "_links": {
-            "_self": "string"
-        },
-        "orders": []
-    }
+    page1_response = {"_links": {"_self": "string"}, "orders": []}
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -93,8 +85,7 @@ def test_cli_orders_list_state(invoke, order_descriptions):
     page1_response = {
         "_links": {
             "_self": "string"
-        },
-        "orders": [order1, order2]
+        }, "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(list_url).return_value = mock_resp
@@ -113,8 +104,7 @@ def test_cli_orders_list_limit(invoke, order_descriptions):
     page1_response = {
         "_links": {
             "_self": "string"
-        },
-        "orders": [order1, order2]
+        }, "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
 
@@ -134,8 +124,7 @@ def test_cli_orders_list_pretty(invoke, monkeypatch, order_description):
     page1_response = {
         "_links": {
             "_self": "string"
-        },
-        "orders": [order_description]
+        }, "orders": [order_description]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp
@@ -194,37 +183,42 @@ def test_cli_orders_cancel_id_not_found(invoke, oid):
 
 @pytest.fixture
 def mock_download_response(oid, order_description):
+
     def _func():
         # Mock an HTTP response for polling and download
         order_description['state'] = 'success'
         dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
         dl_url2 = TEST_DOWNLOAD_URL + '/2?token=IAmAnotherToken'
-        order_description['_links']['results'] = [
-            {'location': dl_url1},
-            {'location': dl_url2}
-        ]
+        order_description['_links']['results'] = [{
+            'location': dl_url1
+        }, {
+            'location': dl_url2
+        }]
 
         get_url = f'{TEST_ORDERS_URL}/{oid}'
         mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
         respx.get(get_url).return_value = mock_resp
 
-        mock_resp1 = httpx.Response(
-            HTTPStatus.OK,
-            json={'key': 'value'},
-            headers={
-                'Content-Type': 'application/json',
-                'Content-Disposition': 'attachment; filename="m1.json"'
-            })
+        mock_resp1 = httpx.Response(HTTPStatus.OK,
+                                    json={'key': 'value'},
+                                    headers={
+                                        'Content-Type':
+                                        'application/json',
+                                        'Content-Disposition':
+                                        'attachment; filename="m1.json"'
+                                    })
         respx.get(dl_url1).return_value = mock_resp1
 
-        mock_resp2 = httpx.Response(
-            HTTPStatus.OK,
-            json={'key2': 'value2'},
-            headers={
-                'Content-Type': 'application/json',
-                'Content-Disposition': 'attachment; filename="m2.json"'
-            })
+        mock_resp2 = httpx.Response(HTTPStatus.OK,
+                                    json={'key2': 'value2'},
+                                    headers={
+                                        'Content-Type':
+                                        'application/json',
+                                        'Content-Disposition':
+                                        'attachment; filename="m2.json"'
+                                    })
         respx.get(dl_url2).return_value = mock_resp2
+
     return _func
 
 
@@ -266,8 +260,10 @@ def test_cli_orders_download_dest(invoke, mock_download_response, oid):
 
 
 @respx.mock
-def test_cli_orders_download_overwrite(
-        invoke, mock_download_response, oid, write_to_tmp_json_file):
+def test_cli_orders_download_overwrite(invoke,
+                                       mock_download_response,
+                                       oid,
+                                       write_to_tmp_json_file):
     mock_download_response()
 
     runner = CliRunner()
@@ -281,13 +277,13 @@ def test_cli_orders_download_overwrite(
         assert json.load(open(filepath)) == {'foo': 'bar'}
 
         # check the file gets overwritten
-        result = invoke(['download', '--overwrite', oid],
-                        runner=runner)
+        result = invoke(['download', '--overwrite', oid], runner=runner)
         assert not result.exception
         assert json.load(open(filepath)) == {'key': 'value'}
 
 
-@pytest.mark.skip('https://github.com/planetlabs/planet-client-python/issues/352') # noqa
+@pytest.mark.skip(
+    'https://github.com/planetlabs/planet-client-python/issues/352')  # noqa
 @respx.mock
 def test_cli_orders_download_quiet(invoke, mock_download_response, oid):
     mock_download_response()
@@ -306,11 +302,12 @@ def test_cli_orders_download_quiet(invoke, mock_download_response, oid):
     "id_string, expected_ids",
     [('4500474_2133707_2021-05-20_2419', ['4500474_2133707_2021-05-20_2419']),
      ('4500474_2133707_2021-05-20_2419,4500474_2133707_2021-05-20_2420',
-      ['4500474_2133707_2021-05-20_2419', '4500474_2133707_2021-05-20_2420'])
-     ])
+      ['4500474_2133707_2021-05-20_2419', '4500474_2133707_2021-05-20_2420'])])
 @respx.mock
-def test_cli_orders_create_basic_success(
-        expected_ids, id_string, invoke, order_description):
+def test_cli_orders_create_basic_success(expected_ids,
+                                         id_string,
+                                         invoke,
+                                         order_description):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -320,12 +317,13 @@ def test_cli_orders_create_basic_success(
         '--id', id_string,
         '--bundle', 'analytic',
         '--item-type', 'PSOrthoTile'
-        ])
+        ])  # yapf: disable
     assert not result.exception
     assert order_description == json.loads(result.output)
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": expected_ids,
             "item_type": "PSOrthoTile",
@@ -343,7 +341,7 @@ def test_cli_orders_create_basic_item_type_invalid(invoke):
         '--id', '4500474_2133707_2021-05-20_2419',
         '--bundle', 'analytic',
         '--item-type', 'invalid'
-        ])
+        ])  # yapf: disable
     assert result.exception
     assert 'Error: Invalid value: item_type' in result.output
 
@@ -351,18 +349,24 @@ def test_cli_orders_create_basic_item_type_invalid(invoke):
 def test_cli_orders_create_id_empty(invoke):
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '',
-        '--bundle', 'analytic',
-        '--item-type', 'invalid'
-        ])
+        '--name',
+        'test',
+        '--id',
+        '',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'invalid'
+    ])
     assert result.exit_code
     assert 'id cannot be empty string.' in result.output
 
 
 @respx.mock
-def test_cli_orders_create_clip(
-        invoke, geom_geojson, order_description, write_to_tmp_json_file):
+def test_cli_orders_create_clip(invoke,
+                                geom_geojson,
+                                order_description,
+                                write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -370,31 +374,43 @@ def test_cli_orders_create_clip(
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--clip', aoi_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--clip',
+        aoi_file
+    ])
     assert not result.exception
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
         }],
-        "tools": [{'clip': {'aoi': geom_geojson}}]
+        "tools": [{
+            'clip': {
+                'aoi': geom_geojson
+            }
+        }]
     }
     sent_request = json.loads(respx.calls.last.request.content)
     assert sent_request == order_request
 
 
 @respx.mock
-def test_cli_orders_create_clip_featureclass(
-        invoke, featureclass_geojson, geom_geojson, order_description,
-        write_to_tmp_json_file):
+def test_cli_orders_create_clip_featureclass(invoke,
+                                             featureclass_geojson,
+                                             geom_geojson,
+                                             order_description,
+                                             write_to_tmp_json_file):
     """Tests that the clip option takes in feature class geojson as well"""
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -403,67 +419,92 @@ def test_cli_orders_create_clip_featureclass(
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--clip', fc_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--clip',
+        fc_file
+    ])
     assert not result.exception
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
         }],
-        "tools": [{'clip': {'aoi': geom_geojson}}]
+        "tools": [{
+            'clip': {
+                'aoi': geom_geojson
+            }
+        }]
     }
     sent_request = json.loads(respx.calls.last.request.content)
     assert sent_request == order_request
 
 
-def test_cli_orders_create_clip_invalid_geometry(
-        invoke, point_geom_geojson, write_to_tmp_json_file):
+def test_cli_orders_create_clip_invalid_geometry(invoke,
+                                                 point_geom_geojson,
+                                                 write_to_tmp_json_file):
     aoi_file = write_to_tmp_json_file(point_geom_geojson, 'aoi.geojson')
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--clip', aoi_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--clip',
+        aoi_file
+    ])
     assert result.exception
     error_msg = ('Error: Invalid value: Invalid geometry type: ' +
                  'Point is not Polygon.')
     assert error_msg in result.output
 
 
-def test_cli_orders_create_clip_and_tools(
-        invoke, geom_geojson, write_to_tmp_json_file):
+def test_cli_orders_create_clip_and_tools(invoke,
+                                          geom_geojson,
+                                          write_to_tmp_json_file):
     # interestingly, it is important that both clip and tools
     # option values lead to valid json files
     aoi_file = write_to_tmp_json_file(geom_geojson, 'aoi.geojson')
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--clip', aoi_file,
-        '--tools', aoi_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--clip',
+        aoi_file,
+        '--tools',
+        aoi_file
+    ])
     assert result.exception
     assert "Specify only one of '--clip' or '--tools'" in result.output
 
 
 @respx.mock
-def test_cli_orders_create_cloudconfig(
-        invoke, geom_geojson, order_description, write_to_tmp_json_file):
+def test_cli_orders_create_cloudconfig(invoke,
+                                       geom_geojson,
+                                       order_description,
+                                       write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -473,66 +514,81 @@ def test_cli_orders_create_cloudconfig(
             'aws_secret_access_key': 'aws_secret_access_key',
             'bucket': 'bucket',
             'aws_region': 'aws_region'
-            },
+        },
         'archive_type': 'zip'
     }
     config_file = write_to_tmp_json_file(config_json, 'config.json')
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--cloudconfig', config_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--cloudconfig',
+        config_file
+    ])
     assert not result.exception
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
         }],
-        "delivery": config_json
+        "delivery":
+        config_json
     }
     sent_request = json.loads(respx.calls.last.request.content)
     assert sent_request == order_request
 
 
 @respx.mock
-def test_cli_orders_create_email(
-        invoke, geom_geojson, order_description):
+def test_cli_orders_create_email(invoke, geom_geojson, order_description):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
         '--email'
-        ])
+    ])
     assert not result.exception
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
         }],
-        "notifications": {"email": True}
+        "notifications": {
+            "email": True
+        }
     }
     sent_request = json.loads(respx.calls.last.request.content)
     assert sent_request == order_request
 
 
 @respx.mock
-def test_cli_orders_create_tools(
-        invoke, geom_geojson, order_description, write_to_tmp_json_file):
+def test_cli_orders_create_tools(invoke,
+                                 geom_geojson,
+                                 order_description,
+                                 write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -541,22 +597,29 @@ def test_cli_orders_create_tools(
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--tools', tools_file
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--tools',
+        tools_file
+    ])
     assert not result.exception
 
     order_request = {
-        "name": "test",
+        "name":
+        "test",
         "products": [{
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
         }],
-        "tools": tools_json
+        "tools":
+        tools_json
     }
     sent_request = json.loads(respx.calls.last.request.content)
     assert sent_request == order_request
@@ -565,12 +628,17 @@ def test_cli_orders_create_tools(
 def test_cli_orders_read_file_json_doesnotexist(invoke):
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--tools', 'doesnnotexist.json'
-        ])
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--tools',
+        'doesnnotexist.json'
+    ])
     assert result.exception
     error_msg = ("Error: Invalid value for '--tools': 'doesnnotexist.json': " +
                  "No such file or directory")
@@ -584,11 +652,16 @@ def test_cli_orders_read_file_json_invalidjson(invoke, tmp_path):
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile',
-        '--tools', invalid_filename
+        '--name',
+        'test',
+        '--id',
+        '4500474_2133707_2021-05-20_2419',
+        '--bundle',
+        'analytic',
+        '--item-type',
+        'PSOrthoTile',
+        '--tools',
+        invalid_filename
     ])
     assert result.exception
     error_msg = "Error: File does not contain valid json."

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -313,11 +313,11 @@ def test_cli_orders_create_basic_success(expected_ids,
 
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', id_string,
-        '--bundle', 'analytic',
-        '--item-type', 'PSOrthoTile'
-        ])  # yapf: disable
+        '--name=test',
+        f'--id={id_string}',
+        '--bundle=analytic',
+        '--item-type=PSOrthoTile'
+    ])
     assert not result.exception
     assert order_description == json.loads(result.output)
 
@@ -337,11 +337,11 @@ def test_cli_orders_create_basic_success(expected_ids,
 def test_cli_orders_create_basic_item_type_invalid(invoke):
     result = invoke([
         'create',
-        '--name', 'test',
-        '--id', '4500474_2133707_2021-05-20_2419',
-        '--bundle', 'analytic',
-        '--item-type', 'invalid'
-        ])  # yapf: disable
+        '--name=test',
+        '--id=4500474_2133707_2021-05-20_2419',
+        '--bundle=analytic',
+        '--item-type=invalid'
+    ])
     assert result.exception
     assert 'Error: Invalid value: item_type' in result.output
 
@@ -597,16 +597,11 @@ def test_cli_orders_create_tools(invoke,
 
     result = invoke([
         'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
-        tools_file
+        '--name=test',
+        '--id=4500474_2133707_2021-05-20_2419',
+        '--bundle=analytic',
+        '--item-type=PSOrthoTile',
+        f'--tools={tools_file}'
     ])
     assert not result.exception
 
@@ -628,16 +623,11 @@ def test_cli_orders_create_tools(invoke,
 def test_cli_orders_read_file_json_doesnotexist(invoke):
     result = invoke([
         'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
-        'doesnnotexist.json'
+        '--name=test',
+        '--id=4500474_2133707_2021-05-20_2419',
+        '--bundle=analytic',
+        '--item-type=PSOrthoTile',
+        '--tools=doesnnotexist.json'
     ])
     assert result.exception
     error_msg = ("Error: Invalid value for '--tools': 'doesnnotexist.json': " +
@@ -652,16 +642,11 @@ def test_cli_orders_read_file_json_invalidjson(invoke, tmp_path):
 
     result = invoke([
         'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
-        invalid_filename
+        '--name=test',
+        '--id=4500474_2133707_2021-05-20_2419',
+        '--bundle=analytic',
+        '--item-type=PSOrthoTile',
+        f'--tools={invalid_filename}'
     ])
     assert result.exception
     error_msg = "Error: File does not contain valid json."

--- a/tests/unit/test_cli_io.py
+++ b/tests/unit/test_cli_io.py
@@ -18,9 +18,9 @@ import pytest
 from planet.cli import io
 
 
-@pytest.mark.parametrize(
-    "pretty,expected",
-    [(False, '{"key": "val"}'), (True, '{\n  "key": "val"\n}')])
+@pytest.mark.parametrize("pretty,expected",
+                         [(False, '{"key": "val"}'),
+                          (True, '{\n  "key": "val"\n}')])
 @patch('planet.cli.io.click.echo')
 def test_cli_echo_json(mock_echo, pretty, expected):
     obj = {'key': 'val'}

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -29,11 +29,13 @@ def test_cli_info_verbosity(monkeypatch):
     @click.command()
     def test():
         pass
+
     cli.main.add_command(test)
 
     def configtest(stream, level, format):
         nonlocal log_level
         log_level = level
+
     monkeypatch.setattr(cli.logging, 'basicConfig', configtest)
 
     runner = CliRunner()

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -23,6 +23,7 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture
 def assert_geom_equal():
+
     def _tuple_to_list(obj):
         return json.loads(json.dumps(obj).replace(")", "]").replace("(", "["))
 
@@ -30,12 +31,14 @@ def assert_geom_equal():
         str_1 = _tuple_to_list(geom_1)
         str_2 = _tuple_to_list(geom_2)
         assert str_1 == str_2
+
     return fcn
 
 
-def test_geom_from_geojson_success(
-        geom_geojson, feature_geojson, featureclass_geojson,
-        assert_geom_equal):
+def test_geom_from_geojson_success(geom_geojson,
+                                   feature_geojson,
+                                   featureclass_geojson,
+                                   assert_geom_equal):
     ggeo = geojson.as_geom(geom_geojson)
     assert_geom_equal(ggeo, geom_geojson)
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -22,7 +22,6 @@ import pytest
 
 from planet import exceptions, http
 
-
 TEST_URL = 'mock://fantastic.com'
 
 LOGGER = logging.getLogger(__name__)
@@ -31,54 +30,44 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture
 def mock_request():
     r = Mock()
-    r.http_request = httpx.Request(
-        'GET',
-        TEST_URL)
+    r.http_request = httpx.Request('GET', TEST_URL)
     yield r
 
 
 @pytest.fixture
 def mock_response():
+
     def mocker(code, text='', json={"message": "nope"}):
         r = Mock()
         r.status_code = code
         r.text = text
         r.json = Mock(return_value=json)
         return r
+
     return mocker
 
 
 def test_basesession__raise_for_status(mock_response):
-    http.BaseSession._raise_for_status(mock_response(
-        HTTPStatus.CREATED,
-        json={}
-    ))
+    http.BaseSession._raise_for_status(
+        mock_response(HTTPStatus.CREATED, json={}))
 
     with pytest.raises(exceptions.BadQuery):
-        http.BaseSession._raise_for_status(mock_response(
-            HTTPStatus.BAD_REQUEST,
-            json={}
-        ))
+        http.BaseSession._raise_for_status(
+            mock_response(HTTPStatus.BAD_REQUEST, json={}))
 
     with pytest.raises(exceptions.TooManyRequests):
-        http.BaseSession._raise_for_status(mock_response(
-            HTTPStatus.TOO_MANY_REQUESTS,
-            text='',
-            json={}
-        ))
+        http.BaseSession._raise_for_status(
+            mock_response(HTTPStatus.TOO_MANY_REQUESTS, text='', json={}))
 
     with pytest.raises(exceptions.OverQuota):
-        http.BaseSession._raise_for_status(mock_response(
-            HTTPStatus.TOO_MANY_REQUESTS,
-            text='exceeded QUOTA"',
-            json={}
-        ))
+        http.BaseSession._raise_for_status(
+            mock_response(HTTPStatus.TOO_MANY_REQUESTS,
+                          text='exceeded QUOTA"',
+                          json={}))
 
     with pytest.raises(exceptions.APIException):
-        http.BaseSession._raise_for_status(mock_response(
-            HTTPStatus.METHOD_NOT_ALLOWED,
-            json={}
-        ))
+        http.BaseSession._raise_for_status(
+            mock_response(HTTPStatus.METHOD_NOT_ALLOWED, json={}))
 
 
 @pytest.mark.asyncio
@@ -131,6 +120,7 @@ async def test_session_request_retry(mock_request, mock_response):
 @pytest.mark.asyncio
 async def test_session_retry(mock_request):
     async with http.Session() as ps:
+
         async def test_func():
             raise exceptions.TooManyRequests
 
@@ -152,13 +142,9 @@ async def test_authsession_request(mock_request):
 
 def test_authsession__raise_for_status(mock_response):
     with pytest.raises(exceptions.APIException):
-        http.AuthSession._raise_for_status(mock_response(
-            HTTPStatus.BAD_REQUEST,
-            json={}
-            ))
+        http.AuthSession._raise_for_status(
+            mock_response(HTTPStatus.BAD_REQUEST, json={}))
 
     with pytest.raises(exceptions.APIException):
-        http.AuthSession._raise_for_status(mock_response(
-            HTTPStatus.UNAUTHORIZED,
-            json={}
-            ))
+        http.AuthSession._raise_for_status(
+            mock_response(HTTPStatus.UNAUTHORIZED, json={}))

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -87,62 +87,64 @@ def test_StreamingBody_name():
     body = models.StreamingBody(r)
 
     assert body.name.startswith('planet-')
-    assert (body.name.endswith('.tiff') or
-            body.name.endswith('.tif'))
+    assert (body.name.endswith('.tiff') or body.name.endswith('.tif'))
 
 
-@pytest.mark.parametrize('headers,expected', [
-    ({
-        'date': 'Thu, 14 Feb 2019 16:13:26 GMT',
-        'last-modified': 'Wed, 22 Nov 2017 17:22:31 GMT',
-        'accept-ranges': 'bytes',
-        'content-type': 'image/tiff',
-        'content-length': '57350256',
-        'content-disposition': 'attachment; filename="open_california.tif"'
-    }, 'open_california.tif'),
-    ({
-        'date': 'Thu, 14 Feb 2019 16:13:26 GMT',
-        'last-modified': 'Wed, 22 Nov 2017 17:22:31 GMT',
-        'accept-ranges': 'bytes',
-        'content-type': 'image/tiff',
-        'content-length': '57350256'
-    }, None),
-    ({}, None)
-])
+NO_NAME_HEADERS = {
+    'date': 'Thu, 14 Feb 2019 16:13:26 GMT',
+    'last-modified': 'Wed, 22 Nov 2017 17:22:31 GMT',
+    'accept-ranges': 'bytes',
+    'content-type': 'image/tiff',
+    'content-length': '57350256'
+}
+OPEN_CALIFORNIA_HEADERS = NO_NAME_HEADERS.update(
+    {'content-disposition': 'attachment; filename="open_california.tif"'})
+
+
+@pytest.mark.parametrize('headers,expected',
+                         [(OPEN_CALIFORNIA_HEADERS, 'open_california.tif'),
+                          (NO_NAME_HEADERS, None),
+                          ({}, None)])  # yapf: disable
 def test__get_filename_from_headers(headers, expected):
     assert models._get_filename_from_headers(headers) == expected
 
 
-@pytest.mark.parametrize('url,expected', [
-    (URL('https://planet.com/'), None),
-    (URL('https://planet.com/path/to/'), None),
-    (URL('https://planet.com/path/to/example.tif'), 'example.tif'),
-    (URL('https://planet.com/path/to/example.tif?foo=f6f1&bar=baz'),
-     'example.tif'),
-    (URL('https://planet.com/path/to/example.tif?foo=f6f1#quux'),
-     'example.tif'),
-])
+@pytest.mark.parametrize(
+    'url,expected',
+    [
+        (URL('https://planet.com/'), None),
+        (URL('https://planet.com/path/to/'), None),
+        (URL('https://planet.com/path/to/example.tif'), 'example.tif'),
+        (URL('https://planet.com/path/to/example.tif?foo=f6f1&bar=baz'),
+         'example.tif'),
+        (URL('https://planet.com/path/to/example.tif?foo=f6f1#quux'),
+         'example.tif'),
+    ])
 def test__get_filename_from_url(url, expected):
     assert models._get_filename_from_url(url) == expected
 
 
-@pytest.mark.parametrize('content_type,check', [
-    (None, lambda x: re.match(r'^planet-[a-z0-9]{8}$', x, re.I) is not None),
-    ('image/tiff', lambda x: x.endswith(('.tif', '.tiff'))),
-])
+@pytest.mark.parametrize(
+    'content_type,check',
+    [
+        (None,
+         lambda x: re.match(r'^planet-[a-z0-9]{8}$', x, re.I) is not None),
+        ('image/tiff', lambda x: x.endswith(('.tif', '.tiff'))),
+    ])
 def test__get_random_filename(content_type, check):
     assert check(models._get_random_filename(content_type))
 
 
 @pytest.mark.asyncio
 async def test_StreamingBody_write_img(tmpdir, mocked_request, open_test_img):
+
     async def _aiter_bytes():
         data = open_test_img.read()
         v = memoryview(data)
 
         chunksize = 100
-        for i in range(math.ceil(len(v)/(chunksize))):
-            yield v[i*chunksize:min((i+1)*chunksize, len(v))]
+        for i in range(math.ceil(len(v) / (chunksize))):
+            yield v[i * chunksize:min((i + 1) * chunksize, len(v))]
 
     r = MagicMock(name='response')
     hr = MagicMock(name='http_response')
@@ -161,14 +163,9 @@ async def test_StreamingBody_write_img(tmpdir, mocked_request, open_test_img):
 
 @pytest.fixture
 def get_pages():
-    p1 = {'links': {'next': 'blah'},
-          'items': [1, 2]}
-    p2 = {'links': {},
-          'items': [3, 4]}
-    responses = [
-        mock_http_response(json=p1),
-        mock_http_response(json=p2)
-    ]
+    p1 = {'links': {'next': 'blah'}, 'items': [1, 2]}
+    p2 = {'links': {}, 'items': [3, 4]}
+    responses = [mock_http_response(json=p1), mock_http_response(json=p2)]
 
     async def do_get(req):
         return responses.pop(0)
@@ -195,8 +192,7 @@ def get_orders_pages(orders_page):
     page2 = copy.deepcopy(orders_page)
     del page2['_links']['next']
     responses = [
-        mock_http_response(json=orders_page),
-        mock_http_response(json=page2)
+        mock_http_response(json=orders_page), mock_http_response(json=page2)
     ]
 
     async def do_get(req):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -97,8 +97,14 @@ NO_NAME_HEADERS = {
     'content-type': 'image/tiff',
     'content-length': '57350256'
 }
-OPEN_CALIFORNIA_HEADERS = NO_NAME_HEADERS.update(
-    {'content-disposition': 'attachment; filename="open_california.tif"'})
+OPEN_CALIFORNIA_HEADERS = {
+    'date': 'Thu, 14 Feb 2019 16:13:26 GMT',
+    'last-modified': 'Wed, 22 Nov 2017 17:22:31 GMT',
+    'accept-ranges': 'bytes',
+    'content-type': 'image/tiff',
+    'content-length': '57350256',
+    'content-disposition': 'attachment; filename="open_california.tif"'
+}
 
 
 @pytest.mark.parametrize('headers,expected',

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -28,39 +28,36 @@ TEST_ARCHIVE_FILENAME = '{{name}}_b_{order_id}}.zip'
 
 def test_build_request():
     product = {
-      "item_ids": [TEST_ID],
-      "item_type": TEST_ITEM_TYPE,
-      "product_bundle": f'{TEST_PRODUCT_BUNDLE},{TEST_FALLBACK_BUNDLE}'
-      }
+        "item_ids": [TEST_ID],
+        "item_type": TEST_ITEM_TYPE,
+        "product_bundle": f'{TEST_PRODUCT_BUNDLE},{TEST_FALLBACK_BUNDLE}'
+    }
     subscription_id = 5
     delivery = {
-      'archive_type': 'zip',
-      'single_archive': True,
-      'archive_filename': TEST_ARCHIVE_FILENAME,
-      'amazon_s3': {
+        'archive_type': 'zip',
+        'single_archive': True,
+        'archive_filename': TEST_ARCHIVE_FILENAME,
+        'amazon_s3': {
             'aws_access_key_id': 'aws_access_key_id',
             'aws_secret_access_key': 'aws_secret_access_key',
             'bucket': 'bucket',
             'aws_region': 'aws_region'
-            }
-      }
+        }
+    }
     notifications = {
-      'email': 'email',
-      'webhook_url': 'webhookurl',
-      'webhook_per_order': True
-      }
+        'email': 'email',
+        'webhook_url': 'webhookurl',
+        'webhook_per_order': True
+    }
     order_type = 'partial'
     tool = {'band_math': 'jsonstring'}
 
-    request = order_request.build_request(
-        'test_name',
-        [product],
-        subscription_id=subscription_id,
-        delivery=delivery,
-        notifications=notifications,
-        order_type=order_type,
-        tools=[tool]
-        )
+    request = order_request.build_request('test_name', [product],
+                                          subscription_id=subscription_id,
+                                          delivery=delivery,
+                                          notifications=notifications,
+                                          order_type=order_type,
+                                          tools=[tool])
     expected = {
         'name': 'test_name',
         'products': [product],
@@ -74,27 +71,26 @@ def test_build_request():
 
     order_type = 'notsupported'
     with pytest.raises(specs.SpecificationException):
-        _ = order_request.build_request(
-            'test_name',
-            [product],
-            subscription_id=subscription_id,
-            delivery=delivery,
-            notifications=notifications,
-            order_type=order_type,
-            tools=[tool]
-            )
+        _ = order_request.build_request('test_name', [product],
+                                        subscription_id=subscription_id,
+                                        delivery=delivery,
+                                        notifications=notifications,
+                                        order_type=order_type,
+                                        tools=[tool])
 
 
 def test_product():
     product_config = order_request.product(
-        [TEST_ID], TEST_PRODUCT_BUNDLE, TEST_ITEM_TYPE,
+        [TEST_ID],
+        TEST_PRODUCT_BUNDLE,
+        TEST_ITEM_TYPE,
         fallback_bundle=TEST_FALLBACK_BUNDLE)
 
     expected = {
-      "item_ids": [TEST_ID],
-      "item_type": TEST_ITEM_TYPE,
-      "product_bundle": f'{TEST_PRODUCT_BUNDLE},{TEST_FALLBACK_BUNDLE}'
-      }
+        "item_ids": [TEST_ID],
+        "item_type": TEST_ITEM_TYPE,
+        "product_bundle": f'{TEST_PRODUCT_BUNDLE},{TEST_FALLBACK_BUNDLE}'
+    }
     assert product_config == expected
 
     with pytest.raises(specs.SpecificationException):
@@ -118,19 +114,15 @@ def test_product():
 
 def test_notifications():
     notifications_config = order_request.notifications(
-        email='email',
-        webhook_url='webhookurl',
-        webhook_per_order=True
-    )
+        email='email', webhook_url='webhookurl', webhook_per_order=True)
     expected = {
-      'email': 'email',
-      'webhook_url': 'webhookurl',
-      'webhook_per_order': True
-      }
+        'email': 'email',
+        'webhook_url': 'webhookurl',
+        'webhook_per_order': True
+    }
     assert notifications_config == expected
 
-    empty_notifications_config = order_request.notifications(
-    )
+    empty_notifications_config = order_request.notifications()
     empty_expected = {}
     assert empty_notifications_config == empty_expected
 
@@ -142,74 +134,65 @@ def test_delivery():
             'aws_secret_access_key': 'aws_secret_access_key',
             'bucket': 'bucket',
             'aws_region': 'aws_region'
-            }
+        }
     }
-    delivery_config = order_request.delivery(
-        'zip',
-        True,
-        TEST_ARCHIVE_FILENAME,
-        cloud_config=as3_config
-    )
+    delivery_config = order_request.delivery('zip',
+                                             True,
+                                             TEST_ARCHIVE_FILENAME,
+                                             cloud_config=as3_config)
 
     expected = {
-      'archive_type': 'zip',
-      'single_archive': True,
-      'archive_filename': TEST_ARCHIVE_FILENAME,
-      'amazon_s3': {
+        'archive_type': 'zip',
+        'single_archive': True,
+        'archive_filename': TEST_ARCHIVE_FILENAME,
+        'amazon_s3': {
             'aws_access_key_id': 'aws_access_key_id',
             'aws_secret_access_key': 'aws_secret_access_key',
             'bucket': 'bucket',
             'aws_region': 'aws_region'
-            }
-      }
+        }
+    }
     assert delivery_config == expected
 
 
 def test_amazon_s3():
-    as3_config = order_request.amazon_s3(
-        'aws_access_key_id',
-        'aws_secret_access_key',
-        'bucket',
-        'aws_region'
-    )
+    as3_config = order_request.amazon_s3('aws_access_key_id',
+                                         'aws_secret_access_key',
+                                         'bucket',
+                                         'aws_region')
     expected = {
         'amazon_s3': {
             'aws_access_key_id': 'aws_access_key_id',
             'aws_secret_access_key': 'aws_secret_access_key',
             'bucket': 'bucket',
             'aws_region': 'aws_region'
-            }
+        }
     }
     assert as3_config == expected
 
 
 def test_azure_blob_storage():
-    abs_config = order_request.azure_blob_storage(
-        'account',
-        'container',
-        'sas_token'
-    )
+    abs_config = order_request.azure_blob_storage('account',
+                                                  'container',
+                                                  'sas_token')
     expected = {
         'azure_blob_storage': {
             'account': 'account',
             'container': 'container',
             'sas_token': 'sas_token',
-            }
+        }
     }
     assert abs_config == expected
 
 
 def test_google_cloud_storage():
-    gcs_config = order_request.google_cloud_storage(
-        'bucket',
-        'credentials'
-    )
+    gcs_config = order_request.google_cloud_storage('bucket', 'credentials')
 
     expected = {
         'google_cloud_storage': {
             'bucket': 'bucket',
             'credentials': 'credentials',
-            }
+        }
     }
     assert gcs_config == expected
 
@@ -220,7 +203,7 @@ def test_google_earth_engine():
         'google_earth_engine': {
             'project': 'project',
             'collection': 'collection',
-            }
+        }
     }
 
     assert gee_config == expected
@@ -236,10 +219,7 @@ def test__tool():
 
 def test_clip_tool(geom_geojson, point_geom_geojson):
     ct = order_request.clip_tool(geom_geojson)
-    expected = {
-        'clip': {
-            'aoi': geom_geojson
-        }}
+    expected = {'clip': {'aoi': geom_geojson}}
     assert ct == expected
 
     with pytest.raises(geojson.WrongTypeException):
@@ -247,46 +227,22 @@ def test_clip_tool(geom_geojson, point_geom_geojson):
 
 
 def test_reproject_tool():
-    rt = order_request.reproject_tool(
-        projection='proj',
-        resolution=5
-    )
-    expected = {
-        'reproject': {
-            'projection': 'proj',
-            'resolution': 5
-            }
-        }
+    rt = order_request.reproject_tool(projection='proj', resolution=5)
+    expected = {'reproject': {'projection': 'proj', 'resolution': 5}}
     assert rt == expected
 
 
 def test_tile_tool():
-    tt = order_request.tile_tool(
-        30,
-        pixel_size=3
-    )
-    expected = {
-        'tile': {
-            'tile_size': 30,
-            'pixel_size': 3
-        }
-    }
+    tt = order_request.tile_tool(30, pixel_size=3)
+    expected = {'tile': {'tile_size': 30, 'pixel_size': 3}}
     assert tt == expected
 
 
 def test_toar_tool():
-    tt = order_request.toar_tool(
-        scale_factor=5
-    )
-    expected = {
-        'toar': {
-            'scale_factor': 5
-            }
-    }
+    tt = order_request.toar_tool(scale_factor=5)
+    expected = {'toar': {'scale_factor': 5}}
     assert tt == expected
 
     tt_empty = order_request.toar_tool()
-    expected_empty = {
-        'toar': {}
-    }
+    expected_empty = {'toar': {}}
     assert tt_empty == expected_empty

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -22,11 +22,11 @@ LOGGER = logging.getLogger(__name__)
 def test_StateBar_enabled():
     with reporting.StateBar() as bar:
         expected_init = '..:.. - order  - state: '
-        assert(re.fullmatch(expected_init, str(bar)))
+        assert (re.fullmatch(expected_init, str(bar)))
 
         expected_update = '..:.. - order 1 - state: init'
         bar.update(order_id='1', state='init')
-        assert(re.fullmatch(expected_update, str(bar)))
+        assert (re.fullmatch(expected_update, str(bar)))
 
 
 def test_StateBar_disabled():

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -25,10 +25,7 @@ TEST_ITEM_TYPE = 'PSOrthoTile'
 
 
 def test_get_type_match():
-    spec_list = [
-        'Locket',
-        'drop',
-        'DEER']
+    spec_list = ['Locket', 'drop', 'DEER']
 
     test_entry = 'locket'
     assert 'Locket' == specs.get_match(test_entry, spec_list)


### PR DESCRIPTION
Add yapf linting. yapf is installed as a part of the tests sub-package. Running yapf as a linter is included in nox automated testing (which is also what is run in github actions). yapf is directed to ignore all hidden directories.


Modify pep8 style with `split_all_top_level_comma_separated_values=True`.

See #406 to see the effect of removing this modifier.