### PR TITLE
fixed broken link to Quick Start Guide #818

### DIFF
--- a/docs/get-started/get-your-planet-account.md
+++ b/docs/get-started/get-your-planet-account.md
@@ -31,5 +31,5 @@ After you’ve installed the Planet SDK, you can authenticate with the Planet se
 
 ## Next steps
 
-Now that you have confirmed your Planet account username and password, you can take the other steps in the [Quick Start](quick-start-guide). 
+Now that you have confirmed your Planet account username and password, you can take the other steps in the [Quick Start](../quick-start-guide). 
 

--- a/docs/get-started/get-your-planet-account.md
+++ b/docs/get-started/get-your-planet-account.md
@@ -31,5 +31,4 @@ After you’ve installed the Planet SDK, you can authenticate with the Planet se
 
 ## Next steps
 
-Now that you have confirmed your Planet account username and password, you can take the other steps in the [Quick Start](../quick-start-guide). 
-
+Now that you have confirmed your Planet account username and password, you can take the other steps in the [Quick Start](../quick-start-guide).


### PR DESCRIPTION
**Related Issue(s):**

Closes #818


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. n/a

Not intended for changelog:

1. 

**Diff of User Interface**


Old behavior
The "Quick Start Guide" link at the bottom of the following page is broken:

https://planet-sdk-for-python-v2.readthedocs.io/en/latest/cli/cli-guide/#cli-set-up

new behavior

It points to:

https://planet-sdk-for-python-v2.readthedocs.io/en/latest/get-started/quick-start-guide/





**PR Checklist:**

- [x] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
