### PR TITLE
Add a draft GHA workflow to release to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 on:
   push:
-    branches: ["main"]
-    tags: ["*"]
 
 jobs:
   package:
@@ -18,11 +16,13 @@ jobs:
       - run: python -m build --sdist --wheel .
       - run: ls -l dist
       - run: check-wheel-contents dist/*.whl
+
       - name: Check long_description
         run: python -m twine check dist/*
-      - name: Upload to PyPI
+
+      - name: Upload to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
+          repository_url: https://test.pypi.org/legacy/
           user: __token__
-          password: ${{ secrets.pypi_password }}
-          skip_existing: true
+          password: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches: ["main"]
+    tags: ["*"]
+
+jobs:
+  package:
+    name: Build, verify, & upload package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - run: python -m pip install build twine check-wheel-contents
+      - run: python -m build --sdist --wheel .
+      - run: ls -l dist
+      - run: check-wheel-contents dist/*.whl
+      - name: Check long_description
+        run: python -m twine check dist/*
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          skip_existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 on:
-  push:
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Is this a pre-release?'
+        required: true
 
 jobs:
   package:
@@ -12,6 +16,16 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions.
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: ${{ inputs.logLevel }}
+
       - run: python -m pip install build twine check-wheel-contents
       - run: python -m build --sdist --wheel .
       - run: ls -l dist
@@ -20,9 +34,15 @@ jobs:
       - name: Check long_description
         run: python -m twine check dist/*
 
-      - name: Upload to Test PyPI
+      - name: Upload to TestPyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           repository_url: https://test.pypi.org/legacy/
           user: __token__
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
+name: Release to GitHub and PyPI
+
 on:
   workflow_dispatch:
     inputs:
       prerelease:
-        description: 'Is this a pre-release?'
+        description: 'Is this a pre-release?'     
         required: true
+        type: boolean
 
 jobs:
   package:


### PR DESCRIPTION
This is a draft of a workflow that builds sdist and wheel distributions, checks them, and uploads to PyPI using twine. It's based upon workflows in [attrs](https://github.com/python-attrs/attrs/blob/main/.github/workflows/main.yml) and [shapely](https://github.com/shapely/shapely/blob/main/.github/workflows/release.yml). A supporting secret upload token has been added to the GitHub settings. I would like to test it by running it using a one-off pre-release tag. If it succeeds, I would yank the resulting pre-release.