### PR TITLE
Remove null printout from CLI subscriptions cancel command

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -96,8 +96,7 @@ async def cancel_subscription_cmd(ctx, subscription_id, pretty):
     """Cancels a subscription and prints the API response."""
     async with CliSession() as session:
         client = SubscriptionsClient(session)
-        sub = await client.cancel_subscription(subscription_id)
-        echo_json(sub, pretty)
+        _ = await client.cancel_subscription(subscription_id)
 
 
 @subscriptions.command(name='update')


### PR DESCRIPTION
**Related Issue(s):**

Closes #778 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Remove null printout from CLI subscriptions cancel command

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```
> planet subscriptions cancel c3195b51-518d-42dc-ad5e-b2ff127070b4
null
```

New behavior:

```
> planet subscriptions cancel c3195b51-518d-42dc-ad5e-b2ff127070b4
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
