### PR TITLE
readme updates for #453

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,31 @@
 
 [Planet](https://planet.com) Software Development Kit (SDK) for Python.
 
+## Versions and Stability
+
+The default branch (main) of this repo is for the [Planet SDK for 
+Python](https://github.com/planetlabs/planet-client-python/projects/2),
+a complete rewrite and upgrade from the original [Planet Python 
+Client](https://developers.planet.com/docs/pythonclient/). If you 
+are looking for the source code to that library see the 
+`[v1](https://github.com/planetlabs/planet-client-python/tree/v1)` branch.
+
+The Planet SDK for Python is in 'pre-release' stages, working towards an 
+initial release around July. Active development is tracked in the [Planet SDK 
+for Python Project](https://github.com/planetlabs/planet-client-python/projects/2). 
+The initial release will support Orders, Data and Subscription API's in the 
+command-line interface, with corresponding Python libraries. We expect 'beta' 
+milestones to be released in some form for each of the API's. After the 
+initial July release there will be additional work to support the remaining 
+Planet API's ([analytics](https://developers.planet.com/docs/analytics/), 
+[basemaps](https://developers.planet.com/docs/basemaps/) and 
+[tasking](https://developers.planet.com/docs/tasking/).
+
 ## Documentation
 
 Full documentation is not yet hosted online but can be built and hosted locally
 (see [CONTRIBUTING.md](CONTRIBUTING.md)) or can be read from source in the
-`docs` directory.
+`[docs](docs/)` directory.
 
 ## Quick Start
 
@@ -16,9 +36,9 @@ The Planet SDK for Python allows Python developers to write software that makes
 use of the following Planet APIs:
 
 * [orders](https://developers.planet.com/docs/orders/)
-* [data](https://developers.planet.com/docs/data/) (not implemented)
-* [analytics](https://developers.planet.com/docs/analytics/) (not implemented)
-* [basemaps](https://developers.planet.com/docs/basemaps/) (referred to in the client as `mosaics`) (not implemented)
+* [data](https://developers.planet.com/docs/data/) (not yet implemented)
+* [subscriptions](https://developers.planet.com/docs/subscriptions/) (not 
+ yet implemented)
 
 The client modules within the Python library are asynchronous, which greatly
 speeds up many interactions with Planet's APIs. Support for asynchronous


### PR DESCRIPTION
This does most of the changes needed for #453

* [x] Link to the v1 branch, after #368 and #367 
* [x] Explain the situation of v1 vs v2, especially the state of stability / completeness of v2.
* [x] Update to the quickstart list - we should have it say orders, data and subscriptions, and perhaps link to the milestones with the 'unimplemented', and then mention that we plan in future versions to support analytics, basemaps and tasking.
* [x] Link to the 'docs' directory, instead of just saying `docs` and making people click through the source code.

The one it doesn't is 

* [ ] Quickstart should show a CLI example, not a python API example (perhaps move that down to a directory / to another file and then link to 'python API examples', as we want to focus on the CLI.

I can probably take that on, but probably not till next week, so just issuing this PR for now to hopefully get merged in soon.