### PR TITLE
release-2.0.0-beta.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,24 @@
+2.0.0-beta.1 (2022-12-07)
+
+Changed:
+- Auth.write() renamed to Auth.store() to match CLI command
+- CLI now only sources from the configuration file
+- the following functions were changed to generator functions and therefore no
+longer require awaits: OrdersClient.list_orders, DataClient.search,
+DataClient.run_search, SubscriptionsClient.list_results,
+SubscriptionsClient.list_subscriptions
+
+Added:
+- support for Sentinel-2 as a target in the harminization tool in
+orders_request
+- `planet auth store` CLI command for storing authentication info
+in the configuration file
+
+Fixed:
+- status option for list_subscriptions now works
+- subscriptions list_results now returns more than the first page
+
+
 2.0a6 (2022-11-10)
 
 - Add SDK identification headers to communication with servers (#754).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ DataClient.run_search, SubscriptionsClient.list_results,
 SubscriptionsClient.list_subscriptions
 
 Added:
-- support for Sentinel-2 as a target in the harminization tool in
+- support for Sentinel-2 as a target in the harmonization tool in
 orders_request
 - `planet auth store` CLI command for storing authentication info
 in the configuration file

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,9 @@ Changed:
 - the following functions were changed to generator functions and therefore no
 longer require awaits: OrdersClient.list_orders, DataClient.search,
 DataClient.run_search, SubscriptionsClient.list_results,
-SubscriptionsClient.list_subscriptions
+SubscriptionsClient.list_subscriptions.
+- - CLI command planet orders request arguments have changed so only IDs is
+positional, all others are flags.
 
 Added:
 - support for Sentinel-2 as a target in the harmonization tool in

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ The following are the release naming conventions:
 1. Current Dev Version is obtained from `planet/__version__.py`
 3. Release Version: Remove `dev` from Current Dev Version
 4. Next Dev Version: Bumped version of last release with `dev` added to the end.
-    * **PROPOSAL**: Version number is determined by [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+    * Bumped version number is determined by [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 
 ##### Example:
@@ -30,16 +30,16 @@ The release on Github and PyPi performed from a release branch while the release
 1. Make the following changes for the release
   * Update `CHANGES.txt` (**PROPOSAL**: change this to `docs/CHANGELOG.md`)
     * Include added, changed, depricated or removed features and bug fixes.
-       A list of merged PRs and their titles since the last release can be obtained with `git log <LAST_RELEASE_TAG>..HEAD | awk '/Merge pull request/{print;getline;getline;print}`.
+       A list of merged PRs and their titles since the last release can be obtained with `git log $PREVIOUS_RELEASE_TAG..HEAD | awk '/Merge pull request/{print;getline;getline;print}`.
     * Sort according to importance
     * **PROPOSAL**: Adhere to [Keep a Changelog](https://keepachangelog.com/)
   * Update `planet/__version__.py` to Release Version
 1. Create a PR for the release branch (named after release branch, description is changelog entry), wait for CI to pass
 1. Create a new github release:
-  * Set Tag Release Version
+  * Set Tag to Release Version
   * **!!!** Set Target to the release branch **!!!**
   * Set Title to Tag Release Version
-  * Copy Description from the new entry in `docs/CHANGELOG.md`
+  * Copy Description from the new entry in the changelog
   * Select "This is a pre-release" if applicable
 1. Verify the successful run of the Github Action "Autopublish to TestPyPi" and validate the test release on [test.pypi.org](https://test.pypi.org/project/planet/)
 1. Run the Github Action "Publish on PyPi", **!!!** Set Branch to the release branch **!!!**

--- a/planet/__version__.py
+++ b/planet/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.0-beta.1'
+__version__ = '2.0.0-beta.2dev'

--- a/planet/__version__.py
+++ b/planet/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '2.0a7dev'
+__version__ = '2.0.0-beta.1'


### PR DESCRIPTION
2.0.0-beta.1 (2022-12-07)

Changed:
- Auth.write() renamed to Auth.store() to match CLI command
- CLI now only sources from the configuration file
- the following functions were changed to generator functions and therefore no
longer require awaits: OrdersClient.list_orders, DataClient.search,
DataClient.run_search, SubscriptionsClient.list_results,
SubscriptionsClient.list_subscriptions

Added:
- support for Sentinel-2 as a target in the harmonization tool in
orders_request
- `planet auth store` CLI command for storing authentication info
in the configuration file

Fixed:
- status option for list_subscriptions now works
- subscriptions list_results now returns more than the first page