### PR TITLE
match folder structure in order download to manifest

### DIFF
--- a/planet/models.py
+++ b/planet/models.py
@@ -15,6 +15,7 @@
 from datetime import datetime
 import logging
 import mimetypes
+from pathlib import Path
 import random
 import re
 import string
@@ -171,17 +172,17 @@ class StreamingBody:
         async for c in self.response.aiter_bytes():
             yield c
 
-    async def write(self, filename, overwrite=True, progress_bar=True):
-        '''Write the body to a file.
+    async def write(self,
+                    filename: Path,
+                    overwrite: bool = True,
+                    progress_bar: bool = True):
+        """Write the body to a file.
 
-        :param filename: Name to assign to downloaded file.
-        :type filename: str
-        :param overwrite: Overwrite any existing files. Defaults to True
-        :type overwrite: boolean, optional
-        :param progress_bar: Show progress bar during download. Defaults to
-            True.
-        :type progress_bar: boolean, optional
-        '''
+        Parameters:
+            filename: Name to assign to downloaded file.
+            overwrite: Overwrite any existing files.
+            progress_bar: Show progress bar during download.
+        """
 
         class _LOG:
 
@@ -190,7 +191,7 @@ class StreamingBody:
                 self.unit = unit
                 self.disable = disable
                 self.previous = 0
-                self.filename = filename
+                self.filename = str(filename)
 
                 if not self.disable:
                     LOGGER.debug(f'writing to {self.filename}')
@@ -216,7 +217,7 @@ class StreamingBody:
                           unit_scale=True,
                           unit_divisor=unit,
                           unit='B',
-                          desc=filename,
+                          desc=str(filename),
                           disable=not progress_bar) as progress:
                     previous = self.num_bytes_downloaded
                     async for chunk in self.aiter_bytes():

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -551,11 +551,11 @@ async def test_download_asset_md(tmpdir, session):
 @respx.mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
-async def test_checksum_success(tmpdir,
-                                order_description,
-                                oid,
-                                session,
-                                checksum):
+async def test_download_order_checksum_success(tmpdir,
+                                               order_description,
+                                               oid,
+                                               session,
+                                               checksum):
     # Mock an HTTP response for download
     order_description['state'] = 'success'
     dl_url1 = TEST_DOWNLOAD_URL + '/asset1'
@@ -631,11 +631,11 @@ async def test_checksum_success(tmpdir,
 @respx.mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
-async def test_checksum_failure(tmpdir,
-                                order_description,
-                                oid,
-                                session,
-                                checksum):
+async def test_download_order_checksum_failure(tmpdir,
+                                               order_description,
+                                               oid,
+                                               session,
+                                               checksum):
     # Note: the hashkeys in the mock manifest below were changed
     # from the correct keys to temporary keys
     # This should cause the checksum to fail.
@@ -710,7 +710,7 @@ async def test_checksum_failure(tmpdir,
     # Test Checksum
     cl = OrdersClient(session, base_url=TEST_URL)
     with pytest.raises(exceptions.ClientError):
-        await cl.download_order(oid, directory=str(tmpdir), checksum=checksum)
+        await cl.download_order(oid, directory=Path(tmpdir), checksum=checksum)
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -59,7 +59,7 @@ def create_download_mock(downloaded_content, order_description, oid):
         dl_url = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
         order_description['_links']['results'] = [
             {
-                'location': dl_url
+                'location': dl_url, 'name': 'file.json'
             },
         ]
 
@@ -550,171 +550,6 @@ async def test_download_asset_md(tmpdir, session):
 
 @respx.mock
 @pytest.mark.asyncio
-@pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
-async def test_download_order_checksum_success(tmpdir,
-                                               order_description,
-                                               oid,
-                                               session,
-                                               checksum):
-    # Mock an HTTP response for download
-    order_description['state'] = 'success'
-    dl_url1 = TEST_DOWNLOAD_URL + '/asset1'
-    dl_url2 = TEST_DOWNLOAD_URL + '/asset2'
-    dl_url3 = TEST_DOWNLOAD_URL + '/manifest'
-    order_description['_links']['results'] = [{
-        'location': dl_url1
-    }, {
-        'location': dl_url2
-    }, {
-        'location': dl_url3
-    }]
-    get_url = f'{TEST_ORDERS_URL}/{oid}'
-    get_order_response = httpx.Response(HTTPStatus.OK, json=order_description)
-    respx.get(get_url).return_value = get_order_response
-
-    # The first asset in the order:
-    # A 1-byte binary file containing the value "1".
-    asset1_content = b"1"
-    asset1_response = httpx.Response(HTTPStatus.OK,
-                                     content=asset1_content,
-                                     headers={
-                                         'Content-Type':
-                                         'image/tiff',
-                                         'Content-Disposition':
-                                         'attachment; filename="asset1.tif"'
-                                     })
-    respx.get(dl_url1).return_value = asset1_response
-
-    asset2_response = httpx.Response(HTTPStatus.OK,
-                                     json={'foo': 'bar'},
-                                     headers={
-                                         'Content-Type':
-                                         'application/json',
-                                         'Content-Disposition':
-                                         'attachment; filename="asset2.json"'
-                                     })
-    respx.get(dl_url2).return_value = asset2_response
-    # Create a mock manifest which has the correct hashkeys for each asset
-    manifest = httpx.Response(
-        HTTPStatus.OK,
-        json={
-            "name":
-            "",
-            "files":
-            [{
-                "path": "asset1.tif",
-                "digests": {
-                    "md5": hashlib.md5(asset1_response.content).hexdigest(),
-                    "sha256":
-                    hashlib.sha256(asset1_response.content).hexdigest()
-                },
-            },
-             {
-                 "path": "asset2.json",
-                 "digests": {
-                     "md5": hashlib.md5(asset2_response.content).hexdigest(),
-                     "sha256":
-                     hashlib.sha256(asset2_response.content).hexdigest()
-                 }
-             }]
-        },
-        headers={
-            'Content-Type': 'application/json',
-            'Content-Disposition': 'attachment; filename="manifest.json"'
-        })
-    respx.get(dl_url3).return_value = manifest
-    # Test Checksum
-    cl = OrdersClient(session, base_url=TEST_URL)
-    await cl.download_order(oid, directory=str(tmpdir), checksum=checksum)
-
-
-@respx.mock
-@pytest.mark.asyncio
-@pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
-async def test_download_order_checksum_failure(tmpdir,
-                                               order_description,
-                                               oid,
-                                               session,
-                                               checksum):
-    # Note: the hashkeys in the mock manifest below were changed
-    # from the correct keys to temporary keys
-    # This should cause the checksum to fail.
-    # Mock an HTTP response for download
-    order_description['state'] = 'success'
-    dl_url1 = TEST_DOWNLOAD_URL + '/asset1'
-    dl_url2 = TEST_DOWNLOAD_URL + '/asset2'
-    dl_url3 = TEST_DOWNLOAD_URL + '/manifest'
-    order_description['_links']['results'] = [{
-        'location': dl_url1
-    }, {
-        'location': dl_url2
-    }, {
-        'location': dl_url3
-    }]
-    get_url = f'{TEST_ORDERS_URL}/{oid}'
-    get_order_response = httpx.Response(HTTPStatus.OK, json=order_description)
-    respx.get(get_url).return_value = get_order_response
-
-    # The first asset in the order:
-    # A 1-byte binary file containing the value "1".
-    asset1_content = b"1"
-    asset1_response = httpx.Response(HTTPStatus.OK,
-                                     content=asset1_content,
-                                     headers={
-                                         'Content-Type':
-                                         'image/tiff',
-                                         'Content-Disposition':
-                                         'attachment; filename="asset1.tif"'
-                                     })
-    respx.get(dl_url1).return_value = asset1_response
-
-    # The second asset in the order is a json file
-    asset2_response = httpx.Response(HTTPStatus.OK,
-                                     json={'foo': 'bar'},
-                                     headers={
-                                         'Content-Type':
-                                         'application/json',
-                                         'Content-Disposition':
-                                         'attachment; filename="asset2.json"'
-                                     })
-    respx.get(dl_url2).return_value = asset2_response
-
-    manifest = httpx.Response(HTTPStatus.OK,
-                              json={
-                                  "name":
-                                  "",
-                                  "files": [{
-                                      "path": "asset1.tif",
-                                      "digests": {
-                                          "md5": "manifest_key1_md5",
-                                          "sha256": "manifest_key1_sha256"
-                                      },
-                                  },
-                                            {
-                                                "path": "asset2.json",
-                                                "digests": {
-                                                    "md5":
-                                                    "manifest_key2_md5",
-                                                    "sha256":
-                                                    "manifest_key2_sha256"
-                                                }
-                                            }]
-                              },
-                              headers={
-                                  'Content-Type':
-                                  'application/json',
-                                  'Content-Disposition':
-                                  'attachment; filename="manifest.json"'
-                              })
-    respx.get(dl_url3).return_value = manifest
-    # Test Checksum
-    cl = OrdersClient(session, base_url=TEST_URL)
-    with pytest.raises(exceptions.ClientError):
-        await cl.download_order(oid, directory=Path(tmpdir), checksum=checksum)
-
-
-@respx.mock
-@pytest.mark.asyncio
 async def test_download_asset_img(tmpdir, open_test_img, session):
     dl_url = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
 
@@ -750,21 +585,30 @@ async def test_download_asset_img(tmpdir, open_test_img, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_download_order_success(tmpdir, order_description, oid, session):
-    '''
-    Test if download_order() successfully downloads an order with two files,
-    given a singular order ID.
-    '''
+@respx.mock
+@pytest.mark.parametrize(
+    "results, paths",
+    [(None, []),
+     ([], []),
+     ([{"location": f'{TEST_DOWNLOAD_URL}/1',
+        "name": "oid/itemtype1/asset.json"},
+       {"location": f'{TEST_DOWNLOAD_URL}/2',
+        "name": "oid/itemtype2/asset.json"},
+       ],
+      [Path('oid', 'itemtype1', 'asset.json'),
+       Path('oid', 'itemtype2', 'asset.json'),
+       ])
+     ])  # yapf: disable
+async def test_download_order_success(results,
+                                      paths,
+                                      tmpdir,
+                                      order_description,
+                                      oid,
+                                      session):
 
     # Mock an HTTP response for download
     order_description['state'] = 'success'
-    dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
-    dl_url2 = TEST_DOWNLOAD_URL + '/2?token=IAmAnotherToken'
-    order_description['_links']['results'] = [{
-        'location': dl_url1
-    }, {
-        'location': dl_url2
-    }]
+    order_description['_links']['results'] = results
 
     get_url = f'{TEST_ORDERS_URL}/{oid}'
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
@@ -776,9 +620,9 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
                                     'Content-Type':
                                     'application/json',
                                     'Content-Disposition':
-                                    'attachment; filename="m1.json"'
+                                    'attachment; filename="asset.json"'
                                 })
-    respx.get(dl_url1).return_value = mock_resp1
+    respx.get(f'{TEST_DOWNLOAD_URL}/1').return_value = mock_resp1
 
     mock_resp2 = httpx.Response(HTTPStatus.OK,
                                 json={'key2': 'value2'},
@@ -786,21 +630,18 @@ async def test_download_order_success(tmpdir, order_description, oid, session):
                                     'Content-Type':
                                     'application/json',
                                     'Content-Disposition':
-                                    'attachment; filename="m2.json"'
+                                    'attachment; filename="asset.json"'
                                 })
-    respx.get(dl_url2).return_value = mock_resp2
+    respx.get(f'{TEST_DOWNLOAD_URL}/2').return_value = mock_resp2
 
     cl = OrdersClient(session, base_url=TEST_URL)
     filenames = await cl.download_order(oid, directory=str(tmpdir))
 
-    # Check there are as many files as expected, given in order_description
-    assert len(filenames) == 2
+    assert filenames == [Path(tmpdir, p) for p in paths]
 
-    # Check that the downloaded files have the correct filename and contents
-    assert json.load(open(filenames[0])) == {'key': 'value'}
-    assert Path(filenames[0]).name == 'm1.json'
-    assert json.load(open(filenames[1])) == {'key2': 'value2'}
-    assert Path(filenames[1]).name == 'm2.json'
+    if filenames:
+        assert json.load(open(filenames[0])) == {'key': 'value'}
+        assert json.load(open(filenames[1])) == {'key2': 'value2'}
 
 
 @respx.mock
@@ -820,37 +661,6 @@ async def test_download_order_state(tmpdir, order_description, oid, session):
     cl = OrdersClient(session, base_url=TEST_URL)
     with pytest.raises(exceptions.ClientError):
         await cl.download_order(oid, directory=str(tmpdir))
-
-
-@respx.mock
-@pytest.mark.asyncio
-async def test_download_order_without_order_links(tmpdir,
-                                                  order_description,
-                                                  oid,
-                                                  session):
-    dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
-
-    order_description['state'] = 'success'
-    order_description['_links']['results'] = None
-
-    get_url = f'{TEST_ORDERS_URL}/{oid}'
-    mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
-    respx.get(get_url).return_value = mock_resp
-
-    mock_resp1 = httpx.Response(HTTPStatus.OK,
-                                json={'key': 'value'},
-                                headers={
-                                    'Content-Type':
-                                    'application/json',
-                                    'Content-Disposition':
-                                    'attachment; filename="m1.json"'
-                                })
-    respx.get(dl_url1).return_value = mock_resp1
-
-    client = OrdersClient(session, base_url=TEST_URL)
-
-    filenames = await client.download_order(oid, directory=str(tmpdir))
-    assert len(filenames) == 0
 
 
 @respx.mock
@@ -932,3 +742,178 @@ async def test_download_order_overwrite_false_nonexisting_data(
 
     # Check that the was data downloaded and has the correct contents
     assert json.load(open(Path(tmpdir, 'file.json'))) == downloaded_content
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
+async def test_download_order_checksum_success(tmpdir,
+                                               order_description,
+                                               oid,
+                                               session,
+                                               checksum):
+    # Mock an HTTP response for download
+    order_description['state'] = 'success'
+    dl_url1 = TEST_DOWNLOAD_URL + '/asset1'
+    dl_url2 = TEST_DOWNLOAD_URL + '/asset2'
+    dl_url3 = TEST_DOWNLOAD_URL + '/manifest'
+    order_description['_links']['results'] = [
+        {
+            'location': dl_url1, 'name': 'oid/itemtype1/asset1.tif'
+        }, {
+            'location': dl_url2, 'name': 'oid/itemtype1/asset2.json'
+        }, {
+            'location': dl_url3, 'name': 'oid/itemtype1/manifest.json'
+        }]  # yapf: disable
+
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+    get_order_response = httpx.Response(HTTPStatus.OK, json=order_description)
+    respx.get(get_url).return_value = get_order_response
+
+    # The first asset in the order:
+    # A 1-byte binary file containing the value "1".
+    asset1_content = b"1"
+    asset1_response = httpx.Response(HTTPStatus.OK,
+                                     content=asset1_content,
+                                     headers={
+                                         'Content-Type':
+                                         'image/tiff',
+                                         'Content-Disposition':
+                                         'attachment; filename="asset1.tif"'
+                                     })
+    respx.get(dl_url1).return_value = asset1_response
+
+    asset2_response = httpx.Response(HTTPStatus.OK,
+                                     json={'foo': 'bar'},
+                                     headers={
+                                         'Content-Type':
+                                         'application/json',
+                                         'Content-Disposition':
+                                         'attachment; filename="asset2.json"'
+                                     })
+    respx.get(dl_url2).return_value = asset2_response
+    # Create a mock manifest which has the correct hashkeys for each asset
+    manifest = httpx.Response(
+        HTTPStatus.OK,
+        json={
+            "name":
+            "",
+            "files":
+            [{
+                "path": "oid/itemtype1/asset1.tif",
+                "digests": {
+                    "md5": hashlib.md5(asset1_response.content).hexdigest(),
+                    "sha256":
+                    hashlib.sha256(asset1_response.content).hexdigest()
+                },
+            },
+             {
+                 "path": "oid/itemtype1/asset2.json",
+                 "digests": {
+                     "md5": hashlib.md5(asset2_response.content).hexdigest(),
+                     "sha256":
+                     hashlib.sha256(asset2_response.content).hexdigest()
+                 }
+             }]
+        },
+        headers={
+            'Content-Type': 'application/json',
+            'Content-Disposition': 'attachment; filename="manifest.json"'
+        })
+    respx.get(dl_url3).return_value = manifest
+
+    cl = OrdersClient(session, base_url=TEST_URL)
+    await cl.download_order(oid, directory=Path(tmpdir), checksum=checksum)
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize("checksum", [("MD5"), ("SHA256")])
+async def test_download_order_checksum_failure(tmpdir,
+                                               order_description,
+                                               oid,
+                                               session,
+                                               checksum):
+    # Note: the hashkeys in the mock manifest below were changed
+    # from the correct keys to temporary keys
+    # This should cause the checksum to fail.
+    # Mock an HTTP response for download
+    order_description['state'] = 'success'
+    dl_url1 = TEST_DOWNLOAD_URL + '/asset1'
+    dl_url2 = TEST_DOWNLOAD_URL + '/asset2'
+    dl_url3 = TEST_DOWNLOAD_URL + '/manifest'
+    order_description['_links']['results'] = [{
+        'location': dl_url1, 'name': 'oid/itemtype1/asset.tif'
+    },
+                                              {
+                                                  'location':
+                                                  dl_url2,
+                                                  'name':
+                                                  'oid/itemtype1/asset2.json'
+                                              },
+                                              {
+                                                  'location':
+                                                  dl_url3,
+                                                  'name':
+                                                  'oid/itemtype1/manifest.json'
+                                              }]
+    get_url = f'{TEST_ORDERS_URL}/{oid}'
+    get_order_response = httpx.Response(HTTPStatus.OK, json=order_description)
+    respx.get(get_url).return_value = get_order_response
+
+    # The first asset in the order:
+    # A 1-byte binary file containing the value "1".
+    asset1_content = b"1"
+    asset1_response = httpx.Response(HTTPStatus.OK,
+                                     content=asset1_content,
+                                     headers={
+                                         'Content-Type':
+                                         'image/tiff',
+                                         'Content-Disposition':
+                                         'attachment; filename="asset1.tif"'
+                                     })
+    respx.get(dl_url1).return_value = asset1_response
+
+    # The second asset in the order is a json file
+    asset2_response = httpx.Response(HTTPStatus.OK,
+                                     json={'foo': 'bar'},
+                                     headers={
+                                         'Content-Type':
+                                         'application/json',
+                                         'Content-Disposition':
+                                         'attachment; filename="asset2.json"'
+                                     })
+    respx.get(dl_url2).return_value = asset2_response
+
+    manifest = httpx.Response(HTTPStatus.OK,
+                              json={
+                                  "name":
+                                  "",
+                                  "files": [{
+                                      "path": "asset1.tif",
+                                      "digests": {
+                                          "md5": "manifest_key1_md5",
+                                          "sha256": "manifest_key1_sha256"
+                                      },
+                                  },
+                                            {
+                                                "path": "asset2.json",
+                                                "digests": {
+                                                    "md5":
+                                                    "manifest_key2_md5",
+                                                    "sha256":
+                                                    "manifest_key2_sha256"
+                                                }
+                                            }]
+                              },
+                              headers={
+                                  'Content-Type':
+                                  'application/json',
+                                  'Content-Disposition':
+                                  'attachment; filename="manifest.json"'
+                              })
+    respx.get(dl_url3).return_value = manifest
+    # Test Checksum
+    cl = OrdersClient(session, base_url=TEST_URL)
+    with pytest.raises(exceptions.ClientError):
+        await cl.download_order(oid, directory=Path(tmpdir), checksum=checksum)

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -257,9 +257,9 @@ def mock_download_response(oid, order_description):
         dl_url1 = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
         dl_url2 = TEST_DOWNLOAD_URL + '/2?token=IAmAnotherToken'
         order_description['_links']['results'] = [{
-            'location': dl_url1
+            'location': dl_url1, 'name': 'oid/itemtype/m1.json'
         }, {
-            'location': dl_url2
+            'location': dl_url2, 'name': 'oid/itemtype/m2.json'
         }]
 
         get_url = f'{TEST_ORDERS_URL}/{oid}'
@@ -303,9 +303,9 @@ def test_cli_orders_download_default(invoke, mock_download_response, oid):
         assert 'm1.json' in result.output
 
         # Check that the files were downloaded and have the correct contents
-        f1_path = Path(folder) / 'm1.json'
+        f1_path = Path(folder) / 'oid/itemtype/m1.json'
         assert json.load(open(f1_path)) == {'key': 'value'}
-        f2_path = Path(folder) / 'm2.json'
+        f2_path = Path(folder) / 'oid/itemtype/m2.json'
         assert json.load(open(f2_path)) == {'key2': 'value2'}
 
 
@@ -322,9 +322,9 @@ def test_cli_orders_download_dest(invoke, mock_download_response, oid):
         assert not result.exception
 
         # Check that the files were downloaded to the custom directory
-        f1_path = dest_dir / 'm1.json'
+        f1_path = dest_dir / 'oid/itemtype/m1.json'
         assert json.load(open(f1_path)) == {'key': 'value'}
-        f2_path = dest_dir / 'm2.json'
+        f2_path = dest_dir / 'oid/itemtype/m2.json'
         assert json.load(open(f2_path)) == {'key2': 'value2'}
 
 
@@ -337,8 +337,9 @@ def test_cli_orders_download_overwrite(invoke,
 
     runner = CliRunner()
     with runner.isolated_filesystem() as folder:
-        filepath = Path(folder) / 'm1.json'
-        write_to_tmp_json_file({'foo': 'bar'}, filepath)
+        filepath = Path(folder) / 'oid/itemtype/m1.json'
+        filepath.parent.mkdir(parents=True)
+        filepath.write_text(json.dumps({'foo': 'bar'}))
 
         # check the file doesn't get overwritten by default
         result = invoke(['download', oid], runner=runner)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -160,7 +160,7 @@ async def test_StreamingBody_write_img(tmpdir, mocked_request, open_test_img):
     r.http_response = hr
     body = models.StreamingBody(r)
 
-    filename = Path(str(tmpdir)) / 'test.tif'
+    filename = Path(tmpdir) / 'test.tif'
     await body.write(filename, progress_bar=False)
 
     assert os.path.isfile(filename)


### PR DESCRIPTION
This changes order download from creating a flat folder structure to creating a folder structure that matches the entries in the manifest file. It also changes the checksum validation to look for files in the new structure.

Side effects:

- To minimize casting between Path and str, OrderClient download_asset() and download_order() parameters and return types changed from str to Path
- download_order() checksum validation now goes through entries in the manifest and fails if one of the entries is not present (previously would only match checksums in cases where both the file existed and the manifest entry was present)
- Moved `_validate_checksum()` to below `download_orders()` to match order of helper function definitions following primary function definition. In retrospect, I would have kept it where it was because the move masks the actual logic changes.

Closes #322