### PR TITLE
Updating spec to match agreed upon usage design

### DIFF
--- a/design-docs/CLI-Orders.md
+++ b/design-docs/CLI-Orders.md
@@ -142,9 +142,8 @@ User Story: As a CLI user I would like to create an order, wait for it to be
 ready to download, then download the order. 
 
 ```
-$ planet orders create –like order_description.json \
-| jq -r ‘.id’ | planet orders wait - \
-| jq -r ‘.id’ | planet orders download -
+$ id=`planet orders create request-1.json | jq -r '.id'` \
+&& planet orders wait $id && planet orders download $id
 <ANSI download status reporting>
 ```
 


### PR DESCRIPTION
From a message:

> We need to update the usage docs. @sgillies  and I discussed the interface design here and decided that the usage you eventually came to was best because having a command output basically the input (in the case of planet orders wait) isn’t considered good design.

Just changing the usage to one that works as implemented.