### PR TITLE
Always use installed code, not editable installs, for nox test session

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - name: Checkout code 
+    - name: Checkout code
       uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -33,9 +33,9 @@ jobs:
     name: Check Linting
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code 
+    - name: Checkout code
       uses: actions/checkout@v2
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
@@ -51,12 +51,12 @@ jobs:
         pip install --upgrade nox
         nox -s lint
   docs:
-    name: Check Docs build 
+    name: Check Docs build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code 
+    - name: Checkout code
       uses: actions/checkout@v2
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
@@ -71,13 +71,13 @@ jobs:
       run: |
         pip install --upgrade nox
         nox -s docs
-  install:
-    name: Check package install
+  coverage:
+    name: Check code coverage
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code 
+    - name: Checkout code
       uses: actions/checkout@v2
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
@@ -91,5 +91,5 @@ jobs:
     - name: Build Docs
       run: |
         pip install --upgrade nox
-        nox -s install
+        nox -s coverage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         pip install --upgrade nox
         nox -s test-${{ matrix.python-version }}
+
   lint:
     name: Check Linting
     runs-on: ubuntu-latest
@@ -50,6 +51,7 @@ jobs:
       run: |
         pip install --upgrade nox
         nox -s lint
+
   docs:
     name: Check Docs build
     runs-on: ubuntu-latest
@@ -71,6 +73,7 @@ jobs:
       run: |
         pip install --upgrade nox
         nox -s docs
+
   coverage:
     name: Check code coverage
     runs-on: ubuntu-latest
@@ -88,7 +91,7 @@ jobs:
         key: ${{ runner.os }}-pip
         restore-keys: |
           ${{ runner.os }}-pip
-    - name: Build Docs
+    - name: Coverage run and report
       run: |
         pip install --upgrade nox
         nox -s coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,14 @@ Python and required development packages.
 Run Nox with the default sessions (same checks as CI):
 
 ```console
-    $ nox
+nox
 ```
 
 If no changes have been made to the Nox environment since it was last run,
 speed up the run by reusing the environment:
 
 ```console
-    $ nox -r
+nox -r
 ```
 
 The configuration for Nox is given in `noxfile.py`. See the Nox link above for
@@ -118,7 +118,7 @@ Command-line arguments can be passed to pytest within Nox. For example, to only
 run the tests on a certain file, use:
 
 ```console
-    $ nox -- [file]
+nox -- [file]
 ```
 
 By default, Nox runs tests on all supported Python versions along with other
@@ -127,7 +127,15 @@ CI checks. However, Nox can run a test on a single Python version.
 To run tests on python 3.7:
 
 ```console
-    $ nox -s test-3.7
+nox -s test-3.7
+```
+
+## Code coverage
+
+To measure code coverage and see a report:
+
+```console
+nox -s coverage
 ```
 
 ## Linting
@@ -139,7 +147,7 @@ all other CI checks. However, Nox can run just the linting check.
 To run lint check:
 
 ```console
-    $ nox -s lint
+nox -s lint
 ```
 
 ## Documentation
@@ -157,13 +165,13 @@ to assist documentation development.
 To build the documentation:
 
 ```console
-    $ nox -s docs
+nox -s docs
 ```
 
 To build and host an automatically-updated local version of the documentation:
 
 ```console
-    $ nox -s watch
+nox -s watch
 ```
 
 In addition to verifying that the documentation renders correctly locally,
@@ -184,14 +192,14 @@ incur usages.
 To test the documentation, run the Nox `docs_test` session:
 
 ```console
-    $ nox -s docs_test
+nox -s docs_test
 ```
 
 This will test all code examples in Markdown documents.
 To only test one document:
 
 ```console
-    $ nox -s docs_test -- <document_name>.md
+nox -s docs_test -- <document_name>.md
 ```
 
 ### Testing Examples
@@ -205,14 +213,14 @@ very slow and also could incur usages.
 To test the examples, run the Nox `examples` session:
 
 ```console
-    $ nox -s examples
+nox -s examples
 ```
 
 This will test all scripts within the `examples` directory.
 To only test one script:
 
 ```console
-    $ nox -s examples -- <script_name>.py
+nox -s examples -- <script_name>.py
 ```
 
 For more information on developing examples, see the examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,13 @@ This repository uses two primary tools for development:
 Install Nox in your local dev environment:
 
 ```console
-pip install nox
+    $ pip install nox
 ```
 
 Install YAPF in your local dev environment:
 
 ```console
-pip install yapf
+    $ pip install yapf
 ```
 
 ### Nox
@@ -45,14 +45,14 @@ Python and required development packages.
 Run Nox with the default sessions (same checks as CI):
 
 ```console
-nox
+    $ nox
 ```
 
 If no changes have been made to the Nox environment since it was last run,
 speed up the run by reusing the environment:
 
 ```console
-nox -r
+    $ nox -r
 ```
 
 The configuration for Nox is given in `noxfile.py`. See the Nox link above for
@@ -69,7 +69,7 @@ of the Planet SDK for Python and required development packages into the virtual
 environment use:
 
 ```console
-pip install -e .[dev]
+    $ pip install -e .[dev]
 ```
 
 ### YAPF
@@ -84,13 +84,13 @@ don't have to worry about formatting issues. WIN!
 To see how YAPF would reformat a file:
 
 ```console
-yapf --diff [file]
+    $ yapf --diff [file]
 ```
 
 To reformat the file:
 
 ```console
-yapf --in-place [file]
+    $ yapf --in-place [file]
 ```
 
 The configuration for YAPF is given in `setup.cfg` and `.yapfignore`.
@@ -118,7 +118,7 @@ Command-line arguments can be passed to pytest within Nox. For example, to only
 run the tests on a certain file, use:
 
 ```console
-nox -- [file]
+    $ nox -- [file]
 ```
 
 By default, Nox runs tests on all supported Python versions along with other
@@ -127,7 +127,7 @@ CI checks. However, Nox can run a test on a single Python version.
 To run tests on python 3.7:
 
 ```console
-nox -s test-3.7
+    $ nox -s test-3.7
 ```
 
 ## Code coverage
@@ -135,7 +135,7 @@ nox -s test-3.7
 To measure code coverage and see a report:
 
 ```console
-nox -s coverage
+    $ nox -s coverage
 ```
 
 ## Linting
@@ -147,7 +147,7 @@ all other CI checks. However, Nox can run just the linting check.
 To run lint check:
 
 ```console
-nox -s lint
+    $ nox -s lint
 ```
 
 ## Documentation
@@ -165,13 +165,13 @@ to assist documentation development.
 To build the documentation:
 
 ```console
-nox -s docs
+    $ nox -s docs
 ```
 
 To build and host an automatically-updated local version of the documentation:
 
 ```console
-nox -s watch
+    $ nox -s watch
 ```
 
 In addition to verifying that the documentation renders correctly locally,
@@ -192,14 +192,14 @@ incur usages.
 To test the documentation, run the Nox `docs_test` session:
 
 ```console
-nox -s docs_test
+    $ nox -s docs_test
 ```
 
 This will test all code examples in Markdown documents.
 To only test one document:
 
 ```console
-nox -s docs_test -- <document_name>.md
+    $ nox -s docs_test -- <document_name>.md
 ```
 
 ### Testing Examples
@@ -213,14 +213,14 @@ very slow and also could incur usages.
 To test the examples, run the Nox `examples` session:
 
 ```console
-nox -s examples
+    $ nox -s examples
 ```
 
 This will test all scripts within the `examples` directory.
 To only test one script:
 
 ```console
-nox -s examples -- <script_name>.py
+    $ nox -s examples -- <script_name>.py
 ```
 
 For more information on developing examples, see the examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,13 @@ This repository uses two primary tools for development:
 Install Nox in your local dev environment:
 
 ```console
-    $ pip install nox
+pip install nox
 ```
 
 Install YAPF in your local dev environment:
 
 ```console
-    $ pip install yapf
+pip install yapf
 ```
 
 ### Nox
@@ -69,7 +69,7 @@ of the Planet SDK for Python and required development packages into the virtual
 environment use:
 
 ```console
-    $ pip install -e .[dev]
+pip install -e .[dev]
 ```
 
 ### YAPF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,13 +84,13 @@ don't have to worry about formatting issues. WIN!
 To see how YAPF would reformat a file:
 
 ```console
-    $ yapf --diff [file]
+yapf --diff [file]
 ```
 
 To reformat the file:
 
 ```console
-    $ yapf --in-place [file]
+yapf --in-place [file]
 ```
 
 The configuration for YAPF is given in `setup.cfg` and `.yapfignore`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,6 +11,7 @@ source_files = ("planet", "examples", "tests", "setup.py", "noxfile.py")
 @nox.session
 def coverage(session):
     session.install("-e", ".[test]")
+
     session.run('coverage',
                 'run',
                 '-m',
@@ -27,12 +28,15 @@ def coverage(session):
 @nox.session(python=["3.7", "3.8", "3.9"])
 def test(session):
     session.install(".[test]")
-    session.run('pytest', '--ignore', 'examples/', '-v')
+
+    options = session.posargs
+    session.run('pytest', '--ignore', 'examples/', '-v', *options)
 
 
 @nox.session
 def lint(session):
     session.install("-e", ".[lint]")
+
     session.run("flake8", *source_files)
     session.run('yapf', '--diff', '-r', *source_files)
 
@@ -40,6 +44,7 @@ def lint(session):
 @nox.session
 def docs_test(session):
     session.install("-e", ".[docs]")
+
     options = session.posargs
 
     # Because these doc examples can be long-running, output
@@ -59,18 +64,21 @@ def docs_test(session):
 @nox.session
 def docs(session):
     session.install("-e", ".[docs]")
+
     session.run("mkdocs", "build")
 
 
 @nox.session
 def watch(session):
     session.install("-e", ".[docs]")
+
     session.run("mkdocs", "serve")
 
 
 @nox.session
 def examples(session):
     session.install("-e", ".[test]")
+
     options = session.posargs
 
     # Because these example scripts can be long-running, output the

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.sessions = ['lint', 'test', 'coverage', 'docs']
 source_files = ("planet", "examples", "tests", "setup.py", "noxfile.py")
 
 
-@nox.session(python=["3.9"])
+@nox.session
 def coverage(session):
     session.install("-e", ".[test]")
     session.run('coverage',

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,6 @@ license_file: LICENSE
 
 [tool:pytest]
 addopts =
-    --cov=planet
-    --cov=tests
-    --cov-report=term-missing
-    --cov-report=xml
-    --cov-fail-under 98
     -rxXs
 
 [coverage:run]
@@ -20,6 +15,7 @@ branch = True
 [coverage:report]
 skip_covered = True
 show_missing = True
+fail_under = 98
 
 [yapf]
 based_on_style = pep8


### PR DESCRIPTION
Testing installed code is the best check since users will be running installed code. Coverage sort of requires an editable install, but we can restrict ourselves to a single Python version for coverage since we don't have different code branches for different versions.

This is a follow up to #461.