### PR TITLE
Improve default cli help

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pull Request (PR) Requirements:
 1. Must include updates to relative documentation in docstrings and `docs` folder. See [Documentation](#documentation) section for information on docstring formatting and building.
 1. Must pass all Continuous Integration (CI) checks. See below for more information on CI checks.
 1. Must have at least one approval by a planet maintainer.
-  * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
+    * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
 1. Should be driven by an issue. Reference the issue in the PR.
 1. Should be as small and focused as possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pull Request (PR) Requirements:
 1. Must include updates to relative documentation in docstrings and `docs` folder. See [Documentation](#documentation) section for information on docstring formatting and building.
 1. Must pass all Continuous Integration (CI) checks. See below for more information on CI checks.
 1. Must have at least one approval by a planet maintainer.
-    * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
+  * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
 1. Should be driven by an issue. Reference the issue in the PR.
 1. Should be as small and focused as possible.
 

--- a/planet/cli/cli.py
+++ b/planet/cli/cli.py
@@ -27,20 +27,17 @@ LOGGER = logging.getLogger(__name__)
 
 @click.group()
 @click.pass_context
-@click.option('--verbosity',
-              default="warning",
-              help=("Optional: set verbosity level to warning, info, or debug.\
-                  Defaults to warning."))
 @click.option('--quiet',
               is_flag=True,
               default=False,
               help='Disable ANSI control output.')
 @click.version_option(version=planet.__version__)
+@click.option('--verbosity',
+              default="warning",
+              help=("Optional: set verbosity level to warning, info, or debug.\
+                  Defaults to warning."))
 def main(ctx, verbosity, quiet):
-    """Planet API Client
-    Parameters:
-        ctx -- context object
-        verbosity -- user input for verbosity."""
+    """Planet API Client"""
     _configure_logging(verbosity)
 
     # ensure that ctx.obj exists and is a dict (in case `cli()` is called

--- a/planet/cli/cli.py
+++ b/planet/cli/cli.py
@@ -37,7 +37,7 @@ LOGGER = logging.getLogger(__name__)
               help=("Optional: set verbosity level to warning, info, or debug.\
                   Defaults to warning."))
 def main(ctx, verbosity, quiet):
-    """Planet API Client"""
+    """Planet SDK for Python CLI"""
     _configure_logging(verbosity)
 
     # ensure that ctx.obj exists and is a dict (in case `cli()` is called

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -43,7 +43,7 @@ async def data_client(ctx):
               default=None,
               help='Assign custom base Orders API URL.')
 def data(ctx, base_url):
-    '''Commands for interacting with the Orders API'''
+    '''Commands for interacting with the Data API'''
     ctx.obj['AUTH'] = None
     ctx.obj['BASE_URL'] = base_url
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -13,6 +13,7 @@ from planet.clients.subscriptions import SubscriptionsClient
 @click.group()
 @click.pass_context
 def subscriptions(ctx):
+    '''Commands for interacting with the Subscriptions API'''
     # None means that order of precedence is 1) environment variable,
     # 2) secret file.
     ctx.obj['AUTH'] = None


### PR DESCRIPTION
- Removed text which referred to API parameters in main CLI help message.
- Changed description in Data CLI message to refer to its API, not the Orders API.
- Added description to Subscription CLI help message.
- Moved the verbosity option description below quiet and version, but cannot go below help, as that must always be the last option listed and cannot be moved.

FYI: @cholmes 

Closes #633 