### PR TITLE
Better error handling in OrdersClient

### DIFF
--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -290,7 +290,7 @@ class OrdersClient():
         Raises:
             planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If the order is not in a final
-                state or if the order's location is not found.
+                state.
         """
         order = await self.get_order(order_id)
         order_state = order['state']
@@ -320,7 +320,10 @@ class OrdersClient():
         try:
             return list(r['location'] for r in results if r)
         except TypeError:
-            raise exceptions.ClientError('Order location not found.')
+            LOGGER.warning(
+                'order does not have any locations, will not download any ' +
+                'files.')
+            return []
 
     async def wait(self,
                    order_id: str,

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -316,7 +316,7 @@ class OrdersClient():
     @staticmethod
     def _get_order_locations(order):
         links = order['_links']
-        results = links.get('results', None)
+        results = links.get('results', [])
         try:
             return list(r['location'] for r in results if r)
         except TypeError:

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -319,7 +319,10 @@ class OrdersClient():
     def _get_order_locations(order):
         links = order['_links']
         results = links.get('results', None)
-        return list(r['location'] for r in results if r)
+        try:
+            return list(r['location'] for r in results if r)
+        except TypeError:
+            return []
 
     async def wait(self,
                    order_id: str,

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -290,10 +290,9 @@ class OrdersClient():
         Raises:
             planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If the order is not in a final
-                state.
+                state or if the order's location is not found.
         """
         order = await self.get_order(order_id)
-
         order_state = order['state']
         if not OrderStates.is_final(order_state):
             raise exceptions.ClientError(
@@ -301,7 +300,6 @@ class OrdersClient():
                 f'({order_state}) is not a final state. '
                 'Consider using wait functionality before '
                 'attempting to download.')
-
         locations = self._get_order_locations(order)
         LOGGER.info(
             f'downloading {len(locations)} assets from order {order_id}')
@@ -322,7 +320,7 @@ class OrdersClient():
         try:
             return list(r['location'] for r in results if r)
         except TypeError:
-            return []
+            raise exceptions.ClientError('Order location not found.')
 
     async def wait(self,
                    order_id: str,

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -647,7 +647,7 @@ async def test_download_order_state(tmpdir, order_description, oid, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_download_order_invalid_order_links(tmpdir,
+async def test_download_order_without_order_links(tmpdir,
                                                   order_description,
                                                   oid,
                                                   session):
@@ -672,8 +672,8 @@ async def test_download_order_invalid_order_links(tmpdir,
 
     client = OrdersClient(session, base_url=TEST_URL)
 
-    with pytest.raises(exceptions.ClientError):
-        await client.download_order(oid, directory=str(tmpdir))
+    filenames = await client.download_order(oid, directory=str(tmpdir))
+    assert len(filenames) == 0
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -647,6 +647,37 @@ async def test_download_order_state(tmpdir, order_description, oid, session):
 
 @respx.mock
 @pytest.mark.asyncio
+async def test_download_order_invalid_order_links(tmpdir,
+                                                  order_description,
+                                                  oid,
+                                                  session):
+    dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
+
+    order_description['state'] = 'success'
+    order_description['_links']['results'] = None
+
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+    mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
+    respx.get(get_url).return_value = mock_resp
+
+    mock_resp1 = httpx.Response(HTTPStatus.OK,
+                                json={'key': 'value'},
+                                headers={
+                                    'Content-Type':
+                                    'application/json',
+                                    'Content-Disposition':
+                                    'attachment; filename="m1.json"'
+                                })
+    respx.get(dl_url1).return_value = mock_resp1
+
+    client = OrdersClient(session, base_url=TEST_URL)
+
+    with pytest.raises(exceptions.ClientError):
+        await client.download_order(oid, directory=str(tmpdir))
+
+
+@respx.mock
+@pytest.mark.asyncio
 async def test_download_order_overwrite_true_preexisting_data(
         tmpdir,
         oid,


### PR DESCRIPTION
Added a try/except clause to `planet.clients.orders.OrdersClient._get_order_locations()` to protect against failed scenarios, where `list(r['location'] for r in results if r)` would return an empty list.

Closes #325 