### PR TITLE
revert yapf linting to pure pep8

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -34,15 +34,8 @@ def docs_test(session):
 
     # Because these doc examples can be long-running, output
     # the INFO and above log messages so we know what's happening
-    session.run('pytest',
-                '--doctest-glob',
-                '*.md',
-                '--no-cov',
-                '--ignore',
-                'examples/',
-                '--ignore',
-                'tests/',
-                '--log-cli-level=INFO',
+    session.run('pytest', '--doctest-glob', '*.md', '--no-cov', '--ignore',
+                'examples/', '--ignore', 'tests/', '--log-cli-level=INFO',
                 *options)
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -218,16 +218,8 @@ def read_file_json(ctx, param, value):
               type=click.File('rb'),
               callback=read_file_json)
 @pretty
-async def create(ctx,
-                 name,
-                 ids,
-                 bundle,
-                 item_type,
-                 email,
-                 cloudconfig,
-                 clip,
-                 tools,
-                 pretty):
+async def create(ctx, name, ids, bundle, item_type, email, cloudconfig, clip,
+                 tools, pretty):
     '''Create an order.'''
     try:
         product = planet.order_request.product(ids, bundle, item_type)

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -20,15 +20,8 @@ from pathlib import Path
 DATA_DIR = 'data'
 PRODUCT_BUNDLE_SPEC_NAME = 'orders_product_bundle_2020_03_10.json'
 SUPPORTED_TOOLS = [
-    'band_math',
-    'clip',
-    'composite',
-    'coregister',
-    'file_format',
-    'reproject',
-    'tile',
-    'toar',
-    'harmonize'
+    'band_math', 'clip', 'composite', 'coregister', 'file_format', 'reproject',
+    'tile', 'toar', 'harmonize'
 ]
 SUPPORTED_ORDER_TYPES = ['full', 'partial']
 SUPPORTED_ARCHIVE_TYPES = ['zip']
@@ -59,8 +52,7 @@ def validate_order_type(order_type):
 
 
 def validate_archive_type(archive_type):
-    return _validate_field(archive_type,
-                           SUPPORTED_ARCHIVE_TYPES,
+    return _validate_field(archive_type, SUPPORTED_ARCHIVE_TYPES,
                            'archive_type')
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,3 @@ show_missing = True
 
 [yapf]
 based_on_style = pep8
-split_all_top_level_comma_separated_values=true

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ test_requires = [
 lint_requires = ['flake8', 'yapf']
 
 doc_requires = [
-    'mkdocs==1.1',
-    'mkdocs-click==0.4.0',
-    'mkdocs-material',
+    'mkdocs==1.1', 'mkdocs-click==0.4.0', 'mkdocs-material',
     'mkdocstrings==0.15.0'
 ]
 
@@ -49,14 +47,11 @@ setup(
     description=u"Planet SDK for Python",
     long_description=Path("README.md").read_text("utf-8"),
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Console',
+        'Development Status :: 2 - Pre-Alpha', 'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development',
+        'Operating System :: OS Independent', 'Programming Language :: Python',
+        'Topic :: Scientific/Engineering', 'Topic :: Software Development',
         'Topic :: Utilities'
     ],
     keywords='planet api sdk client',

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -87,7 +87,8 @@ async def test_list_orders_basic(order_descriptions, session):
 
     page1_response = {
         "_links": {
-            "_self": "string", "next": next_page_url
+            "_self": "string",
+            "next": next_page_url
         },
         "orders": [order1, order2]
     }
@@ -115,7 +116,8 @@ async def test_list_orders_state(order_descriptions, session):
     page1_response = {
         "_links": {
             "_self": "string"
-        }, "orders": [order1, order2]
+        },
+        "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(list_url).return_value = mock_resp
@@ -147,7 +149,8 @@ async def test_list_orders_limit(order_descriptions, session):
 
     page1_response = {
         "_links": {
-            "_self": "string", "next": nono_page_url
+            "_self": "string",
+            "next": nono_page_url
         },
         "orders": [order1, order2]
     }
@@ -219,8 +222,7 @@ async def test_create_order_bad_item_type(order_request, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_create_order_item_id_does_not_exist(order_request,
-                                                   session,
+async def test_create_order_item_id_does_not_exist(order_request, session,
                                                    match_pytest_raises):
     resp = {
         "field": {
@@ -322,8 +324,7 @@ async def test_cancel_order_id_doesnt_exist(oid, session, match_pytest_raises):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_cancel_order_id_cannot_be_cancelled(oid,
-                                                   session,
+async def test_cancel_order_id_cannot_be_cancelled(oid, session,
                                                    match_pytest_raises):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
 
@@ -385,8 +386,10 @@ async def test_cancel_orders_all(session):
         "result": {
             "succeeded": {
                 "count": 2
-            }, "failed": {
-                "count": 0, "failures": []
+            },
+            "failed": {
+                "count": 0,
+                "failures": []
             }
         }
     }
@@ -460,10 +463,12 @@ async def test_poll_invalid_state(oid, session):
 async def test_aggegated_order_stats(session):
     example_stats = {
         "organization": {
-            "queued_orders": 0, "running_orders": 6
+            "queued_orders": 0,
+            "running_orders": 6
         },
         "user": {
-            "queued_orders": 0, "running_orders": 0
+            "queued_orders": 0,
+            "running_orders": 0
         }
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=example_stats)
@@ -587,11 +592,7 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
 @respx.mock
 @pytest.mark.asyncio
 async def test_download_order_overwrite_true_preexisting_data(
-        tmpdir,
-        oid,
-        session,
-        create_download_mock,
-        original_content,
+        tmpdir, oid, session, create_download_mock, original_content,
         downloaded_content):
     '''
     Test if download_order() overwrites pre-existing data with

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -49,7 +49,8 @@ def test_cli_orders_list_basic(invoke, order_descriptions):
 
     page1_response = {
         "_links": {
-            "_self": "string", "next": next_page_url
+            "_self": "string",
+            "next": next_page_url
         },
         "orders": [order1, order2]
     }
@@ -85,7 +86,8 @@ def test_cli_orders_list_state(invoke, order_descriptions):
     page1_response = {
         "_links": {
             "_self": "string"
-        }, "orders": [order1, order2]
+        },
+        "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(list_url).return_value = mock_resp
@@ -104,7 +106,8 @@ def test_cli_orders_list_limit(invoke, order_descriptions):
     page1_response = {
         "_links": {
             "_self": "string"
-        }, "orders": [order1, order2]
+        },
+        "orders": [order1, order2]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
 
@@ -124,7 +127,8 @@ def test_cli_orders_list_pretty(invoke, monkeypatch, order_description):
     page1_response = {
         "_links": {
             "_self": "string"
-        }, "orders": [order_description]
+        },
+        "orders": [order_description]
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
     respx.get(TEST_ORDERS_URL).return_value = mock_resp
@@ -260,9 +264,7 @@ def test_cli_orders_download_dest(invoke, mock_download_response, oid):
 
 
 @respx.mock
-def test_cli_orders_download_overwrite(invoke,
-                                       mock_download_response,
-                                       oid,
+def test_cli_orders_download_overwrite(invoke, mock_download_response, oid,
                                        write_to_tmp_json_file):
     mock_download_response()
 
@@ -304,9 +306,7 @@ def test_cli_orders_download_quiet(invoke, mock_download_response, oid):
      ('4500474_2133707_2021-05-20_2419,4500474_2133707_2021-05-20_2420',
       ['4500474_2133707_2021-05-20_2419', '4500474_2133707_2021-05-20_2420'])])
 @respx.mock
-def test_cli_orders_create_basic_success(expected_ids,
-                                         id_string,
-                                         invoke,
+def test_cli_orders_create_basic_success(expected_ids, id_string, invoke,
                                          order_description):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -348,24 +348,15 @@ def test_cli_orders_create_basic_item_type_invalid(invoke):
 
 def test_cli_orders_create_id_empty(invoke):
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'invalid'
+        'create', '--name', 'test', '--id', '', '--bundle', 'analytic',
+        '--item-type', 'invalid'
     ])
     assert result.exit_code
     assert 'id cannot be empty string.' in result.output
 
 
 @respx.mock
-def test_cli_orders_create_clip(invoke,
-                                geom_geojson,
-                                order_description,
+def test_cli_orders_create_clip(invoke, geom_geojson, order_description,
                                 write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -373,16 +364,8 @@ def test_cli_orders_create_clip(invoke,
     aoi_file = write_to_tmp_json_file(geom_geojson, 'aoi.geojson')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--clip',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--clip',
         aoi_file
     ])
     assert not result.exception
@@ -406,10 +389,8 @@ def test_cli_orders_create_clip(invoke,
 
 
 @respx.mock
-def test_cli_orders_create_clip_featureclass(invoke,
-                                             featureclass_geojson,
-                                             geom_geojson,
-                                             order_description,
+def test_cli_orders_create_clip_featureclass(invoke, featureclass_geojson,
+                                             geom_geojson, order_description,
                                              write_to_tmp_json_file):
     """Tests that the clip option takes in feature class geojson as well"""
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
@@ -418,17 +399,8 @@ def test_cli_orders_create_clip_featureclass(invoke,
     fc_file = write_to_tmp_json_file(featureclass_geojson, 'fc.geojson')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--clip',
-        fc_file
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--clip', fc_file
     ])
     assert not result.exception
 
@@ -450,22 +422,13 @@ def test_cli_orders_create_clip_featureclass(invoke,
     assert sent_request == order_request
 
 
-def test_cli_orders_create_clip_invalid_geometry(invoke,
-                                                 point_geom_geojson,
+def test_cli_orders_create_clip_invalid_geometry(invoke, point_geom_geojson,
                                                  write_to_tmp_json_file):
     aoi_file = write_to_tmp_json_file(point_geom_geojson, 'aoi.geojson')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--clip',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--clip',
         aoi_file
     ])
     assert result.exception
@@ -474,36 +437,23 @@ def test_cli_orders_create_clip_invalid_geometry(invoke,
     assert error_msg in result.output
 
 
-def test_cli_orders_create_clip_and_tools(invoke,
-                                          geom_geojson,
+def test_cli_orders_create_clip_and_tools(invoke, geom_geojson,
                                           write_to_tmp_json_file):
     # interestingly, it is important that both clip and tools
     # option values lead to valid json files
     aoi_file = write_to_tmp_json_file(geom_geojson, 'aoi.geojson')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--clip',
-        aoi_file,
-        '--tools',
-        aoi_file
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--clip',
+        aoi_file, '--tools', aoi_file
     ])
     assert result.exception
     assert "Specify only one of '--clip' or '--tools'" in result.output
 
 
 @respx.mock
-def test_cli_orders_create_cloudconfig(invoke,
-                                       geom_geojson,
-                                       order_description,
+def test_cli_orders_create_cloudconfig(invoke, geom_geojson, order_description,
                                        write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -520,16 +470,8 @@ def test_cli_orders_create_cloudconfig(invoke,
     config_file = write_to_tmp_json_file(config_json, 'config.json')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--cloudconfig',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--cloudconfig',
         config_file
     ])
     assert not result.exception
@@ -555,16 +497,8 @@ def test_cli_orders_create_email(invoke, geom_geojson, order_description):
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--email'
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--email'
     ])
     assert not result.exception
 
@@ -585,9 +519,7 @@ def test_cli_orders_create_email(invoke, geom_geojson, order_description):
 
 
 @respx.mock
-def test_cli_orders_create_tools(invoke,
-                                 geom_geojson,
-                                 order_description,
+def test_cli_orders_create_tools(invoke, geom_geojson, order_description,
                                  write_to_tmp_json_file):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
@@ -596,16 +528,8 @@ def test_cli_orders_create_tools(invoke,
     tools_file = write_to_tmp_json_file(tools_json, 'tools.json')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--tools',
         tools_file
     ])
     assert not result.exception
@@ -627,16 +551,8 @@ def test_cli_orders_create_tools(invoke,
 
 def test_cli_orders_read_file_json_doesnotexist(invoke):
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--tools',
         'doesnnotexist.json'
     ])
     assert result.exception
@@ -651,16 +567,8 @@ def test_cli_orders_read_file_json_invalidjson(invoke, tmp_path):
         fp.write('[Invali]d j*son')
 
     result = invoke([
-        'create',
-        '--name',
-        'test',
-        '--id',
-        '4500474_2133707_2021-05-20_2419',
-        '--bundle',
-        'analytic',
-        '--item-type',
-        'PSOrthoTile',
-        '--tools',
+        'create', '--name', 'test', '--id', '4500474_2133707_2021-05-20_2419',
+        '--bundle', 'analytic', '--item-type', 'PSOrthoTile', '--tools',
         invalid_filename
     ])
     assert result.exception

--- a/tests/unit/test_cli_io.py
+++ b/tests/unit/test_cli_io.py
@@ -18,9 +18,8 @@ import pytest
 from planet.cli import io
 
 
-@pytest.mark.parametrize("pretty,expected",
-                         [(False, '{"key": "val"}'),
-                          (True, '{\n  "key": "val"\n}')])
+@pytest.mark.parametrize("pretty,expected", [(False, '{"key": "val"}'),
+                                             (True, '{\n  "key": "val"\n}')])
 @patch('planet.cli.io.click.echo')
 def test_cli_echo_json(mock_echo, pretty, expected):
     obj = {'key': 'val'}

--- a/tests/unit/test_geojson.py
+++ b/tests/unit/test_geojson.py
@@ -35,10 +35,8 @@ def assert_geom_equal():
     return fcn
 
 
-def test_geom_from_geojson_success(geom_geojson,
-                                   feature_geojson,
-                                   featureclass_geojson,
-                                   assert_geom_equal):
+def test_geom_from_geojson_success(geom_geojson, feature_geojson,
+                                   featureclass_geojson, assert_geom_equal):
     ggeo = geojson.as_geom(geom_geojson)
     assert_geom_equal(ggeo, geom_geojson)
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -115,28 +115,23 @@ def test__get_filename_from_headers(headers, expected):
     assert models._get_filename_from_headers(headers) == expected
 
 
-@pytest.mark.parametrize(
-    'url,expected',
-    [
-        (URL('https://planet.com/'), None),
-        (URL('https://planet.com/path/to/'), None),
-        (URL('https://planet.com/path/to/example.tif'), 'example.tif'),
-        (URL('https://planet.com/path/to/example.tif?foo=f6f1&bar=baz'),
-         'example.tif'),
-        (URL('https://planet.com/path/to/example.tif?foo=f6f1#quux'),
-         'example.tif'),
-    ])
+@pytest.mark.parametrize('url,expected', [
+    (URL('https://planet.com/'), None),
+    (URL('https://planet.com/path/to/'), None),
+    (URL('https://planet.com/path/to/example.tif'), 'example.tif'),
+    (URL('https://planet.com/path/to/example.tif?foo=f6f1&bar=baz'),
+     'example.tif'),
+    (URL('https://planet.com/path/to/example.tif?foo=f6f1#quux'),
+     'example.tif'),
+])
 def test__get_filename_from_url(url, expected):
     assert models._get_filename_from_url(url) == expected
 
 
-@pytest.mark.parametrize(
-    'content_type,check',
-    [
-        (None,
-         lambda x: re.match(r'^planet-[a-z0-9]{8}$', x, re.I) is not None),
-        ('image/tiff', lambda x: x.endswith(('.tif', '.tiff'))),
-    ])
+@pytest.mark.parametrize('content_type,check', [
+    (None, lambda x: re.match(r'^planet-[a-z0-9]{8}$', x, re.I) is not None),
+    ('image/tiff', lambda x: x.endswith(('.tif', '.tiff'))),
+])
 def test__get_random_filename(content_type, check):
     assert check(models._get_random_filename(content_type))
 
@@ -198,7 +193,8 @@ def get_orders_pages(orders_page):
     page2 = copy.deepcopy(orders_page)
     del page2['_links']['next']
     responses = [
-        mock_http_response(json=orders_page), mock_http_response(json=page2)
+        mock_http_response(json=orders_page),
+        mock_http_response(json=page2)
     ]
 
     async def do_get(req):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -97,8 +97,14 @@ NO_NAME_HEADERS = {
     'content-type': 'image/tiff',
     'content-length': '57350256'
 }
-OPEN_CALIFORNIA_HEADERS = NO_NAME_HEADERS.update(
-    {'content-disposition': 'attachment; filename="open_california.tif"'})
+OPEN_CALIFORNIA_HEADERS = {
+    'date': 'Thu, 14 Feb 2019 16:13:26 GMT',
+    'last-modified': 'Wed, 22 Nov 2017 17:22:31 GMT',
+    'accept-ranges': 'bytes',
+    'content-type': 'image/tiff',
+    'content-length': '57350256',
+    'content-disposition': 'attachment; filename="open_california.tif"'
+}
 
 
 @pytest.mark.parametrize('headers,expected',

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -157,8 +157,7 @@ def test_delivery():
 
 def test_amazon_s3():
     as3_config = order_request.amazon_s3('aws_access_key_id',
-                                         'aws_secret_access_key',
-                                         'bucket',
+                                         'aws_secret_access_key', 'bucket',
                                          'aws_region')
     expected = {
         'amazon_s3': {
@@ -172,8 +171,7 @@ def test_amazon_s3():
 
 
 def test_azure_blob_storage():
-    abs_config = order_request.azure_blob_storage('account',
-                                                  'container',
+    abs_config = order_request.azure_blob_storage('account', 'container',
                                                   'sas_token')
     expected = {
         'azure_blob_storage': {


### PR DESCRIPTION
Removes `split_all_top_level_comma_separated_values=True` modifier.

This is prepared for discussion around whether to use the `split_all_top_level_comma_separated_values=True` modifier.