### PR TITLE
download order cli: increase number of poll attempts to a reasonable number

### DIFF
--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -134,7 +134,7 @@ def split_list_arg(ctx, param, value):
               help='Time (in seconds) between polls.')
 @click.option('--max-attempts',
               type=int,
-              default=5,
+              default=200,
               help='Maximum number of polls. Set to zero for no limit.')
 @click.option('--state',
               help='State prior to a final state that will end polling.',


### PR DESCRIPTION
The poll attempts (5) is too low a number for a reasonable polling time. This increases this number to 200, which is the default for the python API.