### PR TITLE
add sort option to planet data search-quick

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -24,8 +24,14 @@ BASE_URL = f'{PLANET_BASE_URL}/data/v1/'
 SEARCHES_PATH = '/searches'
 STATS_PATH = '/stats'
 
+# TODO: get these values from the spec directly gh-619
 LIST_SORT_ORDER = ('created desc', 'created asc')
 LIST_SEARCH_TYPE = ('any', 'saved', 'quick')
+SEARCH_SORT = ('published desc',
+               'published asc',
+               'acquired desc',
+               'acquired asc')
+SEARCH_SORT_DEFAULT = 'published desc'
 STATS_INTERVAL = ('hour', 'day', 'week', 'month', 'year')
 
 WAIT_DELAY = 5
@@ -102,8 +108,8 @@ class DataClient:
         """Execute a quick search.
 
         Quick searches are saved for a short period of time (~month). The
-        `name` parameter of the search defaults to the search id if `name`
-        is not given.
+        `name` parameter of the search defaults to the id of the generated
+        search id if `name` is not specified.
 
         Example:
 
@@ -132,10 +138,8 @@ class DataClient:
         Parameters:
             item_types: The item types to include in the search.
             search_filter: Structured search criteria.
-            sort: Override default of 'published desc' for field and direction
-                to order results by. Specified as '<field> <direction>' where
-                direction is either 'desc' for descending direction or 'asc'
-                for ascending direction.
+            sort: Field and direction to order results by. Valid options are
+            given in SEARCH_SORT.
             name: The name of the saved search.
             limit: Maximum number of items to return.
 
@@ -157,8 +161,11 @@ class DataClient:
             request_json['name'] = name
 
         params = {}
-        if sort:
-            # TODO: validate sort
+        if sort and sort != SEARCH_SORT_DEFAULT:
+            sort = sort.lower()
+            if sort not in SEARCH_SORT:
+                raise exceptions.ClientError(
+                    f'{sort} must be one of {SEARCH_SORT}')
             params['sort'] = sort
 
         request = self._request(url,

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -110,7 +110,7 @@ async def test_quick_search_sort(item_descriptions,
                                  search_response,
                                  session):
 
-    sort = 'created asc'
+    sort = 'acquired asc'
     quick_search_url = f'{TEST_URL}/quick-search?sort={sort}'
 
     item1, _, _ = item_descriptions


### PR DESCRIPTION
add sort option to planet data search-quick, validate sort argument in data client

resulting usage:
```
Usage: planet data search-quick [OPTIONS] ITEM_TYPES [FILTER]

  Execute a structured item search.

  This function outputs a series of GeoJSON descriptions, one for each of the
  returned items, optionally pretty-printed.

  ITEM_TYPES is a comma-separated list of item-types to search.

  FILTER must be JSON and can be specified a json string, filename, or '-' for
  stdin. It defaults to reading from stdin.

  Quick searches are stored for approximately 30 days and the --name parameter
  will be applied to the stored quick search.

Options:
  --limit INTEGER                 Maximum number of results to return. A value
                                  of zero or None means all results (a
                                  potentially large number) are returned.
                                  [default: 100]
  --name TEXT                     Name of the saved search.
  --sort [published desc|published asc|acquired desc|acquired asc]
                                  Field and direction to order results by.
                                  [default: published desc]
  --pretty                        Format JSON output.
  --help                          Show this message and exit.
```
closes #603 