### PR TITLE
Allow httpx>=0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('planet/__version__.py') as f:
 install_requires = [
     'click>=8.0.0',
     'geojson',
-    'httpx==0.23.0',
+    'httpx>=0.23',
     'jsonschema',
     'pyjwt>=2.1',
     'tqdm>=4.56',


### PR DESCRIPTION
So that users can use httpx 0.23.1 etc.

Packages like planet can't fix the upper end of requirement specs. If they do, they can be uninstallable from time to time.