### PR TITLE
fix status value options in subscriptions CLI

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -24,8 +24,15 @@ def subscriptions(ctx):
 @click.option('--pretty', is_flag=True, help='Pretty-print output.')
 @click.option(
     '--status',
-    type=click.Choice(["created", "queued", "processing", "failed",
-                       "success"]),
+    type=click.Choice([
+        "running",
+        "cancelled",
+        "preparing",
+        "pending",
+        "completed",
+        "suspended",
+        "failed"
+    ]),
     multiple=True,
     default=None,
     help="Select subscriptions in one or more states. Default is all.")

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -26,7 +26,7 @@ failing_api_mock.route(
 
 def result_pages(status=None, size=40):
     """Helper for creating fake subscriptions listing pages."""
-    all_subs = [{'id': str(i), 'status': 'created'} for i in range(1, 101)]
+    all_subs = [{'id': str(i), 'status': 'running'} for i in range(1, 101)]
     select_subs = (sub for sub in all_subs
                    if not status or sub['status'] in status)
     pages = []
@@ -47,11 +47,11 @@ def result_pages(status=None, size=40):
 # must disable the default.
 api_mock = respx.mock(assert_all_called=False)
 
-# 1. Request for status: created. Response has three pages.
+# 1. Request for status: running. Response has three pages.
 api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
-               M(params__contains={'status': 'created'})).mock(side_effect=[
+               M(params__contains={'status': 'running'})).mock(side_effect=[
                    Response(200, json=page)
-                   for page in result_pages(status={'created'}, size=40)
+                   for page in result_pages(status={'running'}, size=40)
                ])
 
 # 2. Request for status: failed. Response has a single empty page.
@@ -59,9 +59,9 @@ api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
                M(params__contains={'status': 'failed'})).mock(
                    side_effect=[Response(200, json={'subscriptions': []})])
 
-# 3. Request for status: queued. Response has a single empty page.
+# 3. Request for status: preparing. Response has a single empty page.
 api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
-               M(params__contains={'status': 'queued'})).mock(
+               M(params__contains={'status': 'preparing'})).mock(
                    side_effect=[Response(200, json={'subscriptions': []})])
 
 # 4. No status requested. Response is the same as for 1.
@@ -164,7 +164,7 @@ async def test_list_subscriptions_failure():
             _ = [sub async for sub in client.list_subscriptions()]
 
 
-@pytest.mark.parametrize("status, count", [({"created"}, 100), ({"failed"}, 0),
+@pytest.mark.parametrize("status, count", [({"running"}, 100), ({"failed"}, 0),
                                            (None, 100)])
 @pytest.mark.asyncio
 @api_mock

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -37,10 +37,10 @@ from test_subscriptions_api import (api_mock,
 #
 # does not work.
 @pytest.mark.parametrize('options,expected_count',
-                         [(['--status=created'], 100), ([], 100),
-                          (['--limit=1', '--status=created'], 1),
-                          (['--limit=2', '--pretty', '--status=created'], 2),
-                          (['--limit=1', '--status=queued'], 0)])
+                         [(['--status=running'], 100), ([], 100),
+                          (['--limit=1', '--status=running'], 1),
+                          (['--limit=2', '--pretty', '--status=running'], 2),
+                          (['--limit=1', '--status=preparing'], 0)])
 @api_mock
 # Remember, parameters come before fixtures in the function definition.
 def test_subscriptions_list_options(options, expected_count):


### PR DESCRIPTION
**Related Issue(s):**

Closes # 815


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. fix status value options in `planet subscriptions list`

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet-client-python$> planet subscriptions list --limit 1 | jq .status
"running"
planet-client-python$> planet subscriptions list --status running
Usage: planet subscriptions list [OPTIONS]
Try 'planet subscriptions list --help' for help.

Error: Invalid value for '--status': 'running' is not one of 'created', 'queued', 'processing', 'failed', 'success'.
planet-client-python$> planet subscriptions list --status success
Error: {"error":{"reason":"Request failed schema validation","details":["parameter 'status' in query has an error: JSON value is not one of the allowed values"]}}
```

New behavior:

```console
planet-client-python$> planet subscriptions list --status running
{"name": "test", "source": {"type": "catalog", "parameters": {"asset_types": ["ortho_visual"], "end_time": "2023-11-01T00:00:00Z", "geometry": <REDACTED>, "type": "Polygon"}, "item_types": ["SkySatCollect"], "start_time": "2018-10-01T00:00:00Z"}}, "tools": [{"type": "clip", "parameters": {"aoi": {"coordinates": <REDACTED>, "type": "Polygon"}}}], "delivery": {"type": "google_cloud_storage", "parameters": {"bucket": "<REDACTED>", "credentials": "<REDACTED>"}}, "created": "2022-11-17T20:41:01.094277Z", "_links": {"_self": "https://api.planet.com/subscriptions/v1/abebfd94-4845-46a1-a96e-a911ca9dbf9b"}, "status": "running", "id": "abebfd94-4845-46a1-a96e-a911ca9dbf9b", "updated": "2022-11-17T20:41:10.158928Z"}
```
```console
planet-client-python$> planet subscriptions list --status invalid
Usage: planet subscriptions list [OPTIONS]
Try 'planet subscriptions list --help' for help.

Error: Invalid value for '--status': 'invalid' is not one of 'running', 'cancelled', 'preparing', 'pending', 'completed', 'suspended', 'failed'.
```

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
