### PR TITLE
Add identification headers to SDK communication with servers

### DIFF
--- a/planet/auth.py
+++ b/planet/auth.py
@@ -24,7 +24,7 @@ import typing
 import httpx
 import jwt
 
-from . import http, models
+from . import http
 from .constants import PLANET_BASE_URL, SECRET_FILE_PATH
 from .exceptions import AuthException
 
@@ -174,10 +174,8 @@ class AuthClient:
         data = {'email': email, 'password': password}
 
         sess = http.AuthSession()
-        req = models.Request(url, method='POST', json=data)
-        resp = sess.request(req)
-        auth_data = self.decode_response(resp)
-        return auth_data
+        resp = sess.request(url=url, method='POST', json=data)
+        return self.decode_response(resp)
 
     @staticmethod
     def decode_response(response):

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -22,7 +22,7 @@ import typing
 from .. import exceptions
 from ..constants import PLANET_BASE_URL
 from ..http import Session
-from ..models import Paged, Request, Response, StreamingBody
+from ..models import Paged, StreamingBody
 
 BASE_URL = f'{PLANET_BASE_URL}/data/v1/'
 SEARCHES_PATH = '/searches'
@@ -92,17 +92,6 @@ class DataClient:
 
     def _item_url(self, item_type, item_id):
         return f'{self._base_url}/item-types/{item_type}/items/{item_id}'
-
-    def _request(self, url, method, data=None, params=None, json=None):
-        return Request(url, method=method, data=data, params=params, json=json)
-
-    async def _do_request(self, request: Request) -> Response:
-        """Submit a request and get response.
-
-        Parameters:
-            request: request to submit
-        """
-        return await self._session.request(request)
 
     async def search(self,
                      item_types: typing.List[str],
@@ -185,11 +174,11 @@ class DataClient:
                     f'{sort} must be one of {SEARCH_SORT}')
             params['_sort'] = sort
 
-        request = self._request(url,
-                                method='POST',
-                                json=request_json,
-                                params=params)
-        return Items(request, self._do_request, limit=limit)
+        response = await self._session.request(method='POST',
+                                               url=url,
+                                               json=request_json,
+                                               params=params)
+        return Items(response, self._session.request, limit=limit)
 
     async def create_search(self,
                             name: str,
@@ -229,15 +218,16 @@ class DataClient:
         url = self._searches_url()
 
         # TODO: validate item_types
-        request_json = {
+        request = {
             'name': name,
             'filter': search_filter,
             'item_types': item_types,
             '__daily_email_enabled': enable_email
         }
 
-        request = self._request(url, method='POST', json=request_json)
-        response = await self._do_request(request)
+        response = await self._session.request(method='POST',
+                                               url=url,
+                                               json=request)
         return response.json()
 
     async def update_search(self,
@@ -260,15 +250,16 @@ class DataClient:
         """
         url = f'{self._searches_url()}/{search_id}'
 
-        request_json = {
+        request = {
             'name': name,
             'filter': search_filter,
             'item_types': item_types,
             '__daily_email_enabled': enable_email
         }
 
-        request = self._request(url, method='PUT', json=request_json)
-        response = await self._do_request(request)
+        response = await self._session.request(method='PUT',
+                                               url=url,
+                                               json=request)
         return response.json()
 
     async def list_searches(self,
@@ -307,8 +298,9 @@ class DataClient:
                 f'{search_type} must be one of {LIST_SEARCH_TYPE}')
 
         url = f'{self._searches_url()}'
-        request = self._request(url, method='GET')
-        return Searches(request, self._do_request, limit=limit)
+
+        response = await self._session.request(method='GET', url=url)
+        return Searches(response, self._session.request, limit=limit)
 
     async def delete_search(self, search_id: str):
         """Delete an existing saved search.
@@ -321,8 +313,7 @@ class DataClient:
         """
         url = f'{self._searches_url()}/{search_id}'
 
-        request = self._request(url, method='DELETE')
-        await self._do_request(request)
+        await self._session.request(method='DELETE', url=url)
 
     async def get_search(self, search_id: str) -> dict:
         """Get a saved search by id.
@@ -337,9 +328,9 @@ class DataClient:
             planet.exceptions.APIError: On API error.
         """
         url = f'{self._searches_url()}/{search_id}'
-        req = self._request(url, method='GET')
-        resp = await self._do_request(req)
-        return resp.json()
+
+        response = await self._session.request(method='GET', url=url)
+        return response.json()
 
     async def run_search(self,
                          search_id: str,
@@ -359,8 +350,8 @@ class DataClient:
         """
         url = f'{self._searches_url()}/{search_id}/results'
 
-        request = self._request(url, method='GET')
-        return Items(request, self._do_request, limit=limit)
+        response = await self._session.request(method='GET', url=url)
+        return Items(response, self._session.request, limit=limit)
 
     async def get_stats(self,
                         item_types: typing.List[str],
@@ -388,14 +379,15 @@ class DataClient:
 
         url = f'{self._base_url}{STATS_PATH}'
 
-        request_json = {
+        request = {
             'interval': interval,
             'filter': search_filter,
             'item_types': item_types
         }
 
-        request = self._request(url, method='POST', json=request_json)
-        response = await self._do_request(request)
+        response = await self._session.request(method='POST',
+                                               url=url,
+                                               json=request)
         return response.json()
 
     async def list_asset_types(self) -> typing.List[dict]:
@@ -501,8 +493,8 @@ class DataClient:
             planet.exceptions.APIError: On API error.
         """
         url = f'{self._item_url(item_type_id, item_id)}/assets'
-        request = self._request(url, method='GET')
-        response = await self._do_request(request)
+
+        response = await self._session.request(method='GET', url=url)
         return response.json()
 
     async def get_asset(self,
@@ -559,9 +551,8 @@ class DataClient:
 
         # lets not try to activate an asset already activating or active
         if status == 'inactive':
-            request = self._request(url, method='GET')
             # no response is returned
-            await self._do_request(request)
+            await self._session.request(method='GET', url=url)
 
         return
 
@@ -622,8 +613,7 @@ class DataClient:
                 raise exceptions.ClientError(
                     'asset missing ["_links"]["_self"] entry.')
 
-            request = self._request(asset_url, method='GET')
-            response = await self._do_request(request)
+            response = await self._session.request(method='GET', url=asset_url)
             asset = response.json()
 
         if max_attempts and num_attempts >= max_attempts:
@@ -668,9 +658,7 @@ class DataClient:
             raise exceptions.ClientError(
                 'asset missing ["location"] entry. Is asset active?')
 
-        req = self._request(location, method='GET')
-
-        async with self._session.stream(req) as resp:
+        async with self._session.stream(method='GET', url=location) as resp:
             body = StreamingBody(resp)
             dl_path = Path(directory, filename or body.name)
             dl_path.parent.mkdir(exist_ok=True, parents=True)

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -145,7 +145,9 @@ class OrdersClient:
             planet.exceptions.APIError: On API error.
         '''
         url = self._orders_url()
-        response = await self._session.request(method='POST', url=url)
+        response = await self._session.request(method='POST',
+                                               url=url,
+                                               json=request)
         return response.json()
 
     async def get_order(self, order_id: str) -> dict:

--- a/planet/models.py
+++ b/planet/models.py
@@ -56,12 +56,12 @@ class Response:
 class StreamingResponse(Response):
 
     @property
-    def headers(self) -> list:
+    def headers(self) -> httpx.Headers:
         return self._http_response.headers
 
     @property
     def url(self) -> str:
-        return self._http_response.url
+        return str(self._http_response.url)
 
     @property
     def num_bytes_downloaded(self) -> int:
@@ -78,7 +78,7 @@ class StreamingResponse(Response):
 class StreamingBody:
     """A representation of a streaming resource from the API."""
 
-    def __init__(self, response: httpx.Response):
+    def __init__(self, response: StreamingResponse):
         """Initialize the object.
 
         Parameters:
@@ -104,12 +104,6 @@ class StreamingBody:
     def size(self) -> int:
         """The size of the body."""
         return int(self._response.headers['Content-Length'])
-
-    #
-    # @property
-    # def num_bytes_downloaded(self) -> int:
-    #     """The number of bytes downloaded."""
-    #     return self._response.num_bytes_downloaded
 
     async def write(self,
                     filename: Path,
@@ -215,7 +209,7 @@ class Paged:
 
     def __init__(self,
                  response: Response,
-                 request_fcn: Callable[[str, str], Response],
+                 request_fcn: Callable,
                  limit: int = 0):
         """
         Parameters:

--- a/planet/models.py
+++ b/planet/models.py
@@ -29,10 +29,6 @@ from .exceptions import PagingError
 LOGGER = logging.getLogger(__name__)
 
 
-class Request:
-    pass
-
-
 class Response:
     """Handles the Planet server's response to a HTTP request."""
 

--- a/planet/models.py
+++ b/planet/models.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Manage data for requests and responses."""
-from datetime import datetime
 import logging
 import mimetypes
 from pathlib import Path
@@ -30,156 +29,96 @@ from .exceptions import PagingError
 LOGGER = logging.getLogger(__name__)
 
 
-class RequestException(Exception):
-    """Exceptions thrown by RequestException"""
+class Request:
     pass
 
 
-class Request:
-    '''Handles a HTTP request for the Planet server.
-
-    :param url: URL of API endpoint
-    :type url: str
-    :param params: Values to send in the query string. Defaults to None.
-    :type params: dict, list of tuples, or bytes, optional
-    :param data: Object to send in the body. Defaults to None.
-    :type data: dict, list of tuples, bytes, or file-like object, optional
-    :param json: JSON to send. Defaults to None.
-    :type json: dict, optional
-    :param method: HTTP request method. Defaults to 'GET'
-    :type method: str, optional
-    :raises RequestException: When provided `body_type` is not a subclass of
-        :py:class:`planet.api.models.Body`
-    '''
-
-    def __init__(self, url, params=None, data=None, json=None, method='GET'):
-        if data or json:
-            headers = {'Content-Type': 'application/json'}
-        else:
-            headers = None
-
-        self.http_request = httpx.Request(method,
-                                          url,
-                                          params=params,
-                                          data=data,
-                                          json=json,
-                                          headers=headers)
-
-    @property
-    def url(self):
-        return self.http_request.url
-
-    @url.setter
-    def url(self, url):
-        '''Set the url.
-
-        :param url: URL of API endpoint
-        :type url: str
-        '''
-        self.http_request.url = httpx.URL(url)
-
-
 class Response:
-    '''Handles the Planet server's response to a HTTP request.
+    """Handles the Planet server's response to a HTTP request."""
 
-    :param request: Request that was submitted to the server
-    :type request: :py:Class:`Request`
-    :param http_response: Response that was received from the server
-    :type http_response: :py:Class:`requests.models.Response`
-    '''
+    def __init__(self, http_response: httpx.Response):
+        """Initialize object.
 
-    def __init__(self, request, http_response):
-        self.request = request
-        self.http_response = http_response
+        Parameters:
+            http_response: Response that was received from the server.
+        """
+        self._http_response = http_response
 
     def __repr__(self):
         return f'<models.Response [{self.status_code}]>'
 
     @property
-    def status_code(self):
-        '''HTTP status code.
+    def status_code(self) -> int:
+        """HTTP status code"""
+        return self._http_response.status_code
 
-        :returns: status code
-        :rtype: int
-        '''
-        return self.http_response.status_code
+    def json(self) -> dict:
+        """Response json"""
+        return self._http_response.json()
 
-    def json(self):
-        '''Get response json.
 
-        :returns:response json
-        :rtype: dict
-        '''
-        return self.http_response.json()
+class StreamingResponse(Response):
+    @property
+    def headers(self) -> list:
+        return self._http_response.headers
+
+    @property
+    def url(self) -> str:
+        return self._http_response.url
+
+    @property
+    def num_bytes_downloaded(self) -> int:
+        return self._http_response.num_bytes_downloaded
+
+    async def aiter_bytes(self):
+        async for c in self._http_response.aiter_bytes():
+            yield c
 
     async def aclose(self):
-        await self.http_response.aclose()
+        await self._http_response.aclose()
 
 
 class StreamingBody:
-    '''A representation of a streaming resource from the API.
+    """A representation of a streaming resource from the API."""
 
-    :param response: Response that was received from the server
-    :type response: :py:Class:`requests.models.Response`
-        '''
+    def __init__(self, response: httpx.Response):
+        """Initialize the object.
 
-    def __init__(self, response):
-        self.response = response.http_response
-        self.url = response.request.url
+        Parameters:
+            response: Response that was received from the server.
+        """
+        self._response = response
 
     @property
-    def name(self):
-        '''The name of this resource.
+    def name(self) -> str:
+        """The name of this resource.
+
         The default is to use the content-disposition header value from the
         response. If not found, falls back to resolving the name from the url
         or generating a random name with the type from the response.
-
-        :returns: name of this resource
-        :rtype: str
-        '''
-        name = (_get_filename_from_headers(self.response.headers)
-                or _get_filename_from_url(self.url) or _get_random_filename(
-                    self.response.headers.get('content-type')))
+        """
+        name = (_get_filename_from_headers(self._response.headers)
+                or _get_filename_from_url(self._response.url)
+                or _get_random_filename(
+                    self._response.headers.get('content-type')))
         return name
 
     @property
-    def size(self):
-        '''The size of the body.
+    def size(self) -> int:
+        """The size of the body."""
+        return int(self._response.headers['Content-Length'])
 
-        :returns: size of the body
-        :rtype: int
-        '''
-        return int(self.response.headers['Content-Length'])
-
-    @property
-    def num_bytes_downloaded(self):
-        '''The number of bytes downloaded.
-
-        :returns: number of bytes downloaded
-        :rtype: int
-        '''
-        return self.response.num_bytes_downloaded
-
-    def last_modified(self):
-        '''Read the last-modified header as a datetime, if present.
-
-        :returns: last-modified header
-        :rtype: datatime or None
-        '''
-        lm = self.response.headers.get('last-modified', None)
-        return datetime.strptime(lm, '%a, %d %b %Y %H:%M:%S GMT') if lm \
-            else None
-
-    async def aiter_bytes(self):
-        async for c in self.response.aiter_bytes():
-            yield c
+    #
+    # @property
+    # def num_bytes_downloaded(self) -> int:
+    #     """The number of bytes downloaded."""
+    #     return self._response.num_bytes_downloaded
 
     async def write(self,
                     filename: Path,
                     overwrite: bool = True,
                     progress_bar: bool = True):
         """Write the body to a file.
-
         Parameters:
             filename: Name to assign to downloaded file.
             overwrite: Overwrite any existing files.
@@ -221,10 +160,10 @@ class StreamingBody:
                           unit='B',
                           desc=str(filename),
                           disable=not progress_bar) as progress:
-                    previous = self.num_bytes_downloaded
-                    async for chunk in self.aiter_bytes():
+                    previous = self._response.num_bytes_downloaded
+                    async for chunk in self._response.aiter_bytes():
                         fp.write(chunk)
-                        new = self.num_bytes_downloaded
+                        new = self._response.num_bytes_downloaded
                         _log.update(new)
                         progress.update(new - previous)
                         previous = new
@@ -278,30 +217,25 @@ class Paged:
     ITEMS_KEY = 'items'
 
     def __init__(self,
-                 request: Request,
-                 do_request_fcn: typing.Callable,
+                 first_page: dict,
+                 get_page_fcn: typing.Callable,
                  limit: int = 0):
         """
         Parameters:
             request: Request to send to server for first page.
-            do_request_fcn: Function for submitting a request. Must take in
-                Request object and return Response.
+            get_page_fcn: Function for retrieving a page. Must take in
+                url and method parameters and return the page contents as JSON.
             limit: Maximum number of results to return. When set to 0, no
                 maximum is applied.
         """
-        self.request = request
-        self._do_request = do_request_fcn
+        self._get_page_fcn = get_page_fcn
 
-        self._pages = self._get_pages()
+        self._pages = self._get_pages(first_page)
 
         self._items: typing.List[dict] = []
 
         self.i = 0
         self.limit = limit
-
-    @staticmethod
-    def _next_page_request(url):
-        return Request(url, 'GET')
 
     def __aiter__(self):
         return self
@@ -328,19 +262,14 @@ class Paged:
 
         return item
 
-    async def _get_pages(self) -> typing.AsyncGenerator:
-        LOGGER.debug('getting first page')
-        resp = await self._do_request(self.request)
-        page = resp.json()
+    async def _get_pages(self, first_page) -> typing.AsyncGenerator:
+        page = first_page
         yield page
 
         next_url = self._next_link(page)
         while (next_url):
             LOGGER.debug('getting next page')
-            request = self._next_page_request(next_url)
-            resp = await self._do_request(request)
-            page = resp.json()
-            yield page
+            page = await self._get_page_fcn(url=next_url, method='GET')
 
             # If the next URL is the same as the previous URL we will
             # get the same response and be stuck in a page cycle. This
@@ -352,6 +281,8 @@ class Paged:
             if next_url == prev_url:
                 raise PagingError(
                     "Page cycle detected at {!r}".format(next_url))
+
+            yield page
 
     def _next_link(self, page):
         try:

--- a/planet/models.py
+++ b/planet/models.py
@@ -58,6 +58,7 @@ class Response:
 
 
 class StreamingResponse(Response):
+
     @property
     def headers(self) -> list:
         return self._http_response.headers

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -108,8 +108,8 @@ async def test_list_orders_basic(order_descriptions, session):
         },
         "orders": [order1, order2]
     }
-    mock_resp1 = httpx.Response(HTTPStatus.OK, json=page1_response)
-    respx.get(TEST_ORDERS_URL).return_value = mock_resp1
+    mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
+    respx.get(TEST_ORDERS_URL).return_value = mock_resp
 
     page2_response = {"_links": {"_self": next_page_url}, "orders": [order3]}
     mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
@@ -188,14 +188,19 @@ async def test_list_orders_limit(order_descriptions,
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_create_order(oid, order_description, order_request, session):
-    mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
-    respx.post(TEST_ORDERS_URL).return_value = mock_resp
+async def test_create_order_basic(oid,
+                                  order_description,
+                                  order_request,
+                                  session):
+    route = respx.post(TEST_ORDERS_URL)
+    route.return_value = httpx.Response(HTTPStatus.OK, json=order_description)
 
     cl = OrdersClient(session, base_url=TEST_URL)
     order = await cl.create_order(order_request)
 
     assert order == order_description
+
+    assert json.loads(route.calls.last.request.content) == order_request
 
 
 @respx.mock

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 from http import HTTPStatus
 import math
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import httpx
 import respx
@@ -28,13 +28,6 @@ from planet import exceptions, http
 TEST_URL = 'mock://fantastic.com'
 
 LOGGER = logging.getLogger(__name__)
-
-
-@pytest.fixture
-def mock_request():
-    r = Mock()
-    r.http_request = httpx.Request('GET', TEST_URL)
-    yield r
 
 
 @pytest.fixture

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -28,15 +28,6 @@ from planet.exceptions import PagingError
 LOGGER = logging.getLogger(__name__)
 
 
-def mock_http_response(json=None, iter_content=None, text=None):
-    m = MagicMock(name='http_response')
-    m.headers = {}
-    m.json.return_value = json or {}
-    m.aiter_content = iter_content
-    m.text = text or ''
-    return m
-
-
 def test_StreamingBody_name_filename():
     r = MagicMock(name='response')
     r.url = URL('https://planet.com/path/to/example.tif?foo=f6f1')

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -160,36 +160,43 @@ async def test_StreamingBody_write_img(tmpdir, open_test_img):
 
 @pytest.mark.asyncio
 async def test_Paged_iterator():
-    first_page = {'_links': {'next': 'blah'}, 'items': [1, 2]}
+    resp = MagicMock(name='response')
+    resp.json = lambda: {'_links': {'next': 'blah'}, 'items': [1, 2]}
 
-    async def get_page(url, method):
-        return {'_links': {}, 'items': [3, 4]}
+    async def get_response(url, method):
+        resp = MagicMock(name='response')
+        resp.json = lambda: {'_links': {}, 'items': [3, 4]}
+        return resp
 
-    paged = models.Paged(first_page, get_page)
+    paged = models.Paged(resp, get_response)
     assert [1, 2, 3, 4] == [i async for i in paged]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('limit, expected', [(0, [1, 2, 3, 4]), (1, [1])])
 async def test_Paged_limit(limit, expected):
-    first_page = {'_links': {'next': 'blah'}, 'items': [1, 2]}
+    resp = MagicMock(name='response')
+    resp.json = lambda: {'_links': {'next': 'blah'}, 'items': [1, 2]}
 
-    async def get_page(url, method):
-        return {'_links': {}, 'items': [3, 4]}
+    async def get_response(url, method):
+        resp = MagicMock(name='response')
+        resp.json = lambda: {'_links': {}, 'items': [3, 4]}
+        return resp
 
-    paged = models.Paged(first_page, get_page, limit=limit)
+    paged = models.Paged(resp, get_response, limit=limit)
     assert [i async for i in paged] == expected
 
 
 @pytest.mark.asyncio
 async def test_Paged_break_page_cycle():
     """Check that we break out of a page cycle."""
-    first_page = {'_links': {'next': 'blah'}, 'items': [1, 2]}
+    resp = MagicMock(name='response')
+    resp.json = lambda: {'_links': {'next': 'blah'}, 'items': [1, 2]}
 
-    async def get_page(url, method):
-        return first_page
+    async def get_response(url, method):
+        return resp
 
-    paged = models.Paged(first_page, get_page, limit=None)
+    paged = models.Paged(resp, get_response, limit=None)
 
     with pytest.raises(PagingError):
         [item async for item in paged]


### PR DESCRIPTION
**Related Issue(s):**

Closes #739 


**Proposed Changes:**

For inclusion in changelog:
1. Client identification headers are now sent with all requests.

Not intended for changelog:

1. The Request model has been removed and Sessions.request() and Sessions.stream() now take in arguments such as url, method, json, etc, and create the request internally.
1. All clients now have their methods call Session.request() directly instead of all going through a private method of the class
1. The Paged class in models now takes in the first page response as an argument instead of starting with a Request object and submitting the request and handling the first page internally. This was necessitated by the removal of the Request object but also has the benefit of earlier notification to the user of an error when the first page request was unsuccessful. Previously, the first page was only requested (and error thrown) when the user started using the generator.
1. Adds tests for confirming that the headers are sent in requests and a test for orders client to confirm the expected request is sent to the server.

**Diff of User Interface**

Old behavior:

From the code and output below, this is the relevant line:
```
2022-11-09 20:07:38,294 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - Headers({'host': 'api.planet.com', 'content-type': 'application/json', 'content-length': '158', 'authorization': '[secure]'})
```
Note that the headers 'x-planet-app' and 'user-agent' are not included.

```console
planet-client-python$> planet orders request --name test --id 20221109_052227_10_2432 PSScene analytic_udm2 | planet --verbosity debug orders create
2022-11-09 20:07:38,281 - asyncio - DEBUG - Using selector: KqueueSelector
2022-11-09 20:07:38,282 - planet.auth - DEBUG - Reading from /Users/jennifer.kyle/.planet.json
2022-11-09 20:07:38,282 - planet.auth - DEBUG - Auth read from secret file /Users/jennifer.kyle/.planet.json.
2022-11-09 20:07:38,282 - planet.http - INFO - Session read timeout set to 30.0.
2022-11-09 20:07:38,294 - planet.http - DEBUG - Throttling cadence set to 0.1s.
2022-11-09 20:07:38,294 - planet.http - DEBUG - Workers capped at 50.
2022-11-09 20:07:38,294 - planet.http - DEBUG - Worker acquired.
2022-11-09 20:07:38,294 - planet.http - INFO - POST https://api.planet.com/compute/ops/orders/v2 - Sent
2022-11-09 20:07:38,294 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - Headers({'host': 'api.planet.com', 'content-type': 'application/json', 'content-length': '158', 'authorization': '[secure]'})
2022-11-09 20:07:38,295 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - b'{"name": "test", "products": [{"item_ids": ["20221109_052227_10_2432"], "item_type": "PSScene", "product_bundle": "analytic_udm2"}], "metadata": {"stac": {}}}'
2022-11-09 20:07:39,033 - httpx._client - DEBUG - HTTP Request: POST https://api.planet.com/compute/ops/orders/v2 "HTTP/1.1 202 Accepted"
2022-11-09 20:07:39,033 - planet.http - INFO - POST https://api.planet.com/compute/ops/orders/v2 - Status 202
2022-11-09 20:07:39,033 - planet.http - DEBUG - Headers({'content-type': 'application/json', 'date': 'Thu, 10 Nov 2022 04:07:39 GMT', 'strict-transport-security': 'max-age=15724800; includeSubDomains', 'vary': 'Origin', 'x-planet-span-id': '3178ea59-5cb8-444e-a272-ce0812008a28', 'x-planet-trace-id': '369209dd-9d29-43ae-8d98-a0281e552530', 'x-request-id': '369209dd-9d29-43ae-8d98-a0281e552530', 'content-length': '445', 'via': '1.1 edge, 1.1 google', 'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000'})
2022-11-09 20:07:39,033 - planet.http - DEBUG - Worker released.
{"_links": {"_self": "https://api.planet.com/compute/ops/orders/v2/ce65731e-ee90-4dd4-8950-29ba5496b47f"}, "created_on": "2022-11-10T04:07:38.742Z", "error_hints": [], "id": "ce65731e-ee90-4dd4-8950-29ba5496b47f", "last_message": "Preparing order", "last_modified": "2022-11-10T04:07:38.742Z", "metadata": {"stac": {}}, "name": "test", "products": [{"item_ids": ["20221109_052227_10_2432"], "item_type": "PSScene", "product_bundle": "analytic_udm2"}], "state": "queued"}
```

New behavior:

From the code and output below, this is the relevant line:
```
2022-11-09 20:08:58,295 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - Headers({'host': 'api.planet.com', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'planet-client-python/2.0a6dev', 'x-planet-app': 'python-cli', 'content-type': 'application/json', 'content-length': '158', 'authorization': '[secure]'})
```
Note that the headers 'x-planet-app' and 'user-agent' are now included.

```console
planet-client-python$> planet orders request --name test --id 20221109_052227_10_2432 PSScene analytic_udm2 | planet --verbosity debug orders create
2022-11-09 20:08:58,282 - asyncio - DEBUG - Using selector: KqueueSelector
2022-11-09 20:08:58,282 - planet.auth - DEBUG - Reading from /Users/jennifer.kyle/.planet.json
2022-11-09 20:08:58,282 - planet.auth - DEBUG - Auth read from secret file /Users/jennifer.kyle/.planet.json.
2022-11-09 20:08:58,282 - planet.http - INFO - Session read timeout set to 30.0.
2022-11-09 20:08:58,294 - planet.http - DEBUG - Throttling cadence set to 0.1s.
2022-11-09 20:08:58,294 - planet.http - DEBUG - Workers capped at 50.
2022-11-09 20:08:58,295 - planet.http - DEBUG - Worker acquired.
2022-11-09 20:08:58,295 - planet.http - INFO - POST https://api.planet.com/compute/ops/orders/v2 - Sent
2022-11-09 20:08:58,295 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - Headers({'host': 'api.planet.com', 'accept': '*/*', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'user-agent': 'planet-client-python/2.0a6dev', 'x-planet-app': 'python-cli', 'content-type': 'application/json', 'content-length': '158', 'authorization': '[secure]'})
2022-11-09 20:08:58,295 - planet.http - DEBUG - POST https://api.planet.com/compute/ops/orders/v2 - b'{"name": "test", "products": [{"item_ids": ["20221109_052227_10_2432"], "item_type": "PSScene", "product_bundle": "analytic_udm2"}], "metadata": {"stac": {}}}'
2022-11-09 20:08:58,986 - httpx._client - DEBUG - HTTP Request: POST https://api.planet.com/compute/ops/orders/v2 "HTTP/1.1 202 Accepted"
2022-11-09 20:08:58,986 - planet.http - INFO - POST https://api.planet.com/compute/ops/orders/v2 - Status 202
2022-11-09 20:08:58,986 - planet.http - DEBUG - Headers({'content-encoding': 'gzip', 'content-type': 'application/json', 'date': 'Thu, 10 Nov 2022 04:08:59 GMT', 'strict-transport-security': 'max-age=15724800; includeSubDomains', 'vary': 'Origin', 'x-planet-span-id': 'b8141866-f147-4e5c-867f-928c87e7f3c9', 'x-planet-trace-id': '8f59f424-7a2d-4dfa-aeed-281c1cb5dd6f', 'x-request-id': '8f59f424-7a2d-4dfa-aeed-281c1cb5dd6f', 'via': '1.1 edge, 1.1 google', 'alt-svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000', 'transfer-encoding': 'chunked'})
2022-11-09 20:08:58,988 - planet.http - DEBUG - Worker released.
{"_links": {"_self": "https://api.planet.com/compute/ops/orders/v2/93fb9b71-cbd7-4ed7-be8b-c04c0fc08ec2"}, "created_on": "2022-11-10T04:08:58.733Z", "error_hints": [], "id": "93fb9b71-cbd7-4ed7-be8b-c04c0fc08ec2", "last_message": "Preparing order", "last_modified": "2022-11-10T04:08:58.733Z", "metadata": {"stac": {}}, "name": "test", "products": [{"item_ids": ["20221109_052227_10_2432"], "item_type": "PSScene", "product_bundle": "analytic_udm2"}], "state": "queued"}
```

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or I have determined a Changelog entry is not required
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@cholmes @sgillies 
