### PR TITLE
upgrade httpx to 0.23, change how quota exceptions are caught

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,14 @@ with open('planet/__version__.py') as f:
 install_requires = [
     'click>=8.0.0',
     'geojson',
-    'httpx==0.16.1',
+    'httpx==0.23.0',
     'jsonschema',
     'pyjwt>=2.1',
     'tqdm>=4.56',
 ]
 
 test_requires = [
-    'pytest', 'pytest-asyncio==0.16', 'pytest-cov', 'respx==0.16.3'
+    'pytest', 'pytest-asyncio==0.16', 'pytest-cov', 'respx==0.19'
 ]
 
 lint_requires = ['flake8', 'mypy', 'yapf']

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,7 @@ install_requires = [
     'tqdm>=4.56',
 ]
 
-test_requires = [
-    'pytest', 'pytest-asyncio==0.16', 'pytest-cov', 'respx==0.19'
-]
+test_requires = ['pytest', 'pytest-asyncio==0.16', 'pytest-cov', 'respx==0.19']
 
 lint_requires = ['flake8', 'mypy', 'yapf']
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -41,11 +41,10 @@ def mock_request():
 def mock_response():
 
     def mocker(code, text='', json={"message": "nope"}):
-        r = Mock()
-        r.status_code = code
-        r.text = text
-        r.json = Mock(return_value=json)
-        return r
+        mock_request = httpx.Request('GET', 'url')
+        return httpx.Response(status_code=code,
+                              json=json,
+                              request=mock_request)
 
     return mocker
 
@@ -62,11 +61,9 @@ def test_basesession__raise_for_status(mock_response):
         http.BaseSession._raise_for_status(
             mock_response(HTTPStatus.TOO_MANY_REQUESTS, text='', json={}))
 
-    with pytest.raises(exceptions.OverQuota):
+    with pytest.raises(exceptions.APIError):
         http.BaseSession._raise_for_status(
-            mock_response(HTTPStatus.TOO_MANY_REQUESTS,
-                          text='exceeded QUOTA"',
-                          json={}))
+            mock_response(HTTPStatus.FORBIDDEN))
 
     with pytest.raises(exceptions.APIError):
         http.BaseSession._raise_for_status(

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -62,8 +62,7 @@ def test_basesession__raise_for_status(mock_response):
             mock_response(HTTPStatus.TOO_MANY_REQUESTS, text='', json={}))
 
     with pytest.raises(exceptions.APIError):
-        http.BaseSession._raise_for_status(
-            mock_response(HTTPStatus.FORBIDDEN))
+        http.BaseSession._raise_for_status(mock_response(HTTPStatus.FORBIDDEN))
 
     with pytest.raises(exceptions.APIError):
         http.BaseSession._raise_for_status(


### PR DESCRIPTION
This work upgrades httpx to 0.23.0, the latest version. It also changes how http error responses are handled and adds more debug logging for http requests and responses.

The APIs do not overload TooManyRequests for overquota instances, instead when overquota is encountered, the server responds with FORBIDDEN. This change brings the SDK in line with the APIs. It also uses httpx to help with identifying errors, simplifying the code.

The new debug logging messages help with identifying the cause of and response from http errors.

Closes #276 and #312.

Reduces the severity of #452.