### PR TITLE
create noxfile session and github action for publishing to testpypi

### DIFF
--- a/.github/workflows/autopublish-testpypi.yml
+++ b/.github/workflows/autopublish-testpypi.yml
@@ -1,0 +1,35 @@
+name: Autopublish to TestPyPi
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: Build, verify, & upload package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+
+      - name: Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+          restore-keys: |
+            ${{ runner.os }}-pip
+
+      - name: Build, verify, and upload to TestPyPI
+        run: |
+          pip install --upgrade nox
+          nox -s build publish
+          env:
+            TWINE_USERNAME: __token__
+            TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
Use nox for all of our build/publish-to-testpypi logic, which allows for testing and performing these steps outside of Github. Use GH Action to trigger the nox build/publish logic when a new tag is created.