### PR TITLE
Get auth info as early as possible, store in context, use that

### DIFF
--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -17,6 +17,7 @@ import logging
 import click
 
 import planet
+from planet.exceptions import AuthException
 from .cmds import translate_exceptions
 
 LOGGER = logging.getLogger(__name__)
@@ -53,7 +54,11 @@ def init(ctx, email, password):
 
 
 @auth.command()
+@click.pass_context
 @translate_exceptions
-def value():
+def value(ctx):
     '''Print the stored authentication information'''
-    click.echo(planet.Auth.from_file().value)
+    try:
+        click.echo(ctx.obj['AUTH'].value)
+    except (AttributeError, KeyError):
+        raise AuthException('Command context lacks auth information.')

--- a/planet/cli/cli.py
+++ b/planet/cli/cli.py
@@ -19,6 +19,8 @@ import sys
 import click
 
 import planet
+from planet.auth import Auth
+from planet.exceptions import PlanetError
 
 from . import auth, collect, data, orders, subscriptions
 
@@ -44,6 +46,20 @@ def main(ctx, verbosity, quiet):
     # by means other than the `if` block below)
     ctx.ensure_object(dict)
     ctx.obj['QUIET'] = quiet
+
+    # Check authentication sources and store the highest priority in ctx.
+    # 1. Environment.
+    try:
+        auth_env = Auth.from_env()
+    except PlanetError:
+        auth_env = None
+    # 2. Secret file.
+    try:
+        auth_file = Auth.from_file()
+    except PlanetError:
+        auth_file = None
+
+    ctx.obj['AUTH'] = auth_env or auth_file
 
 
 def _configure_logging(verbosity):

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -48,7 +48,6 @@ async def data_client(ctx):
               help='Assign custom base Orders API URL.')
 def data(ctx, base_url):
     '''Commands for interacting with the Data API'''
-    ctx.obj['AUTH'] = None
     ctx.obj['BASE_URL'] = base_url
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -46,7 +46,6 @@ async def orders_client(ctx):
               help='Assign custom base Orders API URL.')
 def orders(ctx, base_url):
     '''Commands for interacting with the Orders API'''
-    ctx.obj['AUTH'] = None
     ctx.obj['BASE_URL'] = base_url
 
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -14,9 +14,6 @@ from planet.clients.subscriptions import SubscriptionsClient
 @click.pass_context
 def subscriptions(ctx):
     '''Commands for interacting with the Subscriptions API'''
-    # None means that order of precedence is 1) environment variable,
-    # 2) secret file.
-    ctx.obj['AUTH'] = None
 
 
 # We want our command to be known as "list" on the command line but


### PR DESCRIPTION
A possible solution for one of the issues reported in #643.

In a nutshell, the root planet command is now responsible for finding auth info and `planet auth value` reports on the active auth, whatever the source.