### PR TITLE
Updated Harmonization tool to match the openAPI spec

### DIFF
--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -473,7 +473,7 @@ The harmonize tool allows you to compare data to different generations of satell
 [
   {
     "harmonize": {
-      "target_sensor": "PS2"
+      "target_sensor": "Sentinel-2"
       }
     }
 ]

--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -467,7 +467,7 @@ curl -s https://raw.githubusercontent.com/planetlabs/planet-client-python/main/d
 
 ### Harmonize
 
-The harmonize tool allows you to compare data to different generations of satellites by radiometrically harmonizing imagery captured by one satellite instrument type to imagery captured by another. To harmonize with a sensor put the following in your `tools.json`.
+The harmonize tool allows you to compare data to different generations of satellites by radiometrically harmonizing imagery captured by one satellite instrument type to imagery captured by another. To harmonize your data to a sensor you must define the sensor you wish to harmonize with in your `tools.json`. Currently, only "PS2" (Dove Classic) and "Sentinel-2" are supported as target sensors. The Sentinel-2 target only harmonizes PSScene surface reflectance bundle types (`analytic_8b_sr_udm2`, `analytic_sr_udm2`). The PS2 target only works on analytic bundles from Dove-R (`PS2.SD`).
 
 ```json
 [
@@ -479,10 +479,10 @@ The harmonize tool allows you to compare data to different generations of satell
 ]
 ```
 
-Then you may create your order request by calling your `tools.json` with `--tools`.
+You may create an order request by calling `tools.json` with `--tools`.
 
 ```console
-planet orders request psscene analytic_udm2 --name "Harmonized data" --id 20200925_161029_69_2223 --tools tools.json
+planet orders request psscene analytic_sr_udm2 --name "Harmonized data" --id 20200925_161029_69_2223 --tools tools.json
 ```
 
 ### STAC Metadata

--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -467,7 +467,23 @@ curl -s https://raw.githubusercontent.com/planetlabs/planet-client-python/main/d
 
 ### Harmonize
 
-TODO
+The harmonize tool allows you to compare data to different generations of satellites by radiometrically harmonizing imagery captured by one satellite instrument type to imagery captured by another. To harmonize with a sensor put the following in your `tools.json`.
+
+```json
+[
+  {
+    "harmonize": {
+      "target_sensor": "PS2"
+      }
+    }
+]
+```
+
+Then you may create your order request by calling your `tools.json` with `--tools`.
+
+```console
+planet orders request psscene analytic_udm2 --name "Harmonized data" --id 20200925_161029_69_2223 --tools tools.json
+```
 
 ### STAC Metadata
 

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -429,10 +429,13 @@ def toar_tool(scale_factor: Optional[int] = None, ) -> dict:
     return _tool('toar', parameters)
 
 
-def harmonize_tool() -> dict:
+def harmonize_tool(target_sensor: str) -> dict:
     '''Create the API spec representation of a harmonize tool.
 
-    Currently, only "PS2" (Dove Classic) is supported as a target sensor, and
-    it will transform only items captured by “PS2.SD” (Dove-R).
+    Currently, only "PS2" (Dove Classic) and "Sentinel-2" are supported as 
+    target sensors. The Sentinel-2 target only harmonizes PSScene 
+    surface reflectance bundle types (analytic_8b_sr_udm2, analytic_sr_udm2). 
+    The PS2 target only works on analytic bundles
+     from Dove-R (PS2.SD).
     '''
-    return _tool('harmonize', {'target_sensor': 'PS2'})
+    return _tool('harmonize', {'target_sensor': target_sensor})

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -432,10 +432,9 @@ def toar_tool(scale_factor: Optional[int] = None, ) -> dict:
 def harmonize_tool(target_sensor: str) -> dict:
     '''Create the API spec representation of a harmonize tool.
 
-    Currently, only "PS2" (Dove Classic) and "Sentinel-2" are supported as 
-    target sensors. The Sentinel-2 target only harmonizes PSScene 
-    surface reflectance bundle types (analytic_8b_sr_udm2, analytic_sr_udm2). 
-    The PS2 target only works on analytic bundles
-     from Dove-R (PS2.SD).
+    Currently, only "PS2" (Dove Classic) and "Sentinel-2" are supported as
+    target sensors. The Sentinel-2 target only harmonizes PSScene
+    surface reflectance bundle types (analytic_8b_sr_udm2, analytic_sr_udm2).
+    The PS2 target only works on analytic bundles from Dove-R (PS2.SD).
     '''
     return _tool('harmonize', {'target_sensor': target_sensor})

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -251,3 +251,9 @@ def test_toar_tool():
     tt_empty = order_request.toar_tool()
     expected_empty = {'toar': {}}
     assert tt_empty == expected_empty
+
+@pytest.mark.parametrize("target_sensor", ["PS2", "Sentinel-2"])
+def test_harmonization_tool(target_sensor):
+    ht = order_request.harmonize_tool(target_sensor)
+    expected = {'harmonize': {'target_sensor': target_sensor}}
+    assert ht == expected

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -252,6 +252,7 @@ def test_toar_tool():
     expected_empty = {'toar': {}}
     assert tt_empty == expected_empty
 
+
 @pytest.mark.parametrize("target_sensor", ["PS2", "Sentinel-2"])
 def test_harmonization_tool(target_sensor):
     ht = order_request.harmonize_tool(target_sensor)


### PR DESCRIPTION
**Related Issue(s):**

Closes #772 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Added the capability to harmonize data with more sensors. Previously, users could only harmonize with Dove Classic, however the [openAPI spec ](https://developers.planet.com/apis/orders/reference/#tag/Orders/operation/createOrder) has added Sentinel-2 as a target sensor for harmonization. Now, users can harmonize their data with Sentinel-2.

**Diff of User Interface**

Old behavior:
- Could only harmonize Dove-R with Dove Classic.
New behavior:
- Can harmonize data with Dove Classic and Sentinel-2. The Sentinel-2 target only harmonizes PSScene surface reflectance bundle types (analytic_8b_sr_udm2, analytic_sr_udm2). The PS2 target only works on analytic bundles



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
FYI: @cholmes @jreiberkyle 