### PR TITLE
Compatible bundle with item type error

### DIFF
--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -113,8 +113,8 @@ def product(item_ids: List[str],
             are not valid bundles or if item_type is not valid for the given
             bundle or fallback bundle.
     '''
-    item_type = specs.validate_item_type(item_type, product_bundle)
     validated_product_bundle = specs.validate_bundle(product_bundle)
+    item_type = specs.validate_item_type(item_type, validated_product_bundle)
 
     if fallback_bundle is not None:
         validated_fallback_bundle = specs.validate_bundle(fallback_bundle)

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -113,8 +113,8 @@ def product(item_ids: List[str],
             are not valid bundles or if item_type is not valid for the given
             bundle or fallback bundle.
     '''
+    item_type = specs.validate_item_type(item_type, product_bundle)
     validated_product_bundle = specs.validate_bundle(product_bundle)
-    item_type = specs.validate_item_type(item_type, validated_product_bundle)
 
     if fallback_bundle is not None:
         validated_fallback_bundle = specs.validate_bundle(fallback_bundle)

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -37,9 +37,22 @@ SUPPORTED_FILE_FORMATS = ['COG', 'PL_NITF']
 LOGGER = logging.getLogger(__name__)
 
 
-class SpecificationException(Exception):
+class NoMatchException(Exception):
     '''No match was found'''
     pass
+
+
+class SpecificationException(Exception):
+    '''No match was found'''
+
+    def __init__(self, value, supported, field_name):
+        self.value = value
+        self.supported = supported
+        self.field_name = field_name
+        self.opts = ', '.join(["'" + s + "'" for s in supported])
+
+    def __str__(self):
+        return f'{self.field_name} - \'{self.value}\' is not one of {self.opts}.'
 
 
 def validate_bundle(bundle):
@@ -48,7 +61,8 @@ def validate_bundle(bundle):
 
 
 def validate_item_type(item_type, bundle):
-    supported = get_item_types(bundle)
+    validated_bundle = validate_bundle(bundle)
+    supported = get_item_types(validated_bundle)
     return _validate_field(item_type, supported, 'item_type')
 
 
@@ -72,20 +86,13 @@ def validate_file_format(file_format):
 
 def _validate_field(value, supported, field_name):
     try:
-        value = get_match(value, supported)
+        value = get_match(value, supported, field_name)
     except (NoMatchException):
-        opts = ', '.join(["'" + s + "'" for s in supported])
-        msg = f'{field_name} - \'{value}\' is not one of {opts}.'
-        raise SpecificationException(msg)
+        raise SpecificationException(value, supported, field_name)
     return value
 
 
-class NoMatchException(Exception):
-    '''No match was found'''
-    pass
-
-
-def get_match(test_entry, spec_entries):
+def get_match(test_entry, spec_entries, field_name):
     '''Find and return matching spec entry regardless of capitalization.
 
     This is helpful for working with the API spec, where the capitalization
@@ -95,7 +102,7 @@ def get_match(test_entry, spec_entries):
         match = next(e for e in spec_entries
                      if e.lower() == test_entry.lower())
     except (StopIteration):
-        raise NoMatchException('{test_entry} should be one of {spec_entries}')
+        raise SpecificationException(test_entry, spec_entries, field_name)
 
     return match
 
@@ -111,16 +118,13 @@ def get_item_types(product_bundle=None):
     API. Otherwise, get all item types supported by Orders API.'''
     spec = _get_product_bundle_spec()
 
-    try:
-        if product_bundle:
-            item_types = set(spec['bundles'][product_bundle]['assets'].keys())
-        else:
-            item_types = set(
-                itertools.chain.from_iterable(
-                    spec['bundles'][bundle]['assets'].keys()
-                    for bundle in get_product_bundles()))
-    except KeyError:
-        raise validate_bundle(product_bundle)
+    if product_bundle:
+        item_types = set(spec['bundles'][product_bundle]['assets'].keys())
+    else:
+        item_types = set(
+            itertools.chain.from_iterable(
+                spec['bundles'][bundle]['assets'].keys()
+                for bundle in get_product_bundles()))
 
     return item_types
 

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -48,8 +48,8 @@ def validate_bundle(bundle):
 
 
 def validate_item_type(item_type, bundle):
-    bundle = validate_bundle(bundle)
     supported = get_item_types(bundle)
+    bundle = validate_bundle(bundle)
     return _validate_field(item_type, supported, 'item_type')
 
 
@@ -111,15 +111,18 @@ def get_item_types(product_bundle=None):
     '''If given product bundle, get specific item types supported by Orders
     API. Otherwise, get all item types supported by Orders API.'''
     spec = _get_product_bundle_spec()
-    if product_bundle:
-        item_types = spec['bundles'][product_bundle]['assets'].keys()
-    else:
-        product_bundle = get_product_bundles()
-        all_item_types = []
-        for bundle in product_bundle:
-            all_item_types += [*spec['bundles'][bundle]['assets'].keys()]
-        item_types = set(all_item_types)
-    return item_types
+    try:
+        if product_bundle:
+            item_types = spec['bundles'][product_bundle]['assets'].keys()
+        else:
+            product_bundle = get_product_bundles()
+            all_item_types = []
+            for bundle in product_bundle:
+                all_item_types += [*spec['bundles'][bundle]['assets'].keys()]
+            item_types = set(all_item_types)
+        return item_types
+    except KeyError:
+        raise SpecificationException()
 
 
 def _get_product_bundle_spec():

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -46,10 +46,11 @@ def test_get_type_match():
     spec_list = ['Locket', 'drop', 'DEER']
 
     test_entry = 'locket'
-    assert 'Locket' == specs.get_match(test_entry, spec_list)
+    field_name = 'field_name'
+    assert 'Locket' == specs.get_match(test_entry, spec_list, field_name)
 
-    with pytest.raises(specs.NoMatchException):
-        specs.get_match('a', ['b'])
+    with pytest.raises(specs.SpecificationException):
+        specs.get_match('a', ['b'], field_name)
 
 
 def test_validate_bundle_supported():


### PR DESCRIPTION
Validating `item_type` before `bundle`, so that the item type compatibility exception will propagate before the bundle validation exception.

Closes #618 