### PR TITLE
Validated item type with specs module

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -21,7 +21,7 @@ from planet import data_filter, DataClient
 from planet.clients.data import (SEARCH_SORT,
                                  SEARCH_SORT_DEFAULT,
                                  STATS_INTERVAL)
-from planet.specs import get_item_types, SpecificationException
+from planet.specs import get_item_types, validate_item_type
 
 from . import types
 from .cmds import coro, translate_exceptions
@@ -65,15 +65,9 @@ def assets_to_filter(ctx, param, assets: List[str]) -> Optional[dict]:
 
 
 def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
-    # Set difference between given item types and all item types
-    invalid_item_types = set([item.lower() for item in item_types]) - set(
-        [a.lower() for a in ALL_ITEM_TYPES])
-    if invalid_item_types:
-        raise SpecificationException(invalid_item_types,
-                                     ALL_ITEM_TYPES,
-                                     'item_type')
-    else:
-        return item_types
+    for item_type in item_types:
+        validate_item_type(item_type)
+    return item_types
 
 
 def date_range_to_filter(ctx, param, values) -> Optional[List[dict]]:

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -67,6 +67,8 @@ def assets_to_filter(ctx, param, assets: List[str]) -> Optional[dict]:
 
 
 def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
+    '''Validates the item type by comparing the inputted item type to all
+    supported item types.'''
     try:
         for item_type in item_types:
             validate_item_type(item_type)

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -21,7 +21,9 @@ from planet import data_filter, DataClient
 from planet.clients.data import (SEARCH_SORT,
                                  SEARCH_SORT_DEFAULT,
                                  STATS_INTERVAL)
-from planet.specs import get_item_types, validate_item_type
+from planet.specs import (get_item_types,
+                          validate_item_type,
+                          SpecificationException)
 
 from . import types
 from .cmds import coro, translate_exceptions
@@ -65,9 +67,12 @@ def assets_to_filter(ctx, param, assets: List[str]) -> Optional[dict]:
 
 
 def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
-    for item_type in item_types:
-        validate_item_type(item_type)
-    return item_types
+    try:
+        for item_type in item_types:
+            validate_item_type(item_type)
+        return item_types
+    except SpecificationException as e:
+        raise click.BadParameter(e)
 
 
 def date_range_to_filter(ctx, param, values) -> Optional[List[dict]]:

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -490,8 +490,9 @@ def test_cli_orders_request_item_type_invalid(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
-    assert "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE" in result.output
+    assert error_msg in result.output
 
 
 def test_cli_orders_request_product_bundle_invalid(invoke):
@@ -502,8 +503,9 @@ def test_cli_orders_request_product_bundle_invalid(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
-    assert "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE" in result.output
+    assert error_msg in result.output
 
 
 def test_cli_orders_request_product_bundle_incompatible(invoke):
@@ -514,8 +516,9 @@ def test_cli_orders_request_product_bundle_incompatible(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
-    assert "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE" in result.output
+    assert error_msg in result.output
 
 
 def test_cli_orders_request_id_empty(invoke):

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -490,8 +490,8 @@ def test_cli_orders_request_item_type_invalid(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
-    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert error_msg in result.output
 
 
@@ -503,8 +503,8 @@ def test_cli_orders_request_product_bundle_invalid(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
-    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert error_msg in result.output
 
 
@@ -516,8 +516,8 @@ def test_cli_orders_request_product_bundle_incompatible(invoke):
         '--name=test',
         '--id=4500474_2133707_2021-05-20_2419',
     ])
-    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert result.exit_code == 2
+    error_msg = "Usage: main orders request [OPTIONS] ITEM_TYPE BUNDLE"
     assert error_msg in result.output
 
 

--- a/tests/unit/test_data_callbacks.py
+++ b/tests/unit/test_data_callbacks.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import pytest
-from planet.specs import SpecificationException
+import click
 from planet.cli.data import check_item_types
 
 LOGGER = logging.getLogger(__name__)
@@ -51,5 +51,5 @@ def test_item_type_success(item_types):
 
 def test_item_type_fail():
     ctx = MockContext()
-    with pytest.raises(SpecificationException):
+    with pytest.raises(click.BadParameter):
         check_item_types(ctx, 'item_type', "bad_item_type")


### PR DESCRIPTION
Addresses @jreiberkyle's two comments ([comment 1](https://github.com/planetlabs/planet-client-python/pull/695/files/4935b11afab9a5c731831f6930d5bcc2ab5783fd#r977967575), [comment 2](https://github.com/planetlabs/planet-client-python/pull/695/files/4935b11afab9a5c731831f6930d5bcc2ab5783fd#r977970613)).

Fixed a linting issue pulled in from main. 

**Previous behaviour:**
```
Error: Invalid value for 'ITEM_TYPES': ['boo'] should be one of {'PSScene', 'MOD09GA', 'MYD09GA', 'MYD09GQ', 'SkySatCollect', 'REOrthoTile', 'REScene', 'MOD09GQ', 'PSScene4Band', 'Sentinel1', 'Sentinel2L1C', 'SkySatScene', 'Landsat8L1G', 'PSOrthoTile', 'PSScene3Band'}
```

**New behaviour:**
```
Usage: planet data search [OPTIONS] ITEM_TYPES [FILTER]
Try 'planet data search --help' for help.

Error: Invalid value for 'ITEM_TYPES': item_type - 'boo' is not one of 'Landsat8L1G', 'SkySatScene', 'REOrthoTile', 'PSScene', 'PSOrthoTile', 'REScene', 'SkySatCollect', 'PSScene4Band', 'Sentinel1', 'MOD09GQ', 'MOD09GA', 'MYD09GA', 'MYD09GQ', 'PSScene3Band', 'Sentinel2L1C'.
```

Closes #690 