### PR TITLE
Initial skeleton of subscription CLI and its tests

### DIFF
--- a/planet/cli/cli.py
+++ b/planet/cli/cli.py
@@ -19,7 +19,7 @@ import click
 
 import planet
 
-from . import auth, data, orders
+from . import auth, data, orders, subscriptions
 
 LOGGER = logging.getLogger(__name__)
 
@@ -78,3 +78,4 @@ def _configure_logging(verbosity):
 main.add_command(auth.auth)
 main.add_command(data.data)
 main.add_command(orders.orders)
+main.add_command(subscriptions.subscriptions)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -13,6 +13,7 @@ from planet.exceptions import PlanetError
 # A collection of fake subscriptions for testing. Tests will
 # monkeypatch this attribute.
 _fake_subs = None
+_fake_sub_results = None
 
 
 # For test use.
@@ -33,6 +34,10 @@ def _get_fake_sub(sub_id):
     sub = _fake_subs[sub_id].copy()
     sub.update(id=sub_id)
     return sub
+
+
+def _get_fake_sub_results(sub_id):
+    return _fake_sub_results[sub_id]
 
 
 @click.group()
@@ -190,6 +195,36 @@ async def update_subscription(ctx, subscription_id, request, pretty):
     # *will* raise PlanetError like this.
     try:
         sub = _update_fake_sub(subscription_id, **request)
+    except KeyError:
+        raise PlanetError(f"No such subscription: {subscription_id!r}")
+
+    # End fake subscriptions service. After we refactor we will get
+    # the "sub" from a method in planet.clients.subscriptions (which
+    # doesn't exist yet).
+
+    echo_json(sub, pretty)
+
+
+@subscriptions.command(name='describe')
+@click.argument('subscription_id')
+@click.option('--pretty', is_flag=True, help='Pretty-print output.')
+@click.pass_context
+@translate_exceptions
+@coro
+async def describe_subscription(ctx, subscription_id, pretty):
+    """Cancels a subscription and prints the API response.
+
+    This implementation is only a placeholder. To begin, instead
+    of mocking calls to the Subscriptions API, we'll use a
+    collection of fake subscriptions (the all_subs object).
+    After we refactor we will change to mocking the API.
+
+    """
+    # Begin fake subscriptions service. Note that the Subscriptions
+    # API will report missing keys differently, but the Python API
+    # *will* raise PlanetError like this.
+    try:
+        sub = _get_fake_sub(subscription_id)
     except KeyError:
         raise PlanetError(f"No such subscription: {subscription_id!r}")
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -1,0 +1,126 @@
+"""Subscriptions CLI"""
+
+import itertools
+import json
+
+import click
+
+import planet
+from planet.cli.cmds import coro, translate_exceptions
+from planet.cli.io import echo_json
+from planet.exceptions import PlanetError
+
+# A collection of fake subscriptions for testing. Tests will
+# monkeypatch this attribute.
+_fake_subs = None
+
+
+# For test use.
+def _count_fake_subs():
+    return len(_fake_subs)
+
+
+@click.group()
+@click.pass_context
+def subscriptions(ctx):
+    ctx.obj['AUTH'] = planet.Auth.from_file()
+
+
+# We want our command to be known as "list" on the command line but
+# don't want to clobber Python's built-in "list". We'll define the
+# command function as "list_subscriptions".
+@subscriptions.command(name="list")
+@click.option('--pretty', is_flag=True, help='Pretty-print output.')
+@click.option(
+    '--status',
+    type=click.Choice(["created", "queued", "processing", "failed",
+                       "success"]),
+    multiple=True,
+    default=None,
+    help="Select subscriptions in one or more states. Default is all.")
+@click.option('--limit',
+              type=int,
+              default=100,
+              help='Maximum number of results to return. Defaults to 100.')
+@click.pass_context
+@translate_exceptions
+@coro
+async def list_subscriptions(ctx, status, limit, pretty):
+    """Prints a sequence of JSON-encoded Subscription descriptions.
+
+    This implementation is only a placeholder. To begin, instead
+    of mocking calls to the Subscriptions API, we'll use a
+    collection of fake subscriptions (the all_subs fixture).
+    After we refactor we will change to mocking the API.
+
+    """
+    # Filter by status, like the Subscriptions API does.
+    if status:
+        select_subs = (sub for sub in _fake_subs if sub['status'] in status)
+    else:
+        select_subs = _fake_subs
+
+    filtered_subs = itertools.islice(select_subs, limit)
+    # End of placeholder implementation. In the future we will get
+    # the filtered subscriptions from a method of the to-be-written
+    # planet.clients.subscriptions.
+
+    # Print output to terminal, respecting the provided limit.
+    for sub in filtered_subs:
+        echo_json(sub, pretty)
+
+
+def parse_request(ctx, param, value: str) -> dict:
+    """Turn request JSON/file into a dict."""
+    if value.startswith('{'):
+        try:
+            obj = json.loads(value)
+        except json.decoder.JSONDecodeError:
+            raise click.BadParameter('Request does not contain valid json.',
+                                     ctx=ctx,
+                                     param=param)
+        if not obj:
+            raise click.BadParameter('Request is empty.', ctx=ctx, param=param)
+    else:
+        try:
+            with click.open_file(value) as f:
+                obj = json.load(f)
+        except json.decoder.JSONDecodeError:
+            raise click.BadParameter('Request does not contain valid json.',
+                                     ctx=ctx,
+                                     param=param)
+
+    return obj
+
+
+@subscriptions.command(name='create')
+@click.argument('request', callback=parse_request)
+@click.option('--pretty', is_flag=True, help='Pretty-print output.')
+@click.pass_context
+@translate_exceptions
+@coro
+async def create_subscription(ctx, request, pretty):
+    """Submits a subscription request and prints the API response.
+
+    This implementation is only a placeholder. To begin, instead
+    of mocking calls to the Subscriptions API, we'll use a
+    collection of fake subscriptions (the all_subs object).
+    After we refactor we will change to mocking the API.
+
+    """
+    # Begin fake subscriptions service. Note that the Subscriptions
+    # API will report missing keys differently, but the Python API
+    # *will* raise PlanetError like this.
+    missing_keys = {'name', 'delivery', 'source'} - request.keys()
+    if missing_keys:
+        raise PlanetError(f"Request lacks required members: {missing_keys!r}")
+
+    # Update the request with an id.
+    sub = dict(**request, id='42')
+    _fake_subs.append(sub)
+
+    # End fake subscriptions service. After we refactor we will get
+    # the "sub" from a method in planet.clients.subscriptions (which
+    # doesn't exist yet).
+
+    echo_json(sub, pretty)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -20,6 +20,10 @@ def _count_fake_subs():
     return len(_fake_subs)
 
 
+def _cancel_fake_sub(sub_id):
+    return _fake_subs.pop(sub_id)
+
+
 @click.group()
 @click.pass_context
 def subscriptions(ctx):

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -24,6 +24,13 @@ def _cancel_fake_sub(sub_id):
     return _fake_subs.pop(sub_id)
 
 
+def _update_fake_sub(sub_id, **kwds):
+    _fake_subs[sub_id].update(**kwds)
+    sub = _fake_subs[sub_id].copy()
+    sub.update(id=sub_id)
+    return sub
+
+
 @click.group()
 @click.pass_context
 def subscriptions(ctx):

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -126,3 +126,33 @@ async def create_subscription(ctx, request, pretty):
     # doesn't exist yet).
 
     echo_json(sub, pretty)
+
+
+@subscriptions.command(name='cancel')
+@click.argument('subscription_id')
+@click.option('--pretty', is_flag=True, help='Pretty-print output.')
+@click.pass_context
+@translate_exceptions
+@coro
+async def cancel_subscription(ctx, subscription_id, pretty):
+    """Cancels a subscription and prints the API response.
+
+    This implementation is only a placeholder. To begin, instead
+    of mocking calls to the Subscriptions API, we'll use a
+    collection of fake subscriptions (the all_subs object).
+    After we refactor we will change to mocking the API.
+
+    """
+    # Begin fake subscriptions service. Note that the Subscriptions
+    # API will report missing keys differently, but the Python API
+    # *will* raise PlanetError like this.
+    try:
+        sub = _cancel_fake_sub(subscription_id)
+    except KeyError:
+        raise PlanetError(f"No such subscription: {subscription_id!r}")
+
+    # End fake subscriptions service. After we refactor we will get
+    # the "sub" from a method in planet.clients.subscriptions (which
+    # doesn't exist yet).
+
+    echo_json(sub, pretty)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -79,8 +79,6 @@ def parse_request(ctx, param, value: str) -> dict:
             raise click.BadParameter('Request does not contain valid json.',
                                      ctx=ctx,
                                      param=param)
-        if not obj:
-            raise click.BadParameter('Request is empty.', ctx=ctx, param=param)
     else:
         try:
             with click.open_file(value) as f:

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -26,6 +26,10 @@ def _cancel_fake_sub(sub_id):
 
 def _update_fake_sub(sub_id, **kwds):
     _fake_subs[sub_id].update(**kwds)
+    return _get_fake_sub(sub_id)
+
+
+def _get_fake_sub(sub_id):
     sub = _fake_subs[sub_id].copy()
     sub.update(id=sub_id)
     return sub
@@ -155,6 +159,37 @@ async def cancel_subscription(ctx, subscription_id, pretty):
     # *will* raise PlanetError like this.
     try:
         sub = _cancel_fake_sub(subscription_id)
+    except KeyError:
+        raise PlanetError(f"No such subscription: {subscription_id!r}")
+
+    # End fake subscriptions service. After we refactor we will get
+    # the "sub" from a method in planet.clients.subscriptions (which
+    # doesn't exist yet).
+
+    echo_json(sub, pretty)
+
+
+@subscriptions.command(name='update')
+@click.argument('subscription_id')
+@click.argument('request', callback=parse_request)
+@click.option('--pretty', is_flag=True, help='Pretty-print output.')
+@click.pass_context
+@translate_exceptions
+@coro
+async def update_subscription(ctx, subscription_id, request, pretty):
+    """Cancels a subscription and prints the API response.
+
+    This implementation is only a placeholder. To begin, instead
+    of mocking calls to the Subscriptions API, we'll use a
+    collection of fake subscriptions (the all_subs object).
+    After we refactor we will change to mocking the API.
+
+    """
+    # Begin fake subscriptions service. Note that the Subscriptions
+    # API will report missing keys differently, but the Python API
+    # *will* raise PlanetError like this.
+    try:
+        sub = _update_fake_sub(subscription_id, **request)
     except KeyError:
         raise PlanetError(f"No such subscription: {subscription_id!r}")
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -233,6 +233,9 @@ def test_subscriptions_cancel_success(monkeypatch):
 
         echo_json(sub, pretty)
 
+    # Let's check the state of the fake API before we try to cancel.
+    assert _count_fake_subs() == 1
+
     result = CliRunner().invoke(
         cli.main,
         args=['subscriptions', 'cancel', '42'],

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -253,42 +253,6 @@ def test_subscriptions_results_failure(monkeypatch):
 
     monkeypatch.setattr(planet.cli.subscriptions, '_fake_sub_results', {})
 
-    # Begin CLI command.
-    import click
-    from planet.cli.subscriptions import (subscriptions,
-                                          translate_exceptions,
-                                          coro,
-                                          _get_fake_sub_results)
-    from planet.exceptions import PlanetError
-
-    @subscriptions.command(name='results')
-    @click.argument('subscription_id')
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def list_subscription_results(ctx, subscription_id):
-        """Gets results of a subscription and prints the API response.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs object).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Begin fake subscriptions service. Note that the Subscriptions
-        # API will report missing keys differently, but the Python API
-        # *will* raise PlanetError like this.
-        try:
-            _ = _get_fake_sub_results(subscription_id)
-        except KeyError:
-            raise PlanetError(f"No such subscription: {subscription_id!r}")
-
-        # End fake subscriptions service. After we refactor we will get
-        # the "sub" from a method in planet.clients.subscriptions (which
-        # doesn't exist yet).
-
-    # End CLI command.
-
     result = CliRunner().invoke(
         cli.main,
         args=['subscriptions', 'results', '42'],
@@ -316,75 +280,6 @@ def test_subscriptions_results_success(options, expected_count, monkeypatch):
         {'42': [{
             'id': f'r{i}', 'status': 'created'
         } for i in range(101)]})
-
-    # Begin CLI command.
-    import itertools
-    import click
-    from planet.cli.subscriptions import (subscriptions,
-                                          echo_json,
-                                          translate_exceptions,
-                                          coro,
-                                          _get_fake_sub_results)
-    from planet.exceptions import PlanetError
-
-    @subscriptions.command(name='results')
-    @click.argument('subscription_id')
-    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
-    @click.option(
-        '--status',
-        type=click.Choice(
-            ["created", "queued", "processing", "failed", "success"]),
-        multiple=True,
-        default=None,
-        help="Select subscription results in one or more states. Default: all."
-    )
-    @click.option('--limit',
-                  type=int,
-                  default=100,
-                  help='Maximum number of results to return. Defaults to 100.')
-    # TODO: the following 3 options.
-    # –created: timestamp instant or range.
-    # –updated: timestamp instant or range.
-    # –completed: timestamp instant or range.
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def list_subscription_results(ctx,
-                                        subscription_id,
-                                        pretty,
-                                        status,
-                                        limit):
-        """Gets results of a subscription and prints the API response.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs object).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Begin fake subscriptions service. Note that the Subscriptions
-        # API will report missing keys differently, but the Python API
-        # *will* raise PlanetError like this.
-
-        try:
-            # Filter by status, like the Subscriptions API does.
-            if status:
-                select_results = (
-                    res for res in _get_fake_sub_results(subscription_id)
-                    if res['status'] in status)
-            else:
-                select_results = _get_fake_sub_results(subscription_id)
-
-            filtered_results = itertools.islice(select_results, limit)
-        except KeyError:
-            raise PlanetError(f"No such subscription: {subscription_id!r}")
-
-        # End fake subscriptions service. After we refactor we will get
-        # the "sub" from a method in planet.clients.subscriptions (which
-        # doesn't exist yet).
-
-        for result in filtered_results:
-            echo_json(result, pretty)
 
     result = CliRunner().invoke(
         cli.main,

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -78,3 +78,30 @@ def test_subscriptions_create_failure(monkeypatch):
     assert result.exit_code == 1  # failure.
     assert "Request lacks required members" in result.output
     assert _count_fake_subs() == 0
+
+
+def test_subscriptions_create_success(monkeypatch):
+    """An valid subscription request succeeds in creating a new subscription."""
+
+    monkeypatch.setattr(planet.cli.subscriptions, '_fake_subs', [])
+
+    # This subscription request has the members required by our fake API.
+    # It must be updated when we begin to test against a more strict
+    # imitation of the Planet Subscriptions API.
+    sub = {'name': 'lol', 'delivery': True, 'source': 'wut'}
+
+    # The "-" argument says "read from stdin" and the input keyword
+    # argument specifies what bytes go to the runner's stdin.
+    result = CliRunner().invoke(
+        cli.main,
+        args=['subscriptions', 'create', '-'],
+        input=json.dumps(sub),
+        # Note: catch_exceptions=True (the default) is required if we want
+        # to exercise the "translate_exceptions" decorator and test for
+        # failure.
+        catch_exceptions=True)
+
+    assert result.exit_code == 0  # success.
+    assert "Request lacks required members" not in result.output
+    assert json.loads(result.output)['id'] == '42'
+    assert _count_fake_subs() == 1

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -81,7 +81,7 @@ def test_subscriptions_create_failure(monkeypatch):
 
 
 def test_subscriptions_create_success(monkeypatch):
-    """An valid subscription request succeeds in creating a new subscription."""
+    """Subscriptions creation succeeds with a valid subscription request."""
 
     monkeypatch.setattr(planet.cli.subscriptions, '_fake_subs', [])
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -4,10 +4,12 @@ There are 6 subscriptions commands:
 
 [x] planet subscriptions list
 [x] planet subscriptions describe
-[ ] planet subscriptions results
+[x] planet subscriptions results
 [x] planet subscriptions create
 [x] planet subscriptions update
 [x] planet subscriptions cancel
+
+TODO: tests for 3 options of the planet-subscriptions-results command.
 
 """
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -18,7 +18,7 @@ import pytest
 
 from planet.cli import cli
 import planet.cli.subscriptions
-from planet.cli.subscriptions import _count_fake_subs, subscriptions
+from planet.cli.subscriptions import _count_fake_subs
 
 
 # CliRunner doesn't agree with empty options, so a list of option
@@ -140,43 +140,6 @@ def test_subscriptions_cancel_failure(monkeypatch):
 
     monkeypatch.setattr(planet.cli.subscriptions, '_fake_subs', {})
 
-    # Begin CLI command.
-    import click
-    from planet.cli.subscriptions import (_cancel_fake_sub,
-                                          coro,
-                                          echo_json,
-                                          translate_exceptions)
-    from planet.exceptions import PlanetError
-
-    @subscriptions.command(name='cancel')
-    @click.argument('subscription_id')
-    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def cancel_subscription(ctx, subscription_id, pretty):
-        """Cancels a subscription and prints the API response.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs object).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Begin fake subscriptions service. Note that the Subscriptions
-        # API will report missing keys differently, but the Python API
-        # *will* raise PlanetError like this.
-        try:
-            sub = _cancel_fake_sub(subscription_id)
-        except KeyError:
-            raise PlanetError(f"No such subscription: {subscription_id!r}")
-
-        # End fake subscriptions service. After we refactor we will get
-        # the "sub" from a method in planet.clients.subscriptions (which
-        # doesn't exist yet).
-
-        echo_json(sub, pretty)
-
     result = CliRunner().invoke(
         cli.main,
         args=['subscriptions', 'cancel', '42'],
@@ -195,43 +158,6 @@ def test_subscriptions_cancel_success(monkeypatch):
     monkeypatch.setattr(planet.cli.subscriptions,
                         '_fake_subs',
                         {'42': dict(**GOOD_SUB_REQUEST, id='42')})
-
-    # Begin CLI command.
-    import click
-    from planet.cli.subscriptions import (_cancel_fake_sub,
-                                          coro,
-                                          echo_json,
-                                          translate_exceptions)
-    from planet.exceptions import PlanetError
-
-    @subscriptions.command(name='cancel')
-    @click.argument('subscription_id')
-    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def cancel_subscription(ctx, subscription_id, pretty):
-        """Cancels a subscription and prints the API response.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs object).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Begin fake subscriptions service. Note that the Subscriptions
-        # API will report missing keys differently, but the Python API
-        # *will* raise PlanetError like this.
-        try:
-            sub = _cancel_fake_sub(subscription_id)
-        except KeyError:
-            raise PlanetError(f"No such subscription: {subscription_id!r}")
-
-        # End fake subscriptions service. After we refactor we will get
-        # the "sub" from a method in planet.clients.subscriptions (which
-        # doesn't exist yet).
-
-        echo_json(sub, pretty)
 
     # Let's check the state of the fake API before we try to cancel.
     assert _count_fake_subs() == 1

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -1,0 +1,212 @@
+"""Tests of the Subscriptions CLI (aka planet-subscriptions)
+
+There are 6 subscriptions commands:
+
+planet subscriptions list
+planet subscriptions describe
+planet subscriptions results
+planet subscriptions create
+planet subscriptions update
+planet subscriptions cancel
+
+"""
+
+import itertools
+import json
+
+import click
+from click.testing import CliRunner
+
+import pytest
+
+import planet
+from planet.cli import cli
+from planet.cli.cmds import coro, translate_exceptions
+from planet.cli.io import echo_json
+from planet.exceptions import PlanetError
+
+
+@pytest.fixture
+def all_subs():
+    """A collection of fake subscriptions for testing.
+
+    We're not testing the actual API workflow. All subscription states
+    are equal as far as the initial tests are concerned. We have 101
+    fake subscriptions so that we can test the command's default limit
+    of 100.
+
+    """
+    return [{'id': str(i), 'status': 'created'} for i in range(101)]
+
+
+# CliRunner doesn't agree with empty options, so a list of option
+# combinations which omit the empty options is best. For example,
+# parametrizing 'limit' as '' and then executing
+#
+# CliRunner().invoke(cli.main, args=['subscriptions', 'list', limit]
+#
+# does not work.
+@pytest.mark.parametrize('options,expected_count',
+                         [(['--status=created'], 100), ([], 100),
+                          (['--limit=1', '--status=created'], 1),
+                          (['--limit=2', '--pretty', '--status=created'], 2),
+                          (['--limit=1', '--status=queued'], 0)])
+# Remember, parameters come before fixtures in the function definition.
+def test_subscriptions_list_options(options, expected_count, all_subs):
+    """Prints the expected sequence of subscriptions."""
+
+    # As an exercise in test-driven development, let's develop the CLI
+    # right here in the body of the test. Once we have basic tests of
+    # the input/output/options working, we can refactor and move the
+    # command to planet/cli/subscriptions.py.
+    @click.group()
+    @click.pass_context
+    def subscriptions(ctx):
+        ctx.obj['AUTH'] = planet.Auth.from_file()
+
+    # We want our command to be known as "list" on the command line but
+    # don't want to clobber Python's built-in "list". We'll define the
+    # command function as "list_subscriptions".
+    @subscriptions.command(name="list")
+    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
+    @click.option(
+        '--status',
+        type=click.Choice(
+            ["created", "queued", "processing", "failed", "success"]),
+        multiple=True,
+        default=None,
+        help="Select subscriptions in one or more states. Default is all.")
+    @click.option('--limit',
+                  type=int,
+                  default=100,
+                  help='Maximum number of results to return. Defaults to 100.')
+    @click.pass_context
+    @translate_exceptions
+    @coro
+    async def list_subscriptions(ctx, status, limit, pretty):
+        """Prints a sequence of JSON-encoded Subscription descriptions.
+
+        This implementation is only a placeholder. To begin, instead
+        of mocking calls to the Subscriptions API, we'll use a
+        collection of fake subscriptions (the all_subs fixture).
+        After we refactor we will change to mocking the API.
+
+        """
+        # Filter by status, like the Subscriptions API does.
+        if status:
+            select_subs = (sub for sub in all_subs if sub['status'] in status)
+        else:
+            select_subs = all_subs
+
+        filtered_subs = itertools.islice(select_subs, limit)
+        # End of placeholder implementation. In the future we will get
+        # the filtered subscriptions from a method of the to-be-written
+        # planet.clients.subscriptions.
+
+        # Print output to terminal, respecting the provided limit.
+        for sub in filtered_subs:
+            echo_json(sub, pretty)
+
+    cli.main.add_command(subscriptions)
+    # End of the command code.
+
+    # While developing it is handy to have click's command invoker
+    # *not* catch exceptions, so we can use the pytest --pdb option.
+    result = CliRunner().invoke(cli.main,
+                                args=['subscriptions', 'list'] + options,
+                                catch_exceptions=False)
+    assert result.exit_code == 0  # success.
+
+    # For a start, counting the number of "id" strings in the output
+    # tells us how many subscription JSONs were printed, pretty or not.
+    assert result.output.count('"id"') == expected_count
+
+
+def test_subscriptions_create_failure():
+    """An invalid subscription request fails to create a new subscription.
+
+    As above, we develop the command here in the body of the test.
+
+    """
+    # Begin command's code skeleton.
+    @click.group()
+    @click.pass_context
+    def subscriptions(ctx):
+        ctx.obj['AUTH'] = planet.Auth.from_file()
+
+    def parse_request(ctx, param, value: str) -> dict:
+        """Turn request JSON/file into a dict."""
+        if value.startswith('{'):
+            try:
+                obj = json.loads(value)
+            except json.decoder.JSONDecodeError:
+                raise click.BadParameter(
+                    'Request does not contain valid json.',
+                    ctx=ctx,
+                    param=param)
+            if not obj:
+                raise click.BadParameter('Request is empty.',
+                                         ctx=ctx,
+                                         param=param)
+        else:
+            try:
+                with click.open_file(value) as f:
+                    obj = json.load(f)
+            except json.decoder.JSONDecodeError:
+                raise click.BadParameter(
+                    'Request does not contain valid json.',
+                    ctx=ctx,
+                    param=param)
+
+        return obj
+
+    @subscriptions.command(name='create')
+    @click.argument('request', callback=parse_request)
+    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
+    @click.pass_context
+    @translate_exceptions
+    @coro
+    async def create_subscription(ctx, request, pretty):
+        """Submits a subscription request and prints the API response.
+
+        This implementation is only a placeholder. To begin, instead
+        of mocking calls to the Subscriptions API, we'll use a
+        collection of fake subscriptions (the all_subs fixture).
+        After we refactor we will change to mocking the API.
+
+        """
+        # Begin fake subscriptions service. Note that the Subscriptions
+        # API will report missing keys differently, but the Python API
+        # *will* raise PlanetError like this.
+        missing_keys = {'name', 'delivery', 'source'} - request.keys()
+        if missing_keys:
+            raise PlanetError(
+                f"Request lacks required members: {missing_keys!r}")
+
+        # Update the request with an id.
+        sub = dict(**request, id='42')
+        # End fake subscriptions service. After we refactor we will get
+        # the "sub" from a method in planet.clients.subscriptions (which
+        # doesn't exist yet).
+
+        echo_json(sub, pretty)
+
+    cli.main.add_command(subscriptions)
+    # End of the command code.
+
+    # This subscription request lacks the required "delivery" and
+    # "source" members.
+    sub = {'name': 'lol'}
+
+    # The "-" argument says "read from stdin" and the input keyword
+    # argument specifies what bytes go to the runner's stdin.
+    result = CliRunner().invoke(
+        cli.main,
+        args=['subscriptions', 'create', '-'],
+        input=json.dumps(sub),
+        # Note: catch_exceptions=True (the default) is required if we want
+        # to exercise the "translate_exceptions" decorator and test for
+        # failure.
+        catch_exceptions=True)
+    assert result.exit_code == 1  # failure.
+    assert "Request lacks required members" in result.output

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -11,32 +11,14 @@ planet subscriptions cancel
 
 """
 
-import itertools
 import json
 
-import click
 from click.testing import CliRunner
-
 import pytest
 
-import planet
 from planet.cli import cli
-from planet.cli.cmds import coro, translate_exceptions
-from planet.cli.io import echo_json
-from planet.exceptions import PlanetError
-
-
-@pytest.fixture
-def all_subs():
-    """A collection of fake subscriptions for testing.
-
-    We're not testing the actual API workflow. All subscription states
-    are equal as far as the initial tests are concerned. We have 101
-    fake subscriptions so that we can test the command's default limit
-    of 100.
-
-    """
-    return [{'id': str(i), 'status': 'created'} for i in range(101)]
+import planet.cli.subscriptions
+from planet.cli.subscriptions import _count_fake_subs
 
 
 # CliRunner doesn't agree with empty options, so a list of option
@@ -52,63 +34,14 @@ def all_subs():
                           (['--limit=2', '--pretty', '--status=created'], 2),
                           (['--limit=1', '--status=queued'], 0)])
 # Remember, parameters come before fixtures in the function definition.
-def test_subscriptions_list_options(options, expected_count, all_subs):
+def test_subscriptions_list_options(options, expected_count, monkeypatch):
     """Prints the expected sequence of subscriptions."""
 
-    # As an exercise in test-driven development, let's develop the CLI
-    # right here in the body of the test. Once we have basic tests of
-    # the input/output/options working, we can refactor and move the
-    # command to planet/cli/subscriptions.py.
-    @click.group()
-    @click.pass_context
-    def subscriptions(ctx):
-        ctx.obj['AUTH'] = planet.Auth.from_file()
-
-    # We want our command to be known as "list" on the command line but
-    # don't want to clobber Python's built-in "list". We'll define the
-    # command function as "list_subscriptions".
-    @subscriptions.command(name="list")
-    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
-    @click.option(
-        '--status',
-        type=click.Choice(
-            ["created", "queued", "processing", "failed", "success"]),
-        multiple=True,
-        default=None,
-        help="Select subscriptions in one or more states. Default is all.")
-    @click.option('--limit',
-                  type=int,
-                  default=100,
-                  help='Maximum number of results to return. Defaults to 100.')
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def list_subscriptions(ctx, status, limit, pretty):
-        """Prints a sequence of JSON-encoded Subscription descriptions.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs fixture).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Filter by status, like the Subscriptions API does.
-        if status:
-            select_subs = (sub for sub in all_subs if sub['status'] in status)
-        else:
-            select_subs = all_subs
-
-        filtered_subs = itertools.islice(select_subs, limit)
-        # End of placeholder implementation. In the future we will get
-        # the filtered subscriptions from a method of the to-be-written
-        # planet.clients.subscriptions.
-
-        # Print output to terminal, respecting the provided limit.
-        for sub in filtered_subs:
-            echo_json(sub, pretty)
-
-    cli.main.add_command(subscriptions)
-    # End of the command code.
+    monkeypatch.setattr(planet.cli.subscriptions,
+                        '_fake_subs',
+                        [{
+                            'id': str(i), 'status': 'created'
+                        } for i in range(101)])
 
     # While developing it is handy to have click's command invoker
     # *not* catch exceptions, so we can use the pytest --pdb option.
@@ -122,77 +55,10 @@ def test_subscriptions_list_options(options, expected_count, all_subs):
     assert result.output.count('"id"') == expected_count
 
 
-def test_subscriptions_create_failure():
-    """An invalid subscription request fails to create a new subscription.
+def test_subscriptions_create_failure(monkeypatch):
+    """An invalid subscription request fails to create a new subscription."""
 
-    As above, we develop the command here in the body of the test.
-
-    """
-    # Begin command's code skeleton.
-    @click.group()
-    @click.pass_context
-    def subscriptions(ctx):
-        ctx.obj['AUTH'] = planet.Auth.from_file()
-
-    def parse_request(ctx, param, value: str) -> dict:
-        """Turn request JSON/file into a dict."""
-        if value.startswith('{'):
-            try:
-                obj = json.loads(value)
-            except json.decoder.JSONDecodeError:
-                raise click.BadParameter(
-                    'Request does not contain valid json.',
-                    ctx=ctx,
-                    param=param)
-            if not obj:
-                raise click.BadParameter('Request is empty.',
-                                         ctx=ctx,
-                                         param=param)
-        else:
-            try:
-                with click.open_file(value) as f:
-                    obj = json.load(f)
-            except json.decoder.JSONDecodeError:
-                raise click.BadParameter(
-                    'Request does not contain valid json.',
-                    ctx=ctx,
-                    param=param)
-
-        return obj
-
-    @subscriptions.command(name='create')
-    @click.argument('request', callback=parse_request)
-    @click.option('--pretty', is_flag=True, help='Pretty-print output.')
-    @click.pass_context
-    @translate_exceptions
-    @coro
-    async def create_subscription(ctx, request, pretty):
-        """Submits a subscription request and prints the API response.
-
-        This implementation is only a placeholder. To begin, instead
-        of mocking calls to the Subscriptions API, we'll use a
-        collection of fake subscriptions (the all_subs fixture).
-        After we refactor we will change to mocking the API.
-
-        """
-        # Begin fake subscriptions service. Note that the Subscriptions
-        # API will report missing keys differently, but the Python API
-        # *will* raise PlanetError like this.
-        missing_keys = {'name', 'delivery', 'source'} - request.keys()
-        if missing_keys:
-            raise PlanetError(
-                f"Request lacks required members: {missing_keys!r}")
-
-        # Update the request with an id.
-        sub = dict(**request, id='42')
-        # End fake subscriptions service. After we refactor we will get
-        # the "sub" from a method in planet.clients.subscriptions (which
-        # doesn't exist yet).
-
-        echo_json(sub, pretty)
-
-    cli.main.add_command(subscriptions)
-    # End of the command code.
+    monkeypatch.setattr(planet.cli.subscriptions, '_fake_subs', [])
 
     # This subscription request lacks the required "delivery" and
     # "source" members.
@@ -208,5 +74,7 @@ def test_subscriptions_create_failure():
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
         catch_exceptions=True)
+
     assert result.exit_code == 1  # failure.
     assert "Request lacks required members" in result.output
+    assert _count_fake_subs() == 0


### PR DESCRIPTION
This is test-driven to the extreme. The skeleton of the CLI begins in the bodies of the tests. There's no planet.cli.subscriptions at the start.

Resolves #430 and #431