### PR TITLE
PR template tweaks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,17 @@
 **Related Issue(s):**
 
-#
+Closes #
 
 
 **Proposed Changes:**
 
+For inclusion in changelog (if applicable):
+
+1.
+
+Not intended for changelog:
+
 1. 
-2. 
 
 **Diff of User Interface**
 
@@ -19,9 +24,9 @@ New behavior:
 
 **PR Checklist:**
 
-- [ ] This PR is as small and focused as possible
-- [ ] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or I have determined a Changelog entry is not required
-- [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
-- [ ] This PR does not break any examples or I have updated them
+- [] This PR is as small and focused as possible
+- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
+- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
+- [] This PR does not break any examples or I have updated them
 
 **(Optional) @mentions for Notifications:**


### PR DESCRIPTION
**Related Issue(s):**

None

**Proposed Changes:**

1. PR template Proposed Changes section now has two lists, one for changes that are to be included in the changelog and one for those that aren't


**PR Checklist:**

- [x ] This PR is as small and focused as possible
- [x ] The title of this PR and/or the list of proposed changes are ready for inclusion in the Changelog or I have determined a Changelog entry is not required
- [x ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [ x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@JuLeeAtPlanet @cholmes 
