### PR TITLE
Add STAC output orders request

### DIFF
--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -263,6 +263,12 @@ async def create(ctx, request: str, pretty):
     type=types.JSON(),
     help="""Credentials for cloud storage provider to enable cloud delivery of
     data. Can be a json string, filename, or '-' for stdin.""")
+@click.option(
+    '--stac',
+    default=False,
+    is_flag=True,
+    help='Request metadata to be in SpatioTemporal Asset Catalog (STAC) format.'
+)
 @pretty
 async def request(ctx,
                   name,
@@ -273,6 +279,7 @@ async def request(ctx,
                   item_type,
                   email,
                   cloudconfig,
+                  stac,
                   pretty):
     """Generate an order request.
 
@@ -309,6 +316,7 @@ async def request(ctx,
                                                  products=[product],
                                                  delivery=delivery,
                                                  notifications=notifications,
-                                                 tools=tools)
+                                                 tools=tools,
+                                                 stac=stac)
 
     echo_json(request, pretty)

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -264,8 +264,8 @@ async def create(ctx, request: str, pretty):
     help="""Credentials for cloud storage provider to enable cloud delivery of
     data. Can be a json string, filename, or '-' for stdin.""")
 @click.option(
-    '--no-stac',
-    default=False,
+    '--stac/--no-stac',
+    default=True,
     is_flag=True,
     help="""Do not request metadata to be in SpatioTemporal Asset Catalog
     (STAC) format.""")
@@ -279,7 +279,7 @@ async def request(ctx,
                   item_type,
                   email,
                   cloudconfig,
-                  no_stac,
+                  stac,
                   pretty):
     """Generate an order request.
 
@@ -312,10 +312,10 @@ async def request(ctx,
     else:
         delivery = None
 
-    if no_stac:
-        stac_json = {}
-    else:
+    if stac:
         stac_json = {'stac': {}}
+    else:
+        stac_json = {}
 
     request = planet.order_request.build_request(name,
                                                  products=[product],

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -264,11 +264,11 @@ async def create(ctx, request: str, pretty):
     help="""Credentials for cloud storage provider to enable cloud delivery of
     data. Can be a json string, filename, or '-' for stdin.""")
 @click.option(
-    '--stac',
+    '--no-stac',
     default=False,
     is_flag=True,
-    help='Request metadata to be in SpatioTemporal Asset Catalog (STAC) format.'
-)
+    help="""Do not request metadata to be in SpatioTemporal Asset Catalog
+    (STAC) format.""")
 @pretty
 async def request(ctx,
                   name,
@@ -279,7 +279,7 @@ async def request(ctx,
                   item_type,
                   email,
                   cloudconfig,
-                  stac,
+                  no_stac,
                   pretty):
     """Generate an order request.
 
@@ -312,11 +312,16 @@ async def request(ctx,
     else:
         delivery = None
 
+    if no_stac:
+        stac_json = {}
+    else:
+        stac_json = {'stac': {}}
+
     request = planet.order_request.build_request(name,
                                                  products=[product],
                                                  delivery=delivery,
                                                  notifications=notifications,
                                                  tools=tools,
-                                                 stac=stac)
+                                                 stac=stac_json)
 
     echo_json(request, pretty)

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -28,7 +28,8 @@ def build_request(name: str,
                   delivery: dict = None,
                   notifications: dict = None,
                   order_type: str = None,
-                  tools: List[dict] = None) -> dict:
+                  tools: List[dict] = None,
+                  stac: dict = None) -> dict:
     '''Prepare an order request.
 
     ```python
@@ -85,6 +86,9 @@ def build_request(name: str,
 
     if tools:
         details['tools'] = tools
+
+    if stac:
+        details['metadata'] = {'stac': {}}
 
     return details
 

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -88,7 +88,7 @@ def build_request(name: str,
         details['tools'] = tools
 
     if stac:
-        details['metadata'] = {'stac': {}}
+        details['metadata'] = stac
 
     return details
 

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -674,14 +674,15 @@ def test_cli_orders_request_tools(invoke, geom_geojson, stac_json):
 
 
 @respx.mock
-def test_cli_orders_request_stac(invoke, stac_json):
+def test_cli_orders_request_no_stac(invoke):
 
     result = invoke([
         'request',
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
         '--bundle=analytic',
-        '--item-type=PSOrthoTile'
+        '--item-type=PSOrthoTile',
+        '--no-stac'
     ])
 
     order_request = {
@@ -691,8 +692,6 @@ def test_cli_orders_request_stac(invoke, stac_json):
             "item_ids": ["4500474_2133707_2021-05-20_2419"],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic",
-        }],
-        "metadata":
-        stac_json
+        }]
     }
     assert order_request == json.loads(result.output)

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -652,3 +652,31 @@ def test_cli_orders_request_tools(invoke, geom_geojson):
         tools_json
     }
     assert order_request == json.loads(result.output)
+
+
+@respx.mock
+def test_cli_orders_request_stac(invoke):
+
+    stac_json = {'stac': {}}
+
+    result = invoke([
+        'request',
+        '--name=test',
+        '--id=4500474_2133707_2021-05-20_2419',
+        '--bundle=analytic',
+        '--item-type=PSOrthoTile',
+        '--stac'
+    ])
+
+    order_request = {
+        "name":
+        "test",
+        "products": [{
+            "item_ids": ["4500474_2133707_2021-05-20_2419"],
+            "item_type": "PSOrthoTile",
+            "product_bundle": "analytic",
+        }],
+        "metadata":
+        stac_json
+    }
+    assert order_request == json.loads(result.output)

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -52,13 +52,15 @@ def test_build_request():
     }
     order_type = 'partial'
     tool = {'band_math': 'jsonstring'}
+    stac = {'stac': {}}
 
     request = order_request.build_request('test_name', [product],
                                           subscription_id=subscription_id,
                                           delivery=delivery,
                                           notifications=notifications,
                                           order_type=order_type,
-                                          tools=[tool])
+                                          tools=[tool],
+                                          stac=True)
     expected = {
         'name': 'test_name',
         'products': [product],
@@ -66,7 +68,8 @@ def test_build_request():
         'delivery': delivery,
         'notifications': notifications,
         'order_type': order_type,
-        'tools': [tool]
+        'tools': [tool],
+        'metadata': stac
     }
     assert request == expected
 
@@ -77,7 +80,8 @@ def test_build_request():
                                         delivery=delivery,
                                         notifications=notifications,
                                         order_type=order_type,
-                                        tools=[tool])
+                                        tools=[tool],
+                                        stac=True)
 
 
 def test_product():

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -81,7 +81,7 @@ def test_build_request():
                                         notifications=notifications,
                                         order_type=order_type,
                                         tools=[tool],
-                                        stac=False)
+                                        stac=stac_json)
 
 
 def test_product():

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -52,7 +52,7 @@ def test_build_request():
     }
     order_type = 'partial'
     tool = {'band_math': 'jsonstring'}
-    stac = {'stac': {}}
+    stac_json = {'stac': {}}
 
     request = order_request.build_request('test_name', [product],
                                           subscription_id=subscription_id,
@@ -60,7 +60,7 @@ def test_build_request():
                                           notifications=notifications,
                                           order_type=order_type,
                                           tools=[tool],
-                                          stac=True)
+                                          stac=stac_json)
     expected = {
         'name': 'test_name',
         'products': [product],
@@ -69,7 +69,7 @@ def test_build_request():
         'notifications': notifications,
         'order_type': order_type,
         'tools': [tool],
-        'metadata': stac
+        'metadata': stac_json
     }
     assert request == expected
 
@@ -81,7 +81,7 @@ def test_build_request():
                                         notifications=notifications,
                                         order_type=order_type,
                                         tools=[tool],
-                                        stac=True)
+                                        stac=False)
 
 
 def test_product():


### PR DESCRIPTION
As the title reads, I've added STAC output to the Orders CLIs and APIs `request` function.

`planet.cli.orders.py`
- Added `--stac` as a `click.option` as a flag (i.e., boolean)
    - @cholmes, I've set the default to be **_false_**, but I could be convinced that it should be set to true

`planet.orders_request.py`
- Added `stac` as an input to `build_request()`

`tests.integration.test_orders_cli.py`
- Added an integration test for the Orders CLI for a STAC output

`tests.unit.test_orders_request.py`
- Added a unit test for the Orders API (`build_request()`) for a STAC output

Below is an example of the STAC metadata at work:
```
> planet orders request \                          
--name Bangladesh_2018_visual \
--id 20180418_043113_1053,20180418_043112_1053 \
--item-type PSScene \
--bundle visual \
--stac

{"name": "Bangladesh_2018_visual", "products": [{"item_ids": ["20180418_043113_1053", "20180418_043112_1053"], "item_type": "PSScene", "product_bundle": "visual"}], "metadata": {"stac": {}}}
```

**FYI:** @cholmes @sgillies @jreiberkyle @mkshah605 

Closing #597 