### PR TITLE
Exponential backoff for retries

### DIFF
--- a/planet/http.py
+++ b/planet/http.py
@@ -156,6 +156,12 @@ class Session(BaseSession):
         Raises:
             planet.exceptions.TooManyRequests: When retry limit is exceeded.
         """
+        # NOTE: if we need something more fancy, consider the following libs:
+        # * https://pypi.org/project/retry/
+        # * https://pypi.org/project/retrying/
+        # TODO: consider increasing the scope of retryable exceptions, ex:
+        # https://github.com/googleapis/python-storage/blob/1dc6d647b86466bf133
+        # fe03ec8d76c541e19c632/google/cloud/storage/retry.py#L23-L30
         # TODO: if throttling is necessary, check out [1] once v1
         # 1. https://github.com/encode/httpx/issues/984
         num_tries = 0

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -14,7 +14,7 @@
 import logging
 from http import HTTPStatus
 import math
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import httpx
 import respx
@@ -46,13 +46,6 @@ def mock_response():
         return r
 
     return mocker
-
-
-class AsyncMock(MagicMock):
-    """This class was added to the Python library in 3.8"""
-
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
 def test_basesession__raise_for_status(mock_response):

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -119,7 +119,7 @@ async def test_session_request_retry(monkeypatch, mock_request):
         ]
 
         # let's not actually introcude a wait into the tests
-        monkeypatch.setattr(http, 'MAX_BACKOFF', 0)
+        monkeypatch.setattr(http, 'MAX_RETRY_BACKOFF', 0)
         resp = await ps.request(mock_request)
         assert resp
         assert route.call_count == 2


### PR DESCRIPTION
Changes retry backoff from constant to exponential backoff with random jitter.

Introduces `MAX_RETRY_BACKOFF` and `MAX_RETRIES` global vars and removes them from `Session` class variables.

Closes #279