### PR TITLE
Add bug, feature, and templates as well as link to planet community for questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,12 +7,19 @@ assignees: ''
 
 ---
 
-**Related Issues**
+**Expected behavior**
+A clear and concise description of what you expected to happen.
 
+**Actual behavior (describe the problem)**
+Why the current behavior is a problem and why the expected behavior is a better solution.
+
+**Related Issues**
 Please list the ticket numbers (e.g. #708) for any issues already logged in the system.
 
-**Minimum, Complete, Viable Code Sample**
+**Workaround**
+Any ways you have found to work around the problem and accomplish your task.
 
+**Minimum, Complete, Viable Code Sample**
 A "Minimal, Complete and Verifiable Example" will make it much easier for maintainers to help you.
 See http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
 
@@ -23,13 +30,6 @@ or
 ```console
 > command-line-call
 ```
-
-**Problem description**
-
-Why the current behavior is a problem and why the expected behavior is a better solution.
-
-**Expected behavior**
-A clear and concise description of what you expected to happen.
 
 **Environment Information**
 * Operation System Information (`python -c "import platform; print(platform.platform())"`)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Related Issues**
+
+Please list the ticket numbers (e.g. #708) for any issues already logged in the system.
+
+**Minimum, Complete, Viable Code Sample**
+
+A "Minimal, Complete and Verifiable Example" will make it much easier for maintainers to help you.
+See http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+
+```python
+# Your python code here
+```
+or
+```console
+> command-line-call
+```
+
+**Problem description**
+
+Why the current behavior is a problem and why the expected behavior is a better solution.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment Information**
+* Operation System Information (`python -c "import platform; print(platform.platform())"`)
+* Python version (`python -c "import sys; print(sys.version.replace('\n', ' '))"`)
+* Planet package version (`planet -v`)
+
+**Installation Method**
+* conda, pip wheel, from source, etc...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask a question
+    url: https://community.planet.com/planet-s-community-forum-3
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: proposal
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+**Related Issue(s):** #
+
+
+**Proposed Changes:**
+
+1. 
+2. 
+
+**Diff of User Interface**
+
+Old behavior:
+New behavior:
+
+**PR Checklist:**
+
+- [ ] This PR is as small and focused as possible
+- [ ] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or indicated a Changelog entry is not required
+- [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
+- [ ] This PR does not break any examples or I have updated them

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-**Related Issue(s):** #
+**Related Issue(s):**
+
+#
 
 
 **Proposed Changes:**
@@ -9,11 +11,17 @@
 **Diff of User Interface**
 
 Old behavior:
+
 New behavior:
+
+
+
 
 **PR Checklist:**
 
 - [ ] This PR is as small and focused as possible
-- [ ] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or indicated a Changelog entry is not required
+- [ ] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or I have determined a Changelog entry is not required
 - [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
 - [ ] This PR does not break any examples or I have updated them
+
+**(Optional) @mentions for Notifications:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,6 @@ document explains how to contribute successfully.
 
 ## Workflows
 
-### Reporting Bugs
-
-To report a bug, open a new issue with the 'bug' label.
-
-In the issue, provide the following:
-1. Code snippet reproducing the behavior, reduced to the simplest possible case
-1. Operating System and Python version
-1. Installed dependencies / versions
-1. Error traceback
-
 ### Development
 
 #### Development Branch
@@ -37,16 +27,9 @@ For example: `release-contributing-691` for [ticket 691](https://github.com/plan
 
 ### Pull Requests
 
-Pull Request (PR) Requirements:
+The Pull Request requirements are included in the pull request template as a list of checkboxes.
 
-1. Must have a descriptive title. This populates the release changelog.
-1. Must provide a summary of changes and examples of usage input / output in the case of user-interface changes.
-1. Must include updates to relative documentation in docstrings and `docs` folder. See [Documentation](#documentation) section for information on docstring formatting and building.
-1. Must pass all Continuous Integration (CI) checks. See below for more information on CI checks.
-1. Must have at least one approval by a planet maintainer.
-  * For Planet team, **FYI** can be used to specify cases when all that is needed is indication that changes have been noted.
-1. Should be driven by an issue. Reference the issue in the PR.
-1. Should be as small and focused as possible.
+Not listed in the PR template, but enforced by the system, are the additional requirements that the PR pass Continuous Integration (CI) checks and that the PR have at least one approval by a project maintainer.
 
 The CI checks:
 


### PR DESCRIPTION
1. Instead of being met with a blank issue when creating issues, contributors will be met with the options: Bug Report, Feature Request, and Ask A Question. Bug Report and Feature Request will be forms for creating issues with labels bug/proposal, respectively. Ask A Question is a link to planet community.
2. When a PR is initiated, instead of being met with a blank page, contributors will be met with a form to be filled out and checklist to confirm.

Closes #730 