### PR TITLE
v2: manage and return an order as json instead of an object

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -183,7 +183,7 @@ the context of a `Session` with the `OrdersClient`:
 >>> async def main():
 ...     async with Session() as sess:
 ...         cl = OrdersClient(sess)
-...         order_id = await cl.create_order(request)
+...         order = await cl.create_order(request)
 ...
 >>> asyncio.run(main())
 
@@ -210,13 +210,13 @@ from planet import reporting
 ...         with reporting.StateBar(state='creating') as bar:
 ...             # create order
 ...             order = await cl.create_order(request)
-...             bar.update(state='created', order_id=order.id)
+...             bar.update(state='created', order_id=order['id'])
 ...
 ...             # poll
-...             await cl.poll(order.id, report=bar.update)
+...             await cl.poll(order['id'], report=bar.update)
 ...
 ...         # download
-...         await cl.download_order(order.id)
+...         await cl.download_order(order['id'])
 ...
 >>> asyncio.run(create_poll_and_download())
 ```

--- a/planet/__init__.py
+++ b/planet/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .http import Session
-from .models import Order
 from . import order_request, reporting
 from .__version__ import __version__  # NOQA
 from .auth import Auth
@@ -21,7 +20,6 @@ from .clients import OrdersClient
 __all__ = [
     Session,
     OrdersClient,
-    Order,
     order_request,
     reporting,
     Auth,

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -66,9 +66,10 @@ def orders(ctx, base_url):
 async def list(ctx, state, limit, pretty):
     '''List orders'''
     async with orders_client(ctx) as cl:
-        orders = await cl.list_orders(state=state, limit=limit, as_json=True)
+        orders = await cl.list_orders(state=state, limit=limit)
+        orders_list = [o async for o in orders]
 
-    echo_json(orders, pretty)
+    echo_json(orders_list, pretty)
 
 
 @orders.command()
@@ -85,7 +86,7 @@ async def get(ctx, order_id, pretty):
     async with orders_client(ctx) as cl:
         order = await cl.get_order(str(order_id))
 
-    echo_json(order.json, pretty)
+    echo_json(order, pretty)
 
 
 @orders.command()
@@ -315,4 +316,4 @@ async def create(ctx,
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
 
-    echo_json(order.json, pretty)
+    echo_json(order, pretty)

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -22,7 +22,7 @@ import uuid
 from .. import exceptions
 from ..constants import PLANET_BASE_URL
 from ..http import Session
-from ..models import Order, Orders, Request, Response, StreamingBody
+from ..models import Paged, Request, Response, StreamingBody
 
 BASE_URL = f'{PLANET_BASE_URL}/compute/ops'
 STATS_PATH = '/stats/orders/v2'
@@ -35,6 +35,14 @@ ORDER_STATE_SEQUENCE = \
     ('queued', 'running', 'failed', 'success', 'partial', 'cancelled')
 
 LOGGER = logging.getLogger(__name__)
+
+
+class Orders(Paged):
+    '''Asynchronous iterator over Orders from a paged response describing
+    orders.'''
+    LINKS_KEY = '_links'
+    NEXT_KEY = 'next'
+    ITEMS_KEY = 'orders'
 
 
 class OrderStates():
@@ -114,7 +122,7 @@ class OrdersClient():
         '''
         return await self._session.request(request)
 
-    async def create_order(self, request: dict) -> str:
+    async def create_order(self, request: dict) -> dict:
         '''Create an order request.
 
         Example:
@@ -132,17 +140,16 @@ class OrdersClient():
         ...     )
         ...     async with Session() as sess:
         ...         cl = OrdersClient(sess)
-        ...         order_id = await cl.create_order(request)
+        ...         order = await cl.create_order(request)
         ...
         >>> asyncio.run(main())
-
         ```
 
         Parameters:
             request: order request definition
 
         Returns:
-            The ID of the order
+            JSON description of the created order
 
         Raises:
             planet.exceptions.APIError: On API error.
@@ -151,18 +158,16 @@ class OrdersClient():
 
         req = self._request(url, method='POST', json=request)
         resp = await self._do_request(req)
+        return resp.json()
 
-        order = Order(resp.json())
-        return order
-
-    async def get_order(self, order_id: str) -> Order:
+    async def get_order(self, order_id: str) -> dict:
         '''Get order details by Order ID.
 
         Parameters:
             order_id: The ID of the order
 
         Returns:
-            Order information
+            JSON description of the order
 
         Raises:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
@@ -173,9 +178,7 @@ class OrdersClient():
 
         req = self._request(url, method='GET')
         resp = await self._do_request(req)
-
-        order = Order(resp.json())
-        return order
+        return resp.json()
 
     async def cancel_order(self, order_id: str) -> Response:
         '''Cancel a queued order.
@@ -198,8 +201,8 @@ class OrdersClient():
         url = f'{self._orders_url()}/{order_id}'
 
         req = self._request(url, method='PUT')
-
-        await self._do_request(req)
+        resp = await self._do_request(req)
+        return resp.json()
 
     async def cancel_orders(self, order_ids: typing.List[str] = None) -> dict:
         '''Cancel queued orders in bulk.
@@ -294,14 +297,16 @@ class OrdersClient():
                 state.
         """
         order = await self.get_order(order_id)
-        if not OrderStates.is_final(order.state):
+
+        order_state = order['state']
+        if not OrderStates.is_final(order_state):
             raise exceptions.ClientError(
                 'Order cannot be downloaded because the order state '
-                f'({order.state}) is not a final state. '
+                f'({order_state}) is not a final state. '
                 'Consider using wait functionality before '
                 'attempting to download.')
 
-        locations = order.locations
+        locations = self._get_order_locations(order)
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}')
 
@@ -313,6 +318,12 @@ class OrdersClient():
             for location in locations
         ]
         return filenames
+
+    @staticmethod
+    def _get_order_locations(order):
+        links = order['_links']
+        results = links.get('results', None)
+        return list(r['location'] for r in results if r)
 
     async def wait(self,
                    order_id: str,
@@ -376,12 +387,12 @@ class OrdersClient():
             t = time.time()
 
             order = await self.get_order(order_id)
-            current_state = order.state
+            current_state = order['state']
 
-            LOGGER.debug(state)
+            LOGGER.debug(current_state)
 
             if callback:
-                callback(order.state)
+                callback(current_state)
 
             if OrderStates.is_final(current_state) or \
                     (state and OrderStates.reached(state, current_state)):
@@ -399,17 +410,12 @@ class OrdersClient():
 
         return current_state
 
-    async def list_orders(
-            self,
-            state: str = None,
-            limit: int = None,
-            as_json: bool = False) -> typing.Union[typing.List[Order], dict]:
+    async def list_orders(self, state: str = None, limit: int = None):
         """Get all order requests.
 
         Parameters:
             state: Filter orders to given state.
             limit: Limit orders to given limit.
-            as_json: Return orders as a json dict.
 
         Returns:
             User orders that match the query
@@ -429,15 +435,5 @@ class OrdersClient():
         else:
             params = None
 
-        orders = await self._get_orders(url, params=params, limit=limit)
-
-        if as_json:
-            ret = [o.json async for o in orders]
-        else:
-            ret = [o async for o in orders]
-        return ret
-
-    async def _get_orders(self, url, params=None, limit=None):
         request = self._request(url, 'GET', params=params)
-
         return Orders(request, self._do_request, limit=limit)

--- a/planet/models.py
+++ b/planet/models.py
@@ -406,14 +406,3 @@ class Order():
     @property
     def json(self):
         return self.data
-
-
-class Orders(Paged):
-    '''Asynchronous iterator over Orders from a paged response describing
-    orders.'''
-    LINKS_KEY = '_links'
-    NEXT_KEY = 'next'
-    ITEMS_KEY = 'orders'
-
-    async def __anext__(self):
-        return Order(await super().__anext__())

--- a/planet/models.py
+++ b/planet/models.py
@@ -14,7 +14,6 @@
 """Manage data for requests and responses."""
 import copy
 from datetime import datetime
-import json
 import logging
 import mimetypes
 import random
@@ -347,62 +346,3 @@ class Paged():
             LOGGER.debug('end of the pages')
             next_link = False
         return next_link
-
-
-class Order():
-    '''Managing description of an order returned from Orders API.
-
-    :param data: Response json describing order
-    :type data: dict
-    '''
-    LINKS_KEY = '_links'
-    RESULTS_KEY = 'results'
-    LOCATION_KEY = 'location'
-
-    def __init__(self, data):
-        self.data = data
-
-    def __str__(self):
-        return "<Order> " + json.dumps(self.data)
-
-    @property
-    def results(self):
-        '''Results for each item in order.
-
-        :return: result for each item in order
-        :rtype: list of dict
-        '''
-        links = self.data[self.LINKS_KEY]
-        results = links.get(self.RESULTS_KEY, None)
-        return results
-
-    @property
-    def locations(self):
-        '''Download locations for order results.
-
-        :return: download locations in order
-        :rtype: list of str
-        '''
-        return list(r[self.LOCATION_KEY] for r in self.results)
-
-    @property
-    def state(self):
-        '''State of the order.
-
-        :return: state of order
-        :rtype: str
-        '''
-        return self.data['state']
-
-    @property
-    def id(self):
-        '''ID of the order.
-
-        :return: id of order
-        :rtype: str
-        '''
-        return self.data['id']
-
-    @property
-    def json(self):
-        return self.data

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import copy
 import logging
 import math
 from unittest.mock import MagicMock
@@ -179,59 +178,7 @@ def get_pages():
     return do_get
 
 
-@pytest.mark.asyncio
-async def test_Paged_iterator(get_pages):
-    req = MagicMock()
-    paged = models.Paged(req, get_pages)
-    assert [1, 2, 3, 4] == [i async for i in paged]
-
-
-@pytest.mark.asyncio
-async def test_Paged_limit(get_pages):
-    req = MagicMock()
-    paged = models.Paged(req, get_pages, limit=3)
-    assert [1, 2, 3] == [i async for i in paged]
-
-
-@pytest.fixture
-def get_orders_pages(orders_page):
-    page2 = copy.deepcopy(orders_page)
-    del page2['_links']['next']
-    responses = [
-        mock_http_response(json=orders_page), mock_http_response(json=page2)
-    ]
-
-    async def do_get(req):
-        return responses.pop(0)
-
-    return do_get
-
-
-@pytest.mark.asyncio
-async def test_Orders(get_orders_pages):
-    req = MagicMock()
-    orders = models.Orders(req, get_orders_pages)
-    expected_ids = [
-        'f05b1ed7-11f0-43da-960c-a624f7c355c8',
-        '8d4799c4-5291-40c0-a7f5-adb9a974455d',
-        'f05b1ed7-11f0-43da-960c-a624f7c355c8',
-        '8d4799c4-5291-40c0-a7f5-adb9a974455d'
-    ]
-    assert expected_ids == [o.id async for o in orders]
-
-
-def test_Order_results(order_description):
-    order = models.Order(order_description)
-    assert len(order.results) == 3
-
-
-def test_Order_locations(order_description):
-    order = models.Order(order_description)
-    expected_locations = ['location1', 'location2', 'location3']
-    assert order.locations == expected_locations
-
-
-def test_last_modified_emptyheader():
+def test_StreamingBody_last_modified_emptyheader():
     '''This function tests the last_modified function for an empty header, by
     seeing if the last_modified is None.
     '''
@@ -252,7 +199,7 @@ def test_last_modified_emptyheader():
     assert output == expected
 
 
-def test_last_modified_completeheader():
+def test_StreamingBody_last_modified_completeheader():
     '''This function tests the last_modified function for an existing header,
     by comparing the last_modified date to
     an expected output.
@@ -274,3 +221,17 @@ def test_last_modified_completeheader():
     expected = datetime.strptime(hr.headers['last-modified'],
                                  '%a, %d %b %Y %H:%M:%S GMT')
     assert output == expected
+
+
+@pytest.mark.asyncio
+async def test_Paged_iterator(get_pages):
+    req = MagicMock()
+    paged = models.Paged(req, get_pages)
+    assert [1, 2, 3, 4] == [i async for i in paged]
+
+
+@pytest.mark.asyncio
+async def test_Paged_limit(get_pages):
+    req = MagicMock()
+    paged = models.Paged(req, get_pages, limit=3)
+    assert [1, 2, 3] == [i async for i in paged]


### PR DESCRIPTION
This PR implements the following:

- moves `Orders` class from `models` to `orders` modules
- removes `Order` class
- manages and returns orders as json instead of instance of `Order`

Closes #434
Blocks #380 and impacts #325