### PR TITLE
Remove duplicated or unused class attributes.

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -31,7 +31,6 @@ LOGGER = logging.getLogger(__name__)
 
 class Items(Paged):
     '''Asynchronous iterator over items from a paged response.'''
-    LINKS_KEY = '_links'
     NEXT_KEY = '_next'
     ITEMS_KEY = 'features'
 

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -40,8 +40,6 @@ LOGGER = logging.getLogger(__name__)
 class Orders(Paged):
     '''Asynchronous iterator over Orders from a paged response describing
     orders.'''
-    LINKS_KEY = '_links'
-    NEXT_KEY = 'next'
     ITEMS_KEY = 'orders'
 
 

--- a/planet/models.py
+++ b/planet/models.py
@@ -281,7 +281,6 @@ class Paged():
     LINKS_KEY = '_links'
     NEXT_KEY = 'next'
     ITEMS_KEY = 'items'
-    TYPE = None
 
     def __init__(self, request, do_request_fcn, limit=None):
         self.request = request


### PR DESCRIPTION
Follow up to #477 wherein I saw that Page.LINKS_KEY was "links" while Orders.LINKS_KEY was "_links". This PR eliminates unnecessary duplication and hopefully prevents future confusion about the links key.