### PR TITLE
Enable redirect following and avoid treating 302s as errors

### DIFF
--- a/planet/http.py
+++ b/planet/http.py
@@ -97,7 +97,6 @@ class BaseSession:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:
-                import pdb; pdb.set_trace()
                 e.response.read()
                 cls._convert_and_raise(e)
 
@@ -243,7 +242,9 @@ class Session(BaseSession):
 
         LOGGER.info(f'Session read timeout set to {READ_TIMEOUT}.')
         timeout = httpx.Timeout(10.0, read=READ_TIMEOUT)
-        self._client = httpx.AsyncClient(auth=auth, timeout=timeout, follow_redirects=True)
+        self._client = httpx.AsyncClient(auth=auth,
+                                         timeout=timeout,
+                                         follow_redirects=True)
 
         self._client.headers.update({'User-Agent': self._get_user_agent()})
         self._client.headers.update({'X-Planet-App': 'python-sdk'})
@@ -271,7 +272,6 @@ class Session(BaseSession):
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:
-                import pdb; pdb.set_trace()
                 await e.response.aread()
                 cls._convert_and_raise(e)
 

--- a/planet/http.py
+++ b/planet/http.py
@@ -93,11 +93,13 @@ class BaseSession:
 
     @classmethod
     def _raise_for_status(cls, response):
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            e.response.read()
-            cls._convert_and_raise(e)
+        if response.status_code >= 400:
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                import pdb; pdb.set_trace()
+                e.response.read()
+                cls._convert_and_raise(e)
 
         return
 
@@ -241,7 +243,7 @@ class Session(BaseSession):
 
         LOGGER.info(f'Session read timeout set to {READ_TIMEOUT}.')
         timeout = httpx.Timeout(10.0, read=READ_TIMEOUT)
-        self._client = httpx.AsyncClient(auth=auth, timeout=timeout)
+        self._client = httpx.AsyncClient(auth=auth, timeout=timeout, follow_redirects=True)
 
         self._client.headers.update({'User-Agent': self._get_user_agent()})
         self._client.headers.update({'X-Planet-App': 'python-sdk'})
@@ -265,11 +267,13 @@ class Session(BaseSession):
 
     @classmethod
     async def _raise_for_status(cls, response):
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            await e.response.aread()
-            cls._convert_and_raise(e)
+        if response.status_code >= 400:
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                import pdb; pdb.set_trace()
+                await e.response.aread()
+                cls._convert_and_raise(e)
 
         return
 

--- a/planet/http.py
+++ b/planet/http.py
@@ -93,7 +93,7 @@ class BaseSession:
 
     @classmethod
     def _raise_for_status(cls, response):
-        if response.status_code >= 400:
+        if response.is_error:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:
@@ -268,7 +268,7 @@ class Session(BaseSession):
 
     @classmethod
     async def _raise_for_status(cls, response):
-        if response.status_code >= 400:
+        if response.is_error:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:


### PR DESCRIPTION
Towards resolving #678.

Without these changes, an attempt to download an order with 0.23 produces

```
Error:
```

With these changes, I'm able to download an order.