### PR TITLE
Move to async generator functions for paged results

### DIFF
--- a/docs/python/sdk-guide.md
+++ b/docs/python/sdk-guide.md
@@ -109,11 +109,17 @@ Otherwise, the JSON blob is a list of the individual results.
 >>> async def main():
 ...     async with Session() as sess:
 ...         client = OrdersClient(sess)
-...         orders = client.list_orders()
-...         orders_list = collect(orders)
+...         orders_aiter = client.list_orders_aiter()
+...         orders_list = collect(orders_aiter)
 ...
 >>> asyncio.run(main())
 
+```
+
+Alternatively, these results can be converted to a list directly with
+
+```python
+>>>         orders_list = [o async for o in client.list_orders_aiter()]
 ```
 
 

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -272,12 +272,12 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
     parameter will be applied to the stored quick search.
     """
     async with data_client(ctx) as cl:
-        items = await cl.search(item_types,
-                                filter,
-                                name=name,
-                                sort=sort,
-                                limit=limit)
-        async for item in items:
+        items_aiter = cl.search_aiter(item_types,
+                                      filter,
+                                      name=name,
+                                      sort=sort,
+                                      limit=limit)
+        async for item in items_aiter:
             echo_json(item, pretty)
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -67,8 +67,8 @@ async def list(ctx, state, limit, pretty):
     optionally pretty-printed.
     '''
     async with orders_client(ctx) as cl:
-        orders = await cl.list_orders(state=state, limit=limit)
-        async for o in orders:
+        orders_aiter = cl.list_orders_aiter(state=state, limit=limit)
+        async for o in orders_aiter:
             echo_json(o, pretty)
 
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -42,8 +42,9 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
     async with CliSession(auth=ctx.obj['AUTH']) as session:
         client = SubscriptionsClient(session)
-        filtered_subs = client.list_subscriptions(status=status, limit=limit)
-        async for sub in filtered_subs:
+        subs_aiter = client.list_subscriptions_aiter(status=status,
+                                                     limit=limit)
+        async for sub in subs_aiter:
             echo_json(sub, pretty)
 
 
@@ -157,8 +158,8 @@ async def list_subscription_results_cmd(ctx,
     """Gets results of a subscription and prints the API response."""
     async with CliSession(auth=ctx.obj['AUTH']) as session:
         client = SubscriptionsClient(session)
-        filtered_results = client.get_results(subscription_id,
-                                              status=status,
-                                              limit=limit)
-        async for result in filtered_results:
+        results_aiter = client.get_results_aiter(subscription_id,
+                                                 status=status,
+                                                 limit=limit)
+        async for result in results_aiter:
             echo_json(result, pretty)

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -332,10 +332,10 @@ class DataClient:
         response = await self._session.request(method='GET', url=url)
         return response.json()
 
-    async def run_search(self,
-                         search_id: str,
-                         limit: int = 100) -> AsyncIterator[dict]:
-        """Execute a saved search.
+    async def run_search_aiter(self,
+                               search_id: str,
+                               limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate over results from a saved search.
 
         Parameters:
             search_id: Stored search identifier.
@@ -351,7 +351,8 @@ class DataClient:
         url = f'{self._searches_url()}/{search_id}/results'
 
         response = await self._session.request(method='GET', url=url)
-        return Items(response, self._session.request, limit=limit)
+        async for i in Items(response, self._session.request, limit=limit):
+            yield i
 
     async def get_stats(self,
                         item_types: List[str],

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -114,8 +114,8 @@ class DataClient:
             limit: Maximum number of results to return. When set to 0, no
                 maximum is applied.
 
-        Returns:
-            Returns an iterator over all items matching the search.
+        Yields:
+            Description of an item.
 
         Raises:
             planet.exceptions.APIError: On API error.
@@ -224,11 +224,11 @@ class DataClient:
                                                json=request)
         return response.json()
 
-    async def list_searches(self,
-                            sort: str = 'created desc',
-                            search_type: str = 'any',
-                            limit: int = 100) -> AsyncIterator[dict]:
-        """List all saved searches available to the authenticated user.
+    async def list_searches_aiter(self,
+                                  sort: str = 'created desc',
+                                  search_type: str = 'any',
+                                  limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate through list of searches available to the user.
 
         NOTE: the term 'saved' is overloaded here. We want to list saved
         searches that are 'quick' or list saved searches that are 'saved'? Do
@@ -241,8 +241,8 @@ class DataClient:
             limit: Maximum number of results to return. When set to 0, no
                 maximum is applied.
 
-        Returns:
-            An iterator over all searches that match filter.
+        Yields:
+            Description of a search.
 
         Raises:
             planet.exceptions.APIError: On API error.
@@ -262,7 +262,8 @@ class DataClient:
         url = f'{self._searches_url()}'
 
         response = await self._session.request(method='GET', url=url)
-        return Searches(response, self._session.request, limit=limit)
+        async for s in Searches(response, self._session.request, limit=limit):
+            yield s
 
     async def delete_search(self, search_id: str):
         """Delete an existing saved search.
@@ -304,8 +305,8 @@ class DataClient:
             limit: Maximum number of results to return. When set to 0, no
                 maximum is applied.
 
-        Returns:
-            Returns an iterator over all items matching the search.
+        Yields:
+            Description of an item.
 
         Raises:
             planet.exceptions.APIError: On API error.

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -93,56 +93,17 @@ class DataClient:
     def _item_url(self, item_type, item_id):
         return f'{self._base_url}/item-types/{item_type}/items/{item_id}'
 
-    async def search(self,
-                     item_types: List[str],
-                     search_filter: dict,
-                     name: Optional[str] = None,
-                     sort: Optional[str] = None,
-                     limit: int = 100) -> AsyncIterator[dict]:
-        """Execute a quick search.
+    async def search_aiter(self,
+                           item_types: List[str],
+                           search_filter: dict,
+                           name: Optional[str] = None,
+                           sort: Optional[str] = None,
+                           limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate over results from a quick search.
 
         Quick searches are saved for a short period of time (~month). The
         `name` parameter of the search defaults to the id of the generated
         search id if `name` is not specified.
-
-        To filter to items you have access to download which are of standard
-        (aka not test) quality, use the following:
-
-        ```python
-        >>> from planet import data_filter
-        >>> data_filter.and_filter([
-        ...     data_filter.permission_filter(),
-        ...     data_filter.std_quality_filter()
-        >>> ])
-
-        ```
-
-        To avoid filtering out any imagery, supply a blank AndFilter, which can
-        be created with `data_filter.and_filter([])`.
-
-        Example:
-
-        ```python
-        >>> import asyncio
-        >>> from planet import Session, DataClient
-        >>>
-        >>> async def main():
-        ...     item_types = ['PSScene']
-        ...     sfilter = {
-        ...         "type":"DateRangeFilter",
-        ...         "field_name":"acquired",
-        ...         "config":{
-        ...             "gt":"2019-12-31T00:00:00Z",
-        ...             "lte":"2020-01-31T00:00:00Z"
-        ...         }
-        ...     }
-        ...     async with Session() as sess:
-        ...         cl = DataClient(sess)
-        ...         items = await cl.quick_search(item_types, sfilter)
-        ...
-        >>> asyncio.run(main())
-
-        ```
 
         Parameters:
             item_types: The item types to include in the search.
@@ -178,7 +139,8 @@ class DataClient:
                                                url=url,
                                                json=request_json,
                                                params=params)
-        return Items(response, self._session.request, limit=limit)
+        async for i in Items(response, self._session.request, limit=limit):
+            yield i
 
     async def create_search(self,
                             name: str,

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -463,10 +463,10 @@ class OrdersClient:
 
         return current_state
 
-    async def list_orders(self,
-                          state: Optional[str] = None,
-                          limit: int = 100) -> AsyncIterator[dict]:
-        """Get all order requests.
+    async def list_orders_aiter(self,
+                                state: Optional[str] = None,
+                                limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate over the list of stored order requests.
 
         Parameters:
             state: Filter orders to given state.
@@ -474,7 +474,7 @@ class OrdersClient:
                 maximum is applied.
 
         Returns:
-            User orders that match the query
+            Iterator over user orders that match the query
 
         Raises:
             planet.exceptions.APIError: On API error.
@@ -493,4 +493,5 @@ class OrdersClient:
         response = await self._session.request(method='GET',
                                                url=url,
                                                params=params)
-        return Orders(response, self._session.request, limit=limit)
+        async for o in Orders(response, self._session.request, limit=limit):
+            yield o

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -192,11 +192,11 @@ class SubscriptionsClient:
             sub = resp.json()
             return sub
 
-    async def get_results(self,
-                          subscription_id: str,
-                          status: Optional[Set[str]] = None,
-                          limit: int = 100) -> AsyncIterator[dict]:
-        """Get Results of a Subscription.
+    async def get_results_aiter(self,
+                                subscription_id: str,
+                                status: Optional[Set[str]] = None,
+                                limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate over results of a Subscription.
 
         Note:
             The name of this method is based on the API's method name. This

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -31,10 +31,11 @@ class SubscriptionsClient:
     def __init__(self, session: Session) -> None:
         self._session = session
 
-    async def list_subscriptions(self,
-                                 status: Optional[Set[str]] = None,
-                                 limit: int = 100) -> AsyncIterator[dict]:
-        """Get account subscriptions with optional filtering.
+    async def list_subscriptions_aiter(
+            self,
+            status: Optional[Set[str]] = None,
+            limit: int = 100) -> AsyncIterator[dict]:
+        """Iterate over list of account subscriptions with optional filtering.
 
         Note:
             The name of this method is based on the API's method name.

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -372,8 +372,8 @@ async def test_run_search_success(item_descriptions, session):
     respx.get(next_page_url).return_value = mock_resp2
 
     cl = DataClient(session, base_url=TEST_URL)
-    items = await cl.run_search(sid)
-    items_list = [i async for i in items]
+    item_aiter = cl.run_search_aiter(sid)
+    items_list = [i async for i in item_aiter]
 
     assert route.called
 
@@ -390,10 +390,10 @@ async def test_run_search_doesnotexist(session):
 
     cl = DataClient(session, base_url=TEST_URL)
     with pytest.raises(exceptions.APIError):
-        items = await cl.run_search(sid)
+        item_aiter = cl.run_search_aiter(sid)
         # this won't throw the error until the iterator is processed
         # issue 476
-        [i async for i in items]
+        [i async for i in item_aiter]
 
     assert route.called
 

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -67,10 +67,10 @@ def search_response(item_descriptions):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_search_basic(item_descriptions,
-                            search_filter,
-                            search_response,
-                            session):
+async def test_search_aiter_basic(item_descriptions,
+                                  search_filter,
+                                  search_response,
+                                  session):
 
     quick_search_url = f'{TEST_URL}/quick-search'
     next_page_url = f'{TEST_URL}/blob/?page_marker=IAmATest'
@@ -89,8 +89,10 @@ async def test_search_basic(item_descriptions,
     respx.get(next_page_url).return_value = mock_resp2
 
     cl = DataClient(session, base_url=TEST_URL)
-    items = await cl.search(['PSScene'], search_filter, name='quick_search')
-    items_list = [i async for i in items]
+    item_aiter = cl.search_aiter(['PSScene'],
+                                 search_filter,
+                                 name='quick_search')
+    items_list = [i async for i in item_aiter]
 
     # check that request is correct
     expected_request = {
@@ -107,10 +109,10 @@ async def test_search_basic(item_descriptions,
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_search_sort(item_descriptions,
-                           search_filter,
-                           search_response,
-                           session):
+async def test_search_aiter_sort(item_descriptions,
+                                 search_filter,
+                                 search_response,
+                                 session):
 
     sort = 'acquired asc'
     quick_search_url = f'{TEST_URL}/quick-search?_sort={sort}'
@@ -123,18 +125,18 @@ async def test_search_sort(item_descriptions,
     # if the sort parameter is not used correctly, the client will not send
     # the request to the mocked endpoint and this test will fail
     cl = DataClient(session, base_url=TEST_URL)
-    items = await cl.search(['PSScene'], search_filter, sort=sort)
+    item_aiter = cl.search_aiter(['PSScene'], search_filter, sort=sort)
 
     # run through the iterator to actually initiate the call
-    [i async for i in items]
+    [i async for i in item_aiter]
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_search_limit(item_descriptions,
-                            search_filter,
-                            search_response,
-                            session):
+async def test_search_aiter_limit(item_descriptions,
+                                  search_filter,
+                                  search_response,
+                                  session):
 
     quick_search_url = f'{TEST_URL}/quick-search'
 
@@ -146,8 +148,8 @@ async def test_search_limit(item_descriptions,
     respx.post(quick_search_url).return_value = mock_resp
 
     cl = DataClient(session, base_url=TEST_URL)
-    items = await cl.search(['PSScene'], search_filter, limit=2)
-    items_list = [i async for i in items]
+    item_aiter = cl.search_aiter(['PSScene'], search_filter, limit=2)
+    items_list = [i async for i in item_aiter]
 
     # check only the first two results were returned
     assert items_list == item_descriptions[:2]
@@ -353,7 +355,7 @@ async def test_delete_search(retcode, expectation, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_run_search_success(item_descriptions, session):
+async def test_run_search_aiter_success(item_descriptions, session):
     sid = 'search_id'
     route = respx.get(f'{TEST_SEARCHES_URL}/{sid}/results')
 
@@ -383,7 +385,7 @@ async def test_run_search_success(item_descriptions, session):
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_run_search_doesnotexist(session):
+async def test_run_search_aiter_doesnotexist(session):
     sid = 'search_id'
     route = respx.get(f'{TEST_SEARCHES_URL}/{sid}/results')
     route.return_value = httpx.Response(404)

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -97,7 +97,7 @@ def test_OrderStates_passed():
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_list_orders_basic(order_descriptions, session):
+async def test_list_orders_aiter_basic(order_descriptions, session):
     next_page_url = TEST_ORDERS_URL + 'blob/?page_marker=IAmATest'
 
     order1, order2, order3 = order_descriptions
@@ -116,13 +116,13 @@ async def test_list_orders_basic(order_descriptions, session):
     respx.get(next_page_url).return_value = mock_resp2
 
     cl = OrdersClient(session, base_url=TEST_URL)
-    orders = await cl.list_orders()
-    assert order_descriptions == [o async for o in orders]
+    order_aiter = cl.list_orders_aiter()
+    assert order_descriptions == [o async for o in order_aiter]
 
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_list_orders_state(order_descriptions, session):
+async def test_list_orders_aiter_state_success(order_descriptions, session):
     list_url = TEST_ORDERS_URL + '?source_type=all&state=failed'
 
     order1, order2, _ = order_descriptions
@@ -139,26 +139,27 @@ async def test_list_orders_state(order_descriptions, session):
 
     # if the value of state doesn't get sent as a url parameter,
     # the mock will fail and this test will fail
-    orders = await cl.list_orders(state='failed')
-    assert [order1, order2] == [o async for o in orders]
+    order_aiter = cl.list_orders_aiter(state='failed')
+    assert [order1, order2] == [o async for o in order_aiter]
 
 
 @pytest.mark.asyncio
-async def test_list_orders_state_invalid_state(session):
+async def test_list_orders_aiter_state_invalid(session):
     cl = OrdersClient(session, base_url=TEST_URL)
 
     with pytest.raises(exceptions.ClientError):
-        await cl.list_orders(state='invalidstate')
+        order_aiter = cl.list_orders_aiter(state='invalidstate')
+        [o async for o in order_aiter]
 
 
 @respx.mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize("limit,limited_list_length", [(None, 100), (0, 102),
                                                        (1, 1)])
-async def test_list_orders_limit(order_descriptions,
-                                 session,
-                                 limit,
-                                 limited_list_length):
+async def test_list_orders_aiter_limit(order_descriptions,
+                                       session,
+                                       limit,
+                                       limited_list_length):
     nono_page_url = None
 
     # Creating 102 (3x34) order descriptions
@@ -182,8 +183,8 @@ async def test_list_orders_limit(order_descriptions,
 
     cl = OrdersClient(session, base_url=TEST_URL)
 
-    orders = await cl.list_orders(limit=limit)
-    assert len([o async for o in orders]) == limited_list_length
+    order_aiter = cl.list_orders_aiter(limit=limit)
+    assert len([o async for o in order_aiter]) == limited_list_length
 
 
 @respx.mock

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -156,19 +156,19 @@ res_api_mock.route(
 
 @pytest.mark.asyncio
 @failing_api_mock
-async def test_list_subscriptions_failure():
+async def test_list_subscriptions_aiter_failure():
     """ServerError is raised if there is an internal server error (500)."""
     with pytest.raises(ServerError):
         async with Session() as session:
             client = SubscriptionsClient(session)
-            _ = [sub async for sub in client.list_subscriptions()]
+            _ = [sub async for sub in client.list_subscriptions_aiter()]
 
 
 @pytest.mark.parametrize("status, count", [({"created"}, 100), ({"failed"}, 0),
                                            (None, 100)])
 @pytest.mark.asyncio
 @api_mock
-async def test_list_subscriptions_success(
+async def test_list_subscriptions_aiter_success(
     status,
     count,
 ):
@@ -176,7 +176,7 @@ async def test_list_subscriptions_success(
     async with Session() as session:
         client = SubscriptionsClient(session)
         assert len([
-            sub async for sub in client.list_subscriptions(status=status)
+            sub async for sub in client.list_subscriptions_aiter(status=status)
         ]) == count
 
 
@@ -313,9 +313,9 @@ paging_cycle_api_mock.route(
 
 @pytest.mark.asyncio
 @paging_cycle_api_mock
-async def test_list_subscriptions_cycle_break():
+async def test_list_subscriptions_aiter_cycle_break():
     """PagingError is raised if there is a paging cycle."""
     with pytest.raises(PagingError):
         async with Session() as session:
             client = SubscriptionsClient(session)
-            _ = [sub async for sub in client.list_subscriptions()]
+            _ = [sub async for sub in client.list_subscriptions_aiter()]

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -266,21 +266,21 @@ async def test_get_subscription_success(monkeypatch):
 
 @pytest.mark.asyncio
 @failing_api_mock
-async def test_get_results_failure():
+async def test_get_results_aiter_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(APIError):
         async with Session() as session:
             client = SubscriptionsClient(session)
-            _ = [res async for res in client.get_results("lolwut")]
+            _ = [res async for res in client.get_results_aiter("lolwut")]
 
 
 @pytest.mark.asyncio
 @res_api_mock
-async def test_get_results_success():
+async def test_get_results_aiter_success():
     """Subscription description fetched, has the expected items."""
     async with Session() as session:
         client = SubscriptionsClient(session)
-        results = [res async for res in client.get_results("42")]
+        results = [res async for res in client.get_results_aiter("42")]
         assert len(results) == 100
 
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #706 

Moves to wontfix: #476 and #779

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. The following functions which handle paged results were changed to async generator functions and renamed:
  * OrdersClient.list_orders -> list_orders_aiter
  * DataClient.search -> search_aiter
  * DataClient.run_search -> run_search_aiter
  * DataClient.list_searches -> list_searches_aiter
3. The following were renamed to clarify that they are async generator functions:
  * SubscriptionsClient.list_subscription_results -> list_subscription_results_aiter
  * SubscriptionsClient.list_subscriptions -> list_subscriptions_aiter

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

e.g. for OrdersClient.list_orders:

```python
orders = await cl.list_orders()
orders_list = [o async for o in orders]
```

New behavior:

*note that cl.list_orders_aiter() is not awaited*

```python
orders_aiter = cl.list_orders_aiter()
orders_list = [o async for o in orders_aiter]
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@JuLeeAtPlanet @cholmes 