### PR TITLE
reorganize CI steps to match nox order and add typing analysis to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,50 @@ name: test
 on: [pull_request]
 
 jobs:
+  lint:
+    name: Check Linting
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
+        restore-keys: |
+          ${{ runner.os }}-pip
+    - name: Lint
+      run: |
+        pip install --upgrade nox
+        nox -s lint
+
+  analyze:
+    name: Analyze Typing 
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
+        restore-keys: |
+          ${{ runner.os }}-pip
+    - name: Lint
+      run: |
+        pip install --upgrade nox
+        nox -s analyze
+
   test:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
@@ -30,8 +74,8 @@ jobs:
         pip install --upgrade nox
         nox -s test-${{ matrix.python-version }}
 
-  lint:
-    name: Check Linting
+  coverage:
+    name: Check code coverage
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -47,10 +91,10 @@ jobs:
         key: ${{ runner.os }}-pip
         restore-keys: |
           ${{ runner.os }}-pip
-    - name: Lint
+    - name: Coverage run and report
       run: |
         pip install --upgrade nox
-        nox -s lint
+        nox -s coverage
 
   docs:
     name: Check Docs build
@@ -74,25 +118,4 @@ jobs:
         pip install --upgrade nox
         nox -s docs
 
-  coverage:
-    name: Check code coverage
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Pip cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip
-        restore-keys: |
-          ${{ runner.os }}-pip
-    - name: Coverage run and report
-      run: |
-        pip install --upgrade nox
-        nox -s coverage
 


### PR DESCRIPTION
Adds typing analysis (in nox already) to CI tests. Also reorganizes the tests to match nox's order (thought this may not matter much due to GH running tests in parallel). This will avoid issues like #733.

FYI @sgillies @kevinlacaille @mkshah605 

