### PR TITLE
Updated Data API example, resolving rate limiting issue

### DIFF
--- a/examples/download_multiple_assets.py
+++ b/examples/download_multiple_assets.py
@@ -54,6 +54,7 @@ async def main():
     async with Session() as sess:
         # Data client object
         client = DataClient(sess)
+        # Download and validate assets in parallel
         await asyncio.gather(
             download_and_validate(river_item_id,
                                   river_item_type,


### PR DESCRIPTION
**Related Issue(s):**

Closes #759 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. The `download_multiple_assets.py` example now runs the Data client with a single Session, which will fix the rate limiting issue some users were running into.


**Diff of User Interface**

Old behavior:
- Define the Data client in `download_and_validate()`, which then gets called twice, in parallel.
```
async def main():
    await asyncio.gather(
        download_and_validate(river_item_id, river_item_type,
                              river_asset_type),
        download_and_validate(wildfire_item_id,
                              wildfire_item_type,
                              wildfire_asset_type))
```
- Users found that the two Sessions communicating at the same time will somewhat bypass the rate limiting, resulting in kickback from the server. Namely, this error:
```
httpx.HTTPStatusError: Client error '429 Too Many Requests' for url 'https://api.planet.com/data/v1/searches'
```

New behavior:
- Define the Data client in a single Session then run it twice, separately:
```
async def main():
    async with Session() as sess:
        # Data client object
        client = DataClient(sess)
        await asyncio.gather(
            download_and_validate(river_item_id,
                                  river_item_type,
                                  river_asset_type,
                                  client),
            download_and_validate(wildfire_item_id,
                                  wildfire_item_type,
                                  wildfire_asset_type,
                                  client))
```
- This way the `asyncio.gather` is called within the context of the single Session and rate limiting is enabled. 

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@cholmes 