### PR TITLE
Remove empty () after class definitions

### DIFF
--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -45,7 +45,7 @@ class Orders(Paged):
     ITEMS_KEY = 'orders'
 
 
-class OrderStates():
+class OrderStates:
     SEQUENCE = ORDER_STATE_SEQUENCE
 
     @classmethod
@@ -65,7 +65,7 @@ class OrderStates():
         return cls.passed('running', test)
 
 
-class OrdersClient():
+class OrdersClient:
     """High-level asynchronous access to Planet's orders API.
 
     Example:

--- a/planet/models.py
+++ b/planet/models.py
@@ -32,7 +32,7 @@ class RequestException(Exception):
     pass
 
 
-class Request():
+class Request:
     '''Handles a HTTP request for the Planet server.
 
     :param url: URL of API endpoint
@@ -76,7 +76,7 @@ class Request():
         self.http_request.url = httpx.URL(url)
 
 
-class Response():
+class Response:
     '''Handles the Planet server's response to a HTTP request.
 
     :param request: Request that was submitted to the server
@@ -113,7 +113,7 @@ class Response():
         await self.http_response.aclose()
 
 
-class StreamingBody():
+class StreamingBody:
     '''A representation of a streaming resource from the API.
 
     :param response: Response that was received from the server
@@ -183,7 +183,7 @@ class StreamingBody():
         :type progress_bar: boolean, optional
         '''
 
-        class _LOG():
+        class _LOG:
 
             def __init__(self, total, unit, filename, disable):
                 self.total = total
@@ -265,7 +265,7 @@ def _get_random_filename(content_type=None):
     return name
 
 
-class Paged():
+class Paged:
     '''Asynchronous iterator over results in a paged resource from the Planet
     server.
     Each returned result is a json dict.


### PR DESCRIPTION
Resolves #481

Partially this was an exercise in learning how to do more refactoring in VS Code. I used the search tool to find occurrences of `class (\w+)\(\)` (as a regex) and replace them with `class $1`. 7 instances were replaced.

