### PR TITLE
Fix list numbering in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pull Request (PR) Requirements:
 1. Must include updates to relative documentation in docstrings and `docs` folder. See [Documentation](#documentation) section for information on docstring formatting and building.
 1. Must pass all Continuous Integration (CI) checks. See below for more information on CI checks.
 1. Must have at least one approval by a planet maintainer.
-  * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
+    * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
 1. Should be driven by an issue. Reference the issue in the PR.
 1. Should be as small and focused as possible.
 


### PR DESCRIPTION
Added 2 extra spaces to a nested list item (to create the equivalent of a tab). This fixes the number of the list and the visual appearance of the itemized list.

**Before:**
1. item 1
2. item 2
3. item 3
4. item 4
  - sub-item
1. item 5
2. item 6

**After:**
1. item 1
2. item 2
3. item 3
4. item 4
    - sub-item
5. item 5
6. item 6

FYI: @jreiberkyle 