### PR TITLE
Fixed invalid JSON file in guide

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -337,5 +337,6 @@ Example: `tools.json`
             "name_template": "C1232_30_30_{tilex:04d}_{tiley:04d}"
         }
     }
+]
 ```
 


### PR DESCRIPTION
The example JSON for `tool.json` was invalid.
- Added trailing `]` to fix docs