### PR TITLE
 fix checksum validation bug, refactor checksum validation

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -221,6 +221,27 @@ from planet import reporting
 >>> asyncio.run(create_poll_and_download())
 ```
 
+#### Validating Checksums
+
+Checksum validation provides for verification that the files in an order have
+been downloaded successfully and are not missing, currupted, or changed. This
+functionality is included in the OrderClient, but does not require an instance
+of the class to be used.
+
+
+To perform checksum validation:
+
+```python
+from pathlib import Path
+
+# path includes order id
+order_path = Path('193e5bd1-dedc-4c65-a539-6bc70e55d928')
+OrdersClient.validate_checksum(order_path, 'md5')
+```
+
+
+
+
 ### Data Client
 
 The Data Client mostly mirrors the

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -15,6 +15,7 @@
 from contextlib import asynccontextmanager
 import json
 import logging
+from pathlib import Path
 
 import click
 
@@ -200,15 +201,23 @@ async def wait(ctx, order_id, delay, max_attempts, state):
 async def download(ctx, order_id, overwrite, directory, checksum):
     """Download order by order ID.
 
-If --checksum is provided, the associated checksums given in the manifest
-are compared against the downloaded files to verify that they match."""
+    If --checksum is provided, the associated checksums given in the manifest
+    are compared against the downloaded files to verify that they match.
+
+    If --checksum is provided, files are already downloaded, and --overwrite is
+    not specified, this will simply validate the checksums of the files against
+    the manifest.
+    """
     quiet = ctx.obj['QUIET']
     async with orders_client(ctx) as cl:
-        await cl.download_order(str(order_id),
-                                directory=directory,
-                                overwrite=overwrite,
-                                progress_bar=not quiet,
-                                checksum=checksum)
+        await cl.download_order(
+            str(order_id),
+            directory=Path(directory),
+            overwrite=overwrite,
+            progress_bar=not quiet,
+        )
+        if checksum:
+            cl.validate_checksum(Path(directory, str(order_id)), checksum)
 
 
 def read_file_geojson(ctx, param, value):

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -274,42 +274,6 @@ class OrdersClient:
                              progress_bar=progress_bar)
         return dl_path
 
-    @staticmethod
-    def _validate_checksum(manifest_data: dict, directory: Path,
-                           checksum: str):
-        """For each file entry in the manifest, validates checksum against the
-        downloaded file.
-
-        Parameters:
-            manifest_data: The contents of the opened manifest.json file.
-            filenames: List of downloaded assets.
-            checksum: The type of checksum hash- 'MD5' or 'SHA256'.
-
-        Raises:
-            planet.exceptions.ClientError: If the checksum fails.
-        """
-        if checksum.upper() == 'MD5':
-            hash_type = hashlib.md5
-        elif checksum.upper() == 'SHA256':
-            hash_type = hashlib.sha256
-        else:
-            raise exceptions.ClientError(
-                'Checksum ({checksum}) must be one of MD5 or SHA256.')
-
-        for json_entry in manifest_data['files']:
-            origin_hash = json_entry['digests'][checksum.lower()]
-            filename = Path(directory / json_entry['path'])
-
-            try:
-                returned_hash = hash_type(filename.read_bytes()).hexdigest()
-            except FileNotFoundError:
-                raise exceptions.ClientError(
-                    'Checksum failed. File ({filename}) does not exist.')
-
-            if origin_hash != returned_hash:
-                raise exceptions.ClientError(
-                    'File ({filename}) checksums do not match.')
-
     async def download_order(self,
                              order_id: str,
                              directory: Path = Path('.'),
@@ -318,19 +282,12 @@ class OrdersClient:
                              checksum: str = None) -> typing.List[Path]:
         """Download all assets in an order.
 
-        If 'checksum' is specified, the checksums given in the manifest will
-        be validated against checksums calculated from the downloaded files.
-        Checksum validation will fail if any of the files are missing or if the
-        checksums do not match.
-
         Parameters:
             order_id: The ID of the order.
             directory: Base directory for file download. This directory must
                 already exist.
             overwrite: Overwrite files if they already exist.
             progress_bar: Show progress bar during download.
-            checksum: Perform checksum validation against the specified
-                checksum hash type - MD5 or SHA256.
 
         Returns:
             Paths to downloaded files.
@@ -338,7 +295,7 @@ class OrdersClient:
         Raises:
             planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If the order is not in a final
-                state or if checksum validation fails.
+                state.
         """
         order = await self.get_order(order_id)
         order_state = order['state']
@@ -360,21 +317,6 @@ class OrdersClient:
                                       progress_bar=progress_bar) for i in info
         ]
 
-        if checksum:
-            manifest_files = [
-                f for f in filenames if f.name == 'manifest.json'
-            ]
-            manifest_count = len(manifest_files)
-            if manifest_count > 1:
-                raise exceptions.ClientError(
-                    'Only 1 manifest.json expected per order.\
-                                             Recieved: {manifest_count}')
-            elif manifest_count is None:
-                raise exceptions.ClientError('No manifest file found.')
-
-            manifest_file = manifest_files[0]
-            manifest_data = json.loads(manifest_file.read_bytes())
-            self._validate_checksum(manifest_data, directory, checksum)
         return filenames
 
     @staticmethod
@@ -398,6 +340,59 @@ class OrdersClient:
                 'files.')
             info = []
         return info
+
+    @staticmethod
+    def validate_checksum(directory: Path, checksum: str):
+        """Validate checksums of downloaded files against order manifest.
+
+        For each file entry in the order manifest, the specified checksum given
+        in the manifest file will be validated against the checksum calculated
+        from the downloaded file.
+
+        Parameters:
+            directory: Path to order directory.
+            checksum: The type of checksum hash- 'MD5' or 'SHA256'.
+
+        Raises:
+            planet.exceptions.ClientError: If a file is missing or if checksums
+                do not match.
+        """
+        manifest_path = directory / 'manifest.json'
+
+        try:
+            manifest_data = json.loads(manifest_path.read_text())
+        except FileNotFoundError:
+            raise exceptions.ClientError(
+                f'File ({manifest_path}) does not exist.')
+        except json.decoder.JSONDecodeError:
+            raise exceptions.ClientError(
+                f'Manifest file ({manifest_path}) does not contain valid JSON.'
+            )
+
+        if checksum.upper() == 'MD5':
+            hash_type = hashlib.md5
+        elif checksum.upper() == 'SHA256':
+            hash_type = hashlib.sha256
+        else:
+            raise exceptions.ClientError(
+                f'Checksum ({checksum}) must be one of MD5 or SHA256.')
+
+        for json_entry in manifest_data['files']:
+            origin_hash = json_entry['digests'][checksum.lower()]
+
+            # drop top directory in path which is already specified as the
+            # laset entry in directory
+            # filename = directory / Path(*Path(json_entry['path']).parts[1:])
+            filename = directory / json_entry['path']
+            try:
+                returned_hash = hash_type(filename.read_bytes()).hexdigest()
+            except FileNotFoundError:
+                raise exceptions.ClientError(
+                    f'Checksum failed. File ({filename}) does not exist.')
+
+            if origin_hash != returned_hash:
+                raise exceptions.ClientError(
+                    f'File ({filename}) checksums do not match.')
 
     async def wait(self,
                    order_id: str,

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -380,9 +380,6 @@ class OrdersClient:
         for json_entry in manifest_data['files']:
             origin_hash = json_entry['digests'][checksum.lower()]
 
-            # drop top directory in path which is already specified as the
-            # laset entry in directory
-            # filename = directory / Path(*Path(json_entry['path']).parts[1:])
             filename = directory / json_entry['path']
             try:
                 returned_hash = hash_type(filename.read_bytes()).hexdigest()


### PR DESCRIPTION
Checksum validation was failing on tests with actual orders due to the manifest.json file having a different format than what was created in the tests (I should have double-checked that). This fixes that bug. Testing all cases was difficult with checksum validation embedded in `download_order` function, so validation was moved to it's own separate function. With this change, Python API users must call `validate_checksum` separately. This is added to the API User Guide doc.

Specifics:
- `validate_checksum` as a function separate from `download_order` reduces the complexity of testing (soo many permutations when they were combined)
- `validate_checksum` does not require any state information from `OrdersClient`, but it was kept in `OrdersClient` as a static method because `OrdersClient` is a top-level import and the orders module is a bit harder to get to. To use `validate_checksum`, an `OrdersClient` does not need to be instantiated - it can be called with `OrdersClient.validate_checksum`
- checksum cli test added

Closes #521 