### PR TITLE
Clarify auth source, CLI only sources from config file

### DIFF
--- a/docs/get-started/quick-start-guide.md
+++ b/docs/get-started/quick-start-guide.md
@@ -83,8 +83,8 @@ And you can see that the value was stored successfully as an environment variabl
 echo $PL_API_KEY
 ```
 
-!!!note "The API Key environment variable is always used first in the Planet SDK"
-    If you do create a `PL_API_KEY` environment variable, the SDK will use this value. `PL_API_KEY` overrides the value that was retrieved using your Planet login with a call to `planet auth init`. The `planet auth value` call currently does not reflect that `PL_API_KEY` overrides the `auth init` value (this should be fixed in 2.0-beta.1 with [issue 643](https://github.com/planetlabs/planet-client-python/issues/643))
+!!!note "The API Key environment variable is ignored by the CLI but used by the Python library"
+    If you do create a `PL_API_KEY` environment variable, the CLI will be unaffected but the Planet library will use this as the source for authorization instead of the value stored in `planet auth init`.
 
 ## Step 5: Search for Planet Imagery
 

--- a/docs/python/sdk-guide.md
+++ b/docs/python/sdk-guide.md
@@ -46,15 +46,18 @@ asyncio.run(main())
 
 ## Authenticate with Planet services
 
-There are two steps to managing authentication information, obtaining the
-authentication information from Planet and then managing it for local retrieval
-for authentication purposes.
+A `Session` requires authentication to communicate with Planet services. This
+authentication information is retrieved when a `Session` is created. By default,
+a `Session` obtains authorization from the following sources with order
+indicating priority:
 
-The recommended method for obtaining authentication information is through
-logging in, using `Auth.from_login()` (note: using something like the `getpass`
-module is recommended to ensure your password remains secure). Alternatively,
-the api key can be obtained directly from the Planet account site and then used
-in `Auth.from_key()`.
+1. The environment variable `PL_API_KEY`
+2. The secret file
+
+The SDK provides the `auth.Auth` class for managing authentication information.
+This module can be used to obtain authentication information from username
+and password with `Auth.from_login()`. Additionally, it can be created with
+the API key obtained directly from the Planet account site with `Auth.from_key(<API_KEY>)`.
 
 Once the authentication information is obtained, the most convenient way of
 managing it for local use is to write it to a secret file using `Auth.write()`.
@@ -69,16 +72,15 @@ from planet import Auth
 
 pw = getpass.getpass()
 auth = Auth.from_login('user', 'pw')
-auth.write()
+auth.store()
 
 ```
 
-When a `Session` is created, by default, authentication is read from the secret
-file created with `Auth.write()`. This behavior can be modified by specifying
+The default authentication behavior of the `Session` can be modified by specifying
 `Auth` explicitly using the methods `Auth.from_file()` and `Auth.from_env()`.
 While `Auth.from_key()` and `Auth.from_login` can be used, it is recommended
 that those functions be used in authentication initialization and the
-authentication information be stored using `Auth.write()`.
+authentication information be stored using `Auth.store()`.
 
 The file and environment variable read from can be customized in the
 respective functions. For example, authentication can be read from a custom

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -134,9 +134,9 @@ class Auth(metaclass=abc.ABCMeta):
     def to_dict(self) -> dict:
         pass
 
-    def write(self,
+    def store(self,
               filename: Optional[typing.Union[str, pathlib.Path]] = None):
-        '''Write authentication information.
+        '''Store authentication information in secret file.
 
         Parameters:
             filename: Alternate path for the planet secret file.

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -25,14 +25,13 @@ import httpx
 import jwt
 
 from . import http
-from .constants import PLANET_BASE_URL, SECRET_FILE_PATH
+from .constants import ENV_API_KEY, PLANET_BASE_URL, SECRET_FILE_PATH
 from .exceptions import AuthException
 from typing import Optional
 
 LOGGER = logging.getLogger(__name__)
 
 BASE_URL = f'{PLANET_BASE_URL}/v0/auth'
-ENV_API_KEY = 'PL_API_KEY'
 
 AuthType = httpx.Auth
 

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -57,3 +57,13 @@ def init(ctx, email, password):
 def value():
     '''Print the stored authentication information'''
     click.echo(planet.Auth.from_file().value)
+
+
+@auth.command()
+@translate_exceptions
+@click.argument('key')
+def set(key):
+    '''Store authentication information'''
+    plauth = planet.Auth.from_key(key)
+    plauth.write()
+    click.echo('Updated')

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -68,7 +68,7 @@ def value():
 @auth.command()
 @translate_exceptions
 @click.argument('key')
-def set(key):
+def store(key):
     '''Store authentication information'''
     plauth = planet.Auth.from_key(key)
     if click.confirm('This overrides the stored value. Continue?'):

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -50,7 +50,7 @@ def init(ctx, email, password):
     '''Obtain and store authentication information'''
     base_url = ctx.obj['BASE_URL']
     plauth = planet.Auth.from_login(email, password, base_url=base_url)
-    plauth.write()
+    plauth.store()
     click.echo('Initialized')
     if os.getenv(ENV_API_KEY):
         click.echo(f'Warning - Environment variable {ENV_API_KEY} already '
@@ -72,7 +72,7 @@ def store(key):
     '''Store authentication information'''
     plauth = planet.Auth.from_key(key)
     if click.confirm('This overrides the stored value. Continue?'):
-        plauth.write()
+        plauth.store()
         click.echo('Updated')
         if os.getenv(ENV_API_KEY):
             click.echo(f'Warning - Environment variable {ENV_API_KEY} already '

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Auth API CLI"""
 import logging
+import os
 
 import click
 
 import planet
+from planet.constants import ENV_API_KEY
 from .cmds import translate_exceptions
 
 LOGGER = logging.getLogger(__name__)
@@ -50,6 +52,10 @@ def init(ctx, email, password):
     plauth = planet.Auth.from_login(email, password, base_url=base_url)
     plauth.write()
     click.echo('Initialized')
+    if os.getenv(ENV_API_KEY):
+        click.echo(f'Warning - Environment variable {ENV_API_KEY} already '
+                   'exists. To update, with the new value, use the following:')
+        click.echo(f'export {ENV_API_KEY}=$(planet auth value)')
 
 
 @auth.command()
@@ -65,5 +71,11 @@ def value():
 def set(key):
     '''Store authentication information'''
     plauth = planet.Auth.from_key(key)
-    plauth.write()
-    click.echo('Updated')
+    if click.confirm('This overrides the stored value. Continue?'):
+        plauth.write()
+        click.echo('Updated')
+        if os.getenv(ENV_API_KEY):
+            click.echo(f'Warning - Environment variable {ENV_API_KEY} already '
+                       'exists. To update, with the new value, use the '
+                       'following:')
+            click.echo(f'export {ENV_API_KEY}=$(planet auth value)')

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -37,10 +37,8 @@ valid_item_string = "Valid entries for ITEM_TYPES: " + "|".join(ALL_ITEM_TYPES)
 
 @asynccontextmanager
 async def data_client(ctx):
-    auth = ctx.obj['AUTH']
-    base_url = ctx.obj['BASE_URL']
-    async with CliSession(auth=auth) as sess:
-        cl = DataClient(sess, base_url=base_url)
+    async with CliSession() as sess:
+        cl = DataClient(sess, base_url=ctx.obj['BASE_URL'])
         yield cl
 
 
@@ -52,7 +50,6 @@ async def data_client(ctx):
               help='Assign custom base Orders API URL.')
 def data(ctx, base_url):
     '''Commands for interacting with the Data API'''
-    ctx.obj['AUTH'] = None
     ctx.obj['BASE_URL'] = base_url
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -31,9 +31,8 @@ LOGGER = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def orders_client(ctx):
-    auth = ctx.obj['AUTH']
     base_url = ctx.obj['BASE_URL']
-    async with CliSession(auth=auth) as sess:
+    async with CliSession() as sess:
         cl = OrdersClient(sess, base_url=base_url)
         yield cl
 
@@ -46,7 +45,6 @@ async def orders_client(ctx):
               help='Assign custom base Orders API URL.')
 def orders(ctx, base_url):
     '''Commands for interacting with the Orders API'''
-    ctx.obj['AUTH'] = None
     ctx.obj['BASE_URL'] = base_url
 
 

--- a/planet/cli/session.py
+++ b/planet/cli/session.py
@@ -1,12 +1,11 @@
 """CLI HTTP/auth sessions."""
 
-from planet.auth import AuthType
+from planet.auth import Auth
 from planet.http import Session
-from typing import Optional
 
 
 class CliSession(Session):
-
-    def __init__(self, auth: Optional[AuthType] = None):
-        super().__init__(auth)
+    """Session with CLI-specific auth and identifying header"""
+    def __init__(self):
+        super().__init__(Auth.from_file())
         self._client.headers.update({'X-Planet-App': 'python-cli'})

--- a/planet/cli/session.py
+++ b/planet/cli/session.py
@@ -6,6 +6,7 @@ from planet.http import Session
 
 class CliSession(Session):
     """Session with CLI-specific auth and identifying header"""
+
     def __init__(self):
         super().__init__(Auth.from_file())
         self._client.headers.update({'X-Planet-App': 'python-cli'})

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -14,9 +14,7 @@ from planet.clients.subscriptions import SubscriptionsClient
 @click.pass_context
 def subscriptions(ctx):
     '''Commands for interacting with the Subscriptions API'''
-    # None means that order of precedence is 1) environment variable,
-    # 2) secret file.
-    ctx.obj['AUTH'] = None
+    pass
 
 
 # We want our command to be known as "list" on the command line but
@@ -40,7 +38,7 @@ def subscriptions(ctx):
 @coro
 async def list_subscriptions_cmd(ctx, status, limit, pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         subs_aiter = client.list_subscriptions_aiter(status=status,
                                                      limit=limit)
@@ -77,7 +75,7 @@ def parse_request(ctx, param, value: str) -> dict:
 @coro
 async def create_subscription_cmd(ctx, request, pretty):
     """Submits a subscription request and prints the API response."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         sub = await client.create_subscription(request)
         echo_json(sub, pretty)
@@ -91,7 +89,7 @@ async def create_subscription_cmd(ctx, request, pretty):
 @coro
 async def cancel_subscription_cmd(ctx, subscription_id, pretty):
     """Cancels a subscription and prints the API response."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         sub = await client.cancel_subscription(subscription_id)
         echo_json(sub, pretty)
@@ -106,7 +104,7 @@ async def cancel_subscription_cmd(ctx, subscription_id, pretty):
 @coro
 async def update_subscription_cmd(ctx, subscription_id, request, pretty):
     """Updates a subscription and prints the API response."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         sub = await client.update_subscription(subscription_id, request)
         echo_json(sub, pretty)
@@ -120,7 +118,7 @@ async def update_subscription_cmd(ctx, subscription_id, request, pretty):
 @coro
 async def describe_subscription_cmd(ctx, subscription_id, pretty):
     """Gets the description of a subscription and prints the API response."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         sub = await client.get_subscription(subscription_id)
         echo_json(sub, pretty)
@@ -156,7 +154,7 @@ async def list_subscription_results_cmd(ctx,
                                         status,
                                         limit):
     """Gets results of a subscription and prints the API response."""
-    async with CliSession(auth=ctx.obj['AUTH']) as session:
+    async with CliSession() as session:
         client = SubscriptionsClient(session)
         results_aiter = client.get_results_aiter(subscription_id,
                                                  status=status,

--- a/planet/constants.py
+++ b/planet/constants.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 DATA_DIR = Path(os.path.dirname(__file__)) / 'data'
 
+ENV_API_KEY = 'PL_API_KEY'
+
 PLANET_BASE_URL = 'https://api.planet.com'
 
 SECRET_FILE_PATH = Path(os.path.expanduser('~')) / '.planet.json'

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -13,6 +13,7 @@
 # the License.
 from http import HTTPStatus
 import json
+import os
 
 from click.testing import CliRunner
 import httpx
@@ -106,8 +107,14 @@ def test_cli_auth_value_failure(redirect_secretfile):
         in result.output
 
 
-def test_cli_auth_set(redirect_secretfile):
-    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'])
+def test_cli_auth_set_cancel(redirect_secretfile):
+    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'], input='')
+    assert not result.exception
+    assert not os.path.isfile(redirect_secretfile)
+
+
+def test_cli_auth_set_confirm(redirect_secretfile):
+    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'], input='y')
     assert not result.exception
 
     with open(redirect_secretfile, 'r') as f:

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -107,14 +107,16 @@ def test_cli_auth_value_failure(redirect_secretfile):
         in result.output
 
 
-def test_cli_auth_set_cancel(redirect_secretfile):
-    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'], input='')
+def test_cli_auth_store_cancel(redirect_secretfile):
+    result = CliRunner().invoke(cli.main, ['auth', 'store', 'setval'],
+                                input='')
     assert not result.exception
     assert not os.path.isfile(redirect_secretfile)
 
 
-def test_cli_auth_set_confirm(redirect_secretfile):
-    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'], input='y')
+def test_cli_auth_store_confirm(redirect_secretfile):
+    result = CliRunner().invoke(cli.main, ['auth', 'store', 'setval'],
+                                input='y')
     assert not result.exception
 
     with open(redirect_secretfile, 'r') as f:

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -104,3 +104,11 @@ def test_cli_auth_value_failure(redirect_secretfile):
     assert result.exception
     assert 'Error: Auth information does not exist or is corrupted.' \
         in result.output
+
+
+def test_cli_auth_set(redirect_secretfile):
+    result = CliRunner().invoke(cli.main, ['auth', 'set', 'setval'])
+    assert not result.exception
+
+    with open(redirect_secretfile, 'r') as f:
+        assert json.load(f) == {'key': 'setval'}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -118,23 +118,23 @@ def test_Auth_from_login(monkeypatch):
     assert test_auth.value == auth_data
 
 
-def test_Auth_write_doesnotexist(tmp_path):
+def test_Auth_store_doesnotexist(tmp_path):
     test_auth = auth.Auth.from_key('test')
     secret_path = str(tmp_path / '.test')
-    test_auth.write(secret_path)
+    test_auth.store(secret_path)
 
     with open(secret_path, 'r') as fp:
         assert json.loads(fp.read()) == {"key": "test"}
 
 
-def test_Auth_write_exists(tmp_path):
+def test_Auth_store_exists(tmp_path):
     secret_path = str(tmp_path / '.test')
 
     with open(secret_path, 'w') as fp:
         fp.write('{"existing": "exists"}')
 
     test_auth = auth.Auth.from_key('test')
-    test_auth.write(secret_path)
+    test_auth.store(secret_path)
 
     with open(secret_path, 'r') as fp:
         assert json.loads(fp.read()) == {"key": "test", "existing": "exists"}

--- a/tests/unit/test_cli_session.py
+++ b/tests/unit/test_cli_session.py
@@ -1,0 +1,100 @@
+# Copyright 2022 Planet Labs PBC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+import base64
+from http import HTTPStatus
+import json
+
+import httpx
+import respx
+
+import pytest
+
+# from planet.auth import _SecretFile
+from planet import auth
+from planet.cli import session
+from planet.exceptions import AuthException
+
+TEST_URL = 'mock://mock.com'
+
+
+# skip the global mock of _SecretFile.read
+# for this module
+@pytest.fixture(autouse=True, scope='module')
+def test_secretfile_read():
+    return
+
+
+@pytest.fixture()
+def test_valid_secretfile(tmp_path, monkeypatch):
+    # write our own secret file
+    secret_path = f'{tmp_path}/secret.test'
+    monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
+    with open(secret_path, 'w') as fp:
+        json.dump({'key': 'clisessiontest'}, fp)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_CliSession_headers(test_valid_secretfile):
+    async with session.CliSession() as sess:
+        route = respx.get(TEST_URL)
+        route.return_value = httpx.Response(HTTPStatus.OK)
+
+        await sess.request(method='GET', url=TEST_URL)
+
+        # the proper headers are included and they have the expected values
+        received_request = route.calls.last.request
+        assert received_request.headers['x-planet-app'] == 'python-cli'
+        assert 'planet-client-python/' in received_request.headers[
+            'user-agent']
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_CliSession_auth_valid(test_valid_secretfile):
+    async with session.CliSession() as sess:
+        route = respx.get(TEST_URL)
+        route.return_value = httpx.Response(HTTPStatus.OK)
+
+        await sess.request(method='GET', url=TEST_URL)
+
+        # the proper headers are included and they have the expected values
+        received_request = route.calls.last.request
+        credentials = received_request.headers['authorization'].strip(
+            'Authorization: Basic ')
+        assert base64.b64decode(credentials) == b'clisessiontest:'
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_CliSession_auth_invalid(tmp_path, monkeypatch):
+    # write invalid secret file
+    secret_path = f'{tmp_path}/secret.test'
+    monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
+    with open(secret_path, 'w') as fp:
+        json.dump({'invalidkey': 'clisessiontest'}, fp)
+
+    with pytest.raises(AuthException):
+        session.CliSession()
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_CliSession_auth_nofile(tmp_path, monkeypatch):
+    # point to non-existant file
+    secret_path = f'{tmp_path}/doesnotexist.test'
+    monkeypatch.setattr(auth, 'SECRET_FILE_PATH', secret_path)
+
+    with pytest.raises(AuthException):
+        session.CliSession()


### PR DESCRIPTION
**Related Issue(s):**

Closes #808 and #699 and #396


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. CLI now obtains authorization from secret file exclusively.
2. Add `planet auth store` to allow storing authorization in the secret file. This command raises a confirmation prompt.
3. When `planet auth store` or `planet auth init` are used and the authorization environment variable exists, a warning message is printed with instructions for how to update the environment variable, if desired
4. `auth.Auth.write()` renamed to `auth.Auth.store()` to match CLI command

Not intended for changelog:

1. `CliSession()` now manages authorization information in addition to headers instead of managing authorization information in Click context. This has the benefit of only obtaining authorization when a `CliSession()` is created so not every time something like `planet data --help` is called.
2. Add tests for `CLISession()` to ensure auth information is obtained from the file and that expected headers are sent.
3. Update docs on CLI and SDK authorization priorities. I still think that CLI authorization needs its own section, similar to SDK, so this information can be looked up quickly.

**Diff of User Interface**

Scenario 1: Authorization environment variable exists with value `ENVAPIKEY` and config file exists with value `CONFIGAPIKEY`

Old behavior:

```console
$ planet auth value
ENVAPIKEY
```

New behavior:

```console
$ planet auth value
CONFIGAPIKEY
```

Scenario 2: Authorization environment variable exists. It is desired to update the config file

Old behavior:

```console
$ planet auth init
Email: email
Password: 
Initialized
```

New behavior:

```console
$ planet auth init
Email: email
Password: 
Initialized
Warning - Environment variable PL_API_KEY already exists. To update, with the new value, use the following:
export PL_API_KEY=$(planet auth value)
```

Scenario 3: It is desired to update the config file authorization from the environment variable.

Old behavior:

```python
from planet.auth import Auth

Auth.from_env().write()
```

New behavior:

```python
from planet.auth import Auth

Auth.from_env().store()
```

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**