### PR TITLE
describe and implement exception design

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,28 @@
+# Design
+
+## Overview
+
+This document outlines the high-level design that informs the development of
+the Planet SDK for Python.
+
+## Errors
+
+### API Exceptions
+
+Exception hierarchy:
+ - Every exception inherits from the base exception, `PlanetError`.
+ - All client-side exceptions are raised as `ClientError`.
+ - All server-side errors are raised as specific exceptions based on the 
+http code. They all inherit from `APIError` and contain the unedited server 
+error message.
+
+### CLI Return Codes
+
+The following are the values and descriptions of all return codes 
+that can be returned at the end of running a Planet CLI command.
+
+| Value | Description |
+| ----------- | ----------- |
+| 0 | Command was run successfully. |
+| 1 | An error occured while the command was running. |
+| 2 | Command was not run due to invalid syntax or unknown or invalid parameter.|

--- a/planet/cli/cmds.py
+++ b/planet/cli/cmds.py
@@ -59,7 +59,7 @@ def translate_exceptions(func):
             raise click.ClickException(
                 'Auth information does not exist or is corrupted. Initialize '
                 'with `planet auth init`.')
-        except exceptions.PlanetException as ex:
+        except exceptions.PlanetError as ex:
             raise click.ClickException(ex)
 
     return wrapper

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -13,7 +13,6 @@
 # the License.
 """Functionality for interacting with the orders api"""
 import asyncio
-import json
 import logging
 import os
 import time
@@ -146,24 +145,12 @@ class OrdersClient():
             The ID of the order
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         '''
         url = self._orders_url()
+
         req = self._request(url, method='POST', json=request)
-
-        try:
-            resp = await self._do_request(req)
-        except exceptions.BadQuery as ex:
-            msg_json = json.loads(ex.message)
-
-            msg = msg_json['general'][0]['message']
-            try:
-                # get first error field
-                field = next(iter(msg_json['field'].keys()))
-                msg += ' - ' + msg_json['field'][field][0]['message']
-            except AttributeError:
-                pass
-            raise exceptions.BadQuery(msg)
+        resp = await self._do_request(req)
 
         order = Order(resp.json())
         return order
@@ -179,19 +166,13 @@ class OrdersClient():
 
         Raises:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         '''
         self._check_order_id(order_id)
         url = f'{self._orders_url()}/{order_id}'
 
         req = self._request(url, method='GET')
-
-        try:
-            resp = await self._do_request(req)
-        except exceptions.MissingResource as ex:
-            msg_json = json.loads(ex.message)
-            msg = msg_json['message']
-            raise exceptions.MissingResource(msg)
+        resp = await self._do_request(req)
 
         order = Order(resp.json())
         return order
@@ -211,21 +192,14 @@ class OrdersClient():
 
         Raises:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         '''
         self._check_order_id(order_id)
         url = f'{self._orders_url()}/{order_id}'
 
         req = self._request(url, method='PUT')
 
-        try:
-            await self._do_request(req)
-        except exceptions.Conflict as ex:
-            msg = json.loads(ex.message)['message']
-            raise exceptions.Conflict(msg)
-        except exceptions.MissingResource as ex:
-            msg = json.loads(ex.message)['message']
-            raise exceptions.MissingResource(msg)
+        await self._do_request(req)
 
     async def cancel_orders(self, order_ids: typing.List[str] = None) -> dict:
         '''Cancel queued orders in bulk.
@@ -240,7 +214,7 @@ class OrdersClient():
         Raises:
             planet.exceptions.ClientError: If an entry in order_ids is not a
                 valid UUID.
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         '''
         url = f'{self._base_url}{BULK_PATH}/cancel'
         cancel_body = {}
@@ -260,7 +234,7 @@ class OrdersClient():
             Aggregated order counts
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         '''
         url = self._stats_url()
         req = self._request(url, method='GET')
@@ -286,7 +260,7 @@ class OrdersClient():
             Path to downloaded file.
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
         """
         req = self._request(location, method='GET')
 
@@ -315,7 +289,7 @@ class OrdersClient():
             Paths to downloaded files.
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If the order is not in a final
                 state.
         """
@@ -386,7 +360,7 @@ class OrdersClient():
             State of the order.
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If order_id or state is not valid or
                 if the maximum number of attempts is reached before the
                 specified state or a final state is reached.
@@ -441,7 +415,7 @@ class OrdersClient():
             User orders that match the query
 
         Raises:
-            planet.exceptions.APIException: On API error.
+            planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If state is not valid.
         """
         url = self._orders_url()

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -13,74 +13,65 @@
 # limitations under the License.
 
 
-class PlanetException(Exception):
+class PlanetError(Exception):
     """Root for all exceptions thrown by the SDK"""
     pass
 
 
-class APIException(PlanetException):
+class APIError(PlanetError):
     '''General unexpected API response'''
 
-    @property
-    def message(self):
-        return self.args[0]
 
-
-class BadQuery(APIException):
+class BadQuery(APIError):
     '''Invalid inputs, HTTP 400'''
     pass
 
 
-class InvalidAPIKey(APIException):
+class InvalidAPIKey(APIError):
     '''Invalid key, HTTP 401'''
     pass
 
 
-class NoPermission(APIException):
+class NoPermission(APIError):
     '''Insufficient permissions, HTTP 403'''
     pass
 
 
-class MissingResource(APIException):
+class MissingResource(APIError):
     '''Request for non existing resource, HTTP 404'''
     pass
 
 
-class Conflict(APIException):
+class Conflict(APIError):
     '''Request conflict with current state of the target resource, HTTP 409'''
     pass
 
 
-class TooManyRequests(APIException):
+class TooManyRequests(APIError):
     '''Too many requests, HTTP 429'''
     pass
 
 
-class OverQuota(APIException):
+class OverQuota(APIError):
     '''Quota exceeded, HTTP 429'''
     pass
 
 
-class ServerError(APIException):
+class ServerError(APIError):
     '''Unexpected internal server error, HTTP 500'''
     pass
 
 
-class InvalidIdentity(APIException):
+class InvalidIdentity(APIError):
     '''Raised when logging in with invalid credentials'''
     pass
 
 
-class ClientError(PlanetException):
+class ClientError(PlanetError):
     """Exceptions thrown client-side"""
     pass
 
 
 class AuthException(ClientError):
     '''Exceptions encountered during authentication'''
-    pass
-
-
-class RequestCancelled(ClientError):
-    '''Internal exception when a request is cancelled'''
     pass

--- a/planet/http.py
+++ b/planet/http.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Planet Labs, Inc.
+# Copyright 2020 Planet Labs, PBC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -27,11 +27,6 @@ RETRY_COUNT = 5
 RETRY_WAIT_TIME = 1  # seconds
 
 LOGGER = logging.getLogger(__name__)
-
-
-class SessionException(Exception):
-    '''exceptions thrown by Session'''
-    pass
 
 
 class BaseSession():
@@ -66,7 +61,7 @@ class BaseSession():
             HTTPStatus.CONFLICT: exceptions.Conflict,
             HTTPStatus.TOO_MANY_REQUESTS: exceptions.TooManyRequests,
             HTTPStatus.INTERNAL_SERVER_ERROR: exceptions.ServerError
-        }.get(status, exceptions.APIException)
+        }.get(status, exceptions.APIError)
         LOGGER.debug(f"Exception type: {exception}")
 
         msg = response.text
@@ -154,7 +149,11 @@ class Session(BaseSession):
         await self._client.aclose()
 
     async def _retry(self, func, *a, **kw):
-        '''Run an asynchronous request function with retry.'''
+        """Run an asynchronous request function with retry.
+
+        Raises:
+            planet.exceptions.TooManyRequests: When retry limit is exceeded.
+        """
         # TODO: retry will be provided in httpx v1 [1] with usage [2]
         # 1. https://github.com/encode/httpcore/pull/221
         # 2. https://github.com/encode/httpx/blob/
@@ -164,30 +163,39 @@ class Session(BaseSession):
         retry_count = self.retry_count
         wait_time = self.retry_wait_time
 
-        max_retry = retry_count + 1
-        for i in range(max_retry):
+        num_tries = 0
+        while True:
+            num_tries += 1
             try:
-                return await func(*a, **kw)
-            except exceptions.TooManyRequests:
-                if i < max_retry:
-                    LOGGER.debug(f'Try {i}')
+                resp = await func(*a, **kw)
+                break
+            except exceptions.TooManyRequests as e:
+                if num_tries > retry_count:
+                    raise e
+                else:
+                    LOGGER.debug(f'Try {num_tries}')
                     LOGGER.info(f'Too Many Requests: sleeping {wait_time}s')
                     # TODO: consider exponential backoff
                     # https://developers.planet.com/docs/data/api-mechanics/
                     await asyncio.sleep(wait_time)
-        raise SessionException('Too many throttles, giving up.')
+        return resp
 
     async def request(self,
                       request: models.Request,
                       stream: bool = False) -> models.Response:
-        '''Submit a request with retry.
+        """Submit a request with retry.
 
         Parameters:
             request: Request to submit.
             stream: Get the body as a stream.
+
         Returns:
-            Response.
-        '''
+            Server response.
+
+        Raises:
+            planet.exceptions.APIException: On API error.
+            planet.exceptions.ClientError: When retry limit is exceeded.
+        """
         # TODO: retry will be provided in httpx v1 [1] with usage [2]
         # 1. https://github.com/encode/httpcore/pull/221
         # 2. https://github.com/encode/httpx/blob/
@@ -197,24 +205,25 @@ class Session(BaseSession):
         return await self._retry(self._request, request, stream=stream)
 
     async def _request(self, request, stream=False):
-        '''Submit a request'''
+        """Submit a request"""
         http_resp = await self._client.send(request.http_request,
                                             stream=stream)
         return models.Response(request, http_resp)
 
     def stream(self, request: models.Request) -> Stream:
-        '''Submit a request and get the response as a stream context manager.
+        """Submit a request and get the response as a stream context manager.
 
         Parameters:
             request: Request to submit
+
         Returns:
             Context manager providing the body as a stream.
-        '''
+        """
         return Stream(session=self, request=request)
 
 
 class AuthSession(BaseSession):
-    '''Synchronous connection to the Planet Auth service.'''
+    """Synchronous connection to the Planet Auth service."""
 
     def __init__(self):
         """Initialize an AuthSession.
@@ -227,7 +236,18 @@ class AuthSession(BaseSession):
         ]
 
     def request(self, request):
-        '''Submit a request'''
+        """Submit a request
+
+        Parameters:
+            request: Request to submit.
+
+        Returns:
+            Server response.
+
+        Raises:
+            planet.exceptions.APIException: On API error.
+        """
+
         http_resp = self._client.send(request.http_request)
         return models.Response(request, http_resp)
 
@@ -236,9 +256,9 @@ class AuthSession(BaseSession):
         try:
             super()._raise_for_status(response)
         except exceptions.BadQuery:
-            raise exceptions.APIException('Not a valid email address.')
+            raise exceptions.APIError('Not a valid email address.')
         except exceptions.InvalidAPIKey:
-            raise exceptions.APIException('Incorrect email or password.')
+            raise exceptions.APIError('Incorrect email or password.')
 
 
 class Stream():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Planet Labs, Inc.
+# Copyright 2020 Planet Labs, PBC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import contextlib
 import copy
 
 import pytest
@@ -24,18 +23,6 @@ from planet import Session
 async def session():
     async with Session() as ps:
         yield ps
-
-
-@pytest.fixture
-def match_pytest_raises():
-    '''this is like pytest.raises but does a full string match'''
-
-    @contextlib.contextmanager
-    def cm(ex, msg):
-        with pytest.raises(ex, match=f'^{msg}$') as pt:
-            yield pt
-
-    return cm
 
 
 @pytest.fixture

--- a/tests/integration/test_auth_api.py
+++ b/tests/integration/test_auth_api.py
@@ -55,7 +55,7 @@ def test_AuthClient_invalid_email():
     respx.post(TEST_LOGIN_URL).return_value = mock_resp
 
     cl = AuthClient(base_url=TEST_URL)
-    with pytest.raises(exceptions.APIException,
+    with pytest.raises(exceptions.APIError,
                        match='Not a valid email address.'):
         _ = cl.login('email', 'password')
 
@@ -72,6 +72,6 @@ def test_AuthClient_invalid_password():
     respx.post(TEST_LOGIN_URL).return_value = mock_resp
 
     cl = AuthClient(base_url=TEST_URL)
-    with pytest.raises(exceptions.APIException,
+    with pytest.raises(exceptions.APIError,
                        match='Incorrect email or password.'):
         _ = cl.login('email', 'password')

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -210,7 +210,7 @@ async def test_create_order_bad_item_type(order_request, session):
         "field": {
             "Products": [{
                 "message":
-                ("Bad item type 'invalid' for bundle type " + "'analytic'")
+                "Bad item type 'invalid' for bundle type 'analytic'"
             }]
         },
         "general": [{
@@ -222,19 +222,13 @@ async def test_create_order_bad_item_type(order_request, session):
     order_request['products'][0]['item_type'] = 'invalid'
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    expected_msg = (
-        "Unable to accept order - Bad item type 'invalid' for bundle type " +
-        "'analytic'")
-
-    with pytest.raises(exceptions.BadQuery, match=expected_msg):
-        _ = await cl.create_order(order_request)
+    with pytest.raises(exceptions.BadQuery):
+        await cl.create_order(order_request)
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_create_order_item_id_does_not_exist(order_request,
-                                                   session,
-                                                   match_pytest_raises):
+async def test_create_order_item_id_does_not_exist(order_request, session):
     resp = {
         "field": {
             "Details": [{
@@ -252,12 +246,8 @@ async def test_create_order_item_id_does_not_exist(order_request,
         '4500474_2133707_2021-05-20_2419'
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    expected_msg = (
-        "Unable to accept order - Item ID 4500474_2133707_2021-05-20_2419 " +
-        "/ Item Type PSScene3Band doesn't exist")
-
-    with match_pytest_raises(exceptions.BadQuery, expected_msg):
-        _ = await cl.create_order(order_request)
+    with pytest.raises(exceptions.BadQuery):
+        await cl.create_order(order_request)
 
 
 @respx.mock
@@ -282,18 +272,17 @@ async def test_get_order_invalid_id(session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_get_order_id_doesnt_exist(oid, session, match_pytest_raises):
+async def test_get_order_id_doesnt_exist(oid, session):
     get_url = f'{TEST_ORDERS_URL}/{oid}'
 
-    msg = f'Could not load order ID: {oid}.'
-    resp = {"message": msg}
+    resp = {"message": f'Could not load order ID: {oid}'}
     mock_resp = httpx.Response(404, json=resp)
     respx.get(get_url).return_value = mock_resp
 
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    with match_pytest_raises(exceptions.MissingResource, msg):
-        _ = await cl.get_order(oid)
+    with pytest.raises(exceptions.MissingResource):
+        await cl.get_order(oid)
 
 
 @respx.mock
@@ -319,36 +308,32 @@ async def test_cancel_order_invalid_id(session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_cancel_order_id_doesnt_exist(oid, session, match_pytest_raises):
+async def test_cancel_order_id_doesnt_exist(oid, session):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
 
-    msg = f'No such order ID: {oid}.'
-    resp = {"message": msg}
+    resp = {"message": f'No such order ID: {oid}.'}
     mock_resp = httpx.Response(404, json=resp)
     respx.put(cancel_url).return_value = mock_resp
 
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    with match_pytest_raises(exceptions.MissingResource, msg):
-        _ = await cl.cancel_order(oid)
+    with pytest.raises(exceptions.MissingResource):
+        await cl.cancel_order(oid)
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_cancel_order_id_cannot_be_cancelled(oid,
-                                                   session,
-                                                   match_pytest_raises):
+async def test_cancel_order_id_cannot_be_cancelled(oid, session):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
 
-    msg = 'Order not in a cancellable state'
-    resp = {"message": msg}
+    resp = {"message": 'Order not in a cancellable state'}
     mock_resp = httpx.Response(409, json=resp)
     respx.put(cancel_url).return_value = mock_resp
 
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    with match_pytest_raises(exceptions.Conflict, msg):
-        _ = await cl.cancel_order(oid)
+    with pytest.raises(exceptions.Conflict):
+        await cl.cancel_order(oid)
 
 
 @respx.mock
@@ -701,7 +686,7 @@ async def test_download_order_overwrite_true_preexisting_data(
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)
-    _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
+    await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
 
     # Check that the data downloaded has overwritten the original data
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content
@@ -722,7 +707,7 @@ async def test_download_order_overwrite_false_preexisting_data(
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)
-    _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
+    await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
 
     # Check that the original data has not been overwritten
     assert json.load(open(Path(tmpdir, 'file.json'))) == original_content
@@ -739,7 +724,7 @@ async def test_download_order_overwrite_true_nonexisting_data(
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)
-    _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
+    await cl.download_order(oid, directory=str(tmpdir), overwrite=True)
 
     # Check that the was data downloaded and has the correct contents
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content
@@ -756,7 +741,7 @@ async def test_download_order_overwrite_false_nonexisting_data(
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)
-    _ = await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
+    await cl.download_order(oid, directory=str(tmpdir), overwrite=False)
 
     # Check that the was data downloaded and has the correct contents
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -159,13 +159,13 @@ def test_cli_orders_get(invoke, oid, order_description):
 @respx.mock
 def test_cli_orders_get_id_not_found(invoke, oid):
     get_url = f'{TEST_ORDERS_URL}/{oid}'
-    error_json = {'message': 'A descriptive error message'}
+    error_json = {"message": "Error message"}
     mock_resp = httpx.Response(404, json=error_json)
     respx.get(get_url).return_value = mock_resp
 
     result = invoke(['get', oid])
     assert result.exception
-    assert 'Error: A descriptive error message\n' == result.output
+    assert 'Error: {"message": "Error message"}\n' == result.output
 
 
 @respx.mock
@@ -183,13 +183,13 @@ def test_cli_orders_cancel(invoke, oid, order_description):
 @respx.mock
 def test_cli_orders_cancel_id_not_found(invoke, oid):
     cancel_url = f'{TEST_ORDERS_URL}/{oid}'
-    error_json = {'message': 'A descriptive error message'}
+    error_json = {"message": "Error message"}
     mock_resp = httpx.Response(404, json=error_json)
     respx.put(cancel_url).return_value = mock_resp
 
     result = invoke(['cancel', oid])
     assert result.exception
-    assert 'Error: A descriptive error message\n' == result.output
+    assert 'Error: {"message": "Error message"}\n' == result.output
 
 
 @respx.mock

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Planet Labs, Inc.
+# Copyright 2020 Planet Labs, PBC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -65,7 +65,7 @@ def test_basesession__raise_for_status(mock_response):
                           text='exceeded QUOTA"',
                           json={}))
 
-    with pytest.raises(exceptions.APIException):
+    with pytest.raises(exceptions.APIError):
         http.BaseSession._raise_for_status(
             mock_response(HTTPStatus.METHOD_NOT_ALLOWED, json={}))
 
@@ -125,7 +125,7 @@ async def test_session_retry(mock_request):
             raise exceptions.TooManyRequests
 
         ps.retry_wait_time = 0
-        with pytest.raises(http.SessionException):
+        with pytest.raises(exceptions.TooManyRequests):
             await ps._retry(test_func)
 
 
@@ -141,10 +141,10 @@ async def test_authsession_request(mock_request):
 
 
 def test_authsession__raise_for_status(mock_response):
-    with pytest.raises(exceptions.APIException):
+    with pytest.raises(exceptions.APIError):
         http.AuthSession._raise_for_status(
             mock_response(HTTPStatus.BAD_REQUEST, json={}))
 
-    with pytest.raises(exceptions.APIException):
+    with pytest.raises(exceptions.APIError):
         http.AuthSession._raise_for_status(
             mock_response(HTTPStatus.UNAUTHORIZED, json={}))


### PR DESCRIPTION
This PR implements the following:

- Add `DESIGN.md` doc which currently just explains error design
- All exception names end in 'error'.
- Retry in `http` module now raises `TooManyRequests` exception from API upon reaching max retries
- No longer parse (obfuscate) `APIError` messages in orders client.

Closes #414 