### PR TITLE
Add support for base_url in subscriptions client

### DIFF
--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -13,12 +13,16 @@ from planet.clients.subscriptions import SubscriptionsClient
 from planet.exceptions import APIError, PagingError, ServerError
 from planet.http import Session
 
+# M(url=TEST_URL) is case sensitive and matching a lower-case url, and it
+# requires that there not be a '/'
+TEST_URL = 'http://www.mocknotrealurl.com/api/path'
+
 # Mock router representing an API that returns only a 500
 # internal server error. The router is configured outside the test
 # to help keep our test more readable.
 failing_api_mock = respx.mock()
 failing_api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1')).mock(
+    M(url__startswith=TEST_URL)).mock(
         return_value=Response(500, json={
             "code": 0, "message": "string"
         }))
@@ -36,7 +40,7 @@ def result_pages(status=None, size=40):
         pm = datetime.now().isoformat()
         if len(subs) == size:
             page['_links'][
-                'next'] = f'https://api.planet.com/subscriptions/v1?pm={pm}'
+                'next'] = f'{TEST_URL}?pm={pm}'
         pages.append(page)
     return pages
 
@@ -48,25 +52,26 @@ def result_pages(status=None, size=40):
 api_mock = respx.mock(assert_all_called=False)
 
 # 1. Request for status: running. Response has three pages.
-api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
+api_mock.route(M(url=TEST_URL),
                M(params__contains={'status': 'running'})).mock(side_effect=[
                    Response(200, json=page)
                    for page in result_pages(status={'running'}, size=40)
                ])
 
+
 # 2. Request for status: failed. Response has a single empty page.
-api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
+api_mock.route(M(url=TEST_URL),
                M(params__contains={'status': 'failed'})).mock(
                    side_effect=[Response(200, json={'subscriptions': []})])
 
 # 3. Request for status: preparing. Response has a single empty page.
-api_mock.route(M(url__startswith='https://api.planet.com/subscriptions/v1'),
+api_mock.route(M(url=TEST_URL),
                M(params__contains={'status': 'preparing'})).mock(
                    side_effect=[Response(200, json={'subscriptions': []})])
 
 # 4. No status requested. Response is the same as for 1.
 api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1')
+    M(url=TEST_URL)
 ).mock(
     side_effect=[Response(200, json=page) for page in result_pages(size=40)])
 
@@ -82,25 +87,20 @@ def modify_response(request):
 
 
 create_mock = respx.mock()
-create_mock.route(host='api.planet.com',
-                  path='/subscriptions/v1',
+create_mock.route(M(url=TEST_URL),
                   method='POST').mock(side_effect=modify_response)
 
 update_mock = respx.mock()
-update_mock.route(host='api.planet.com',
-                  path__regex=r'^/subscriptions/v1/(\w+)',
+update_mock.route(M(url=f'{TEST_URL}/test'),
                   method='PUT').mock(side_effect=modify_response)
 
 cancel_mock = respx.mock()
-cancel_mock.route(host='api.planet.com',
-                  path__regex=r'^/subscriptions/v1/(\w+)/cancel',
+cancel_mock.route(M(url=f'{TEST_URL}/test/cancel'),
                   method='POST').mock(side_effect=modify_response)
 
 # Mock the subscription description API endpoint.
 describe_mock = respx.mock()
-describe_mock.route(
-    host='api.planet.com',
-    path__regex=r'^/subscriptions/v1/(\w+)',
+describe_mock.route(M(url=f'{TEST_URL}/test'),
     method='GET').mock(return_value=Response(200,
                                              json={
                                                  'id': '42',
@@ -121,7 +121,7 @@ def result_pages(status=None, size=40):
         page = {'results': results, '_links': {}}
         pm = datetime.now().isoformat()
         if len(results) == size:
-            url = f'https://api.planet.com/subscriptions/v1/42/results?pm={pm}'
+            url = f'{TEST_URL}/42/results?pm={pm}'
             page['_links']['next'] = url
         pages.append(page)
     return pages
@@ -135,7 +135,7 @@ res_api_mock = respx.mock(assert_all_called=False)
 
 # 1. Request for status: created. Response has three pages.
 res_api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1'),
+    M(url__startswith=TEST_URL),
     M(params__contains={'status': 'created'})).mock(side_effect=[
         Response(200, json=page)
         for page in result_pages(status={'created'}, size=40)
@@ -143,13 +143,13 @@ res_api_mock.route(
 
 # 2. Request for status: queued. Response has a single empty page.
 res_api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1'),
+    M(url__startswith=TEST_URL),
     M(params__contains={'status': 'queued'})).mock(
         side_effect=[Response(200, json={'results': []})])
 
 # 3. No status requested. Response is the same as for 1.
 res_api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1')
+    M(url__startswith=TEST_URL)
 ).mock(
     side_effect=[Response(200, json=page) for page in result_pages(size=40)])
 
@@ -160,7 +160,7 @@ async def test_list_subscriptions_failure():
     """ServerError is raised if there is an internal server error (500)."""
     with pytest.raises(ServerError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = [sub async for sub in client.list_subscriptions()]
 
 
@@ -174,7 +174,7 @@ async def test_list_subscriptions_success(
 ):
     """Account subscriptions iterator yields expected descriptions."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         assert len([
             sub async for sub in client.list_subscriptions(status=status)
         ]) == count
@@ -186,7 +186,7 @@ async def test_create_subscription_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(ServerError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = await client.create_subscription({"lol": "wut"})
 
 
@@ -195,7 +195,7 @@ async def test_create_subscription_failure():
 async def test_create_subscription_success():
     """Subscription is created, description has the expected items."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         sub = await client.create_subscription({
             'name': 'test', 'delivery': 'yes, please', 'source': 'test'
         })
@@ -208,7 +208,7 @@ async def test_cancel_subscription_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(ServerError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = await client.cancel_subscription("lolwut")
 
 
@@ -217,7 +217,7 @@ async def test_cancel_subscription_failure():
 async def test_cancel_subscription_success():
     """Subscription is canceled, description has the expected items."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         _ = await client.cancel_subscription("test")
 
 
@@ -227,7 +227,7 @@ async def test_update_subscription_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(ServerError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = await client.update_subscription("lolwut", {})
 
 
@@ -236,7 +236,7 @@ async def test_update_subscription_failure():
 async def test_update_subscription_success():
     """Subscription is created, description has the expected items."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         sub = await client.update_subscription(
             "test", {
                 'name': 'test', 'delivery': "no, thanks", 'source': 'test'
@@ -250,7 +250,7 @@ async def test_get_subscription_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(ServerError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = await client.get_subscription("lolwut")
 
 
@@ -259,7 +259,7 @@ async def test_get_subscription_failure():
 async def test_get_subscription_success(monkeypatch):
     """Subscription description fetched, has the expected items."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         sub = await client.get_subscription("test")
         assert sub['delivery'] == "yes, please"
 
@@ -270,7 +270,7 @@ async def test_get_results_failure():
     """APIError is raised if there is a server error."""
     with pytest.raises(APIError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = [res async for res in client.get_results("lolwut")]
 
 
@@ -279,7 +279,7 @@ async def test_get_results_failure():
 async def test_get_results_success():
     """Subscription description fetched, has the expected items."""
     async with Session() as session:
-        client = SubscriptionsClient(session)
+        client = SubscriptionsClient(session, base_url=TEST_URL)
         results = [res async for res in client.get_results("42")]
         assert len(results) == 100
 
@@ -288,7 +288,7 @@ paging_cycle_api_mock = respx.mock()
 
 # Identical next links is a hangup we want to avoid.
 paging_cycle_api_mock.route(
-    M(url__startswith='https://api.planet.com/subscriptions/v1')).mock(
+    M(url__startswith=TEST_URL)).mock(
         side_effect=[
             Response(200,
                      json={
@@ -296,7 +296,7 @@ paging_cycle_api_mock.route(
                              'id': '1'
                          }],
                          '_links': {
-                             "next": 'https://api.planet.com/subscriptions/v1'
+                             "next": TEST_URL
                          }
                      }),
             Response(200,
@@ -305,7 +305,7 @@ paging_cycle_api_mock.route(
                              'id': '2'
                          }],
                          '_links': {
-                             "next": 'https://api.planet.com/subscriptions/v1'
+                             "next": TEST_URL
                          }
                      })
         ])
@@ -317,5 +317,5 @@ async def test_list_subscriptions_cycle_break():
     """PagingError is raised if there is a paging cycle."""
     with pytest.raises(PagingError):
         async with Session() as session:
-            client = SubscriptionsClient(session)
+            client = SubscriptionsClient(session, base_url=TEST_URL)
             _ = [sub async for sub in client.list_subscriptions()]

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -21,11 +21,10 @@ TEST_URL = 'http://www.mocknotrealurl.com/api/path'
 # internal server error. The router is configured outside the test
 # to help keep our test more readable.
 failing_api_mock = respx.mock()
-failing_api_mock.route(
-    M(url__startswith=TEST_URL)).mock(
-        return_value=Response(500, json={
-            "code": 0, "message": "string"
-        }))
+failing_api_mock.route(M(url__startswith=TEST_URL)).mock(
+    return_value=Response(500, json={
+        "code": 0, "message": "string"
+    }))
 
 
 def result_pages(status=None, size=40):
@@ -39,8 +38,7 @@ def result_pages(status=None, size=40):
         page = {'subscriptions': subs, '_links': {}}
         pm = datetime.now().isoformat()
         if len(subs) == size:
-            page['_links'][
-                'next'] = f'{TEST_URL}?pm={pm}'
+            page['_links']['next'] = f'{TEST_URL}?pm={pm}'
         pages.append(page)
     return pages
 
@@ -58,11 +56,9 @@ api_mock.route(M(url=TEST_URL),
                    for page in result_pages(status={'running'}, size=40)
                ])
 
-
 # 2. Request for status: failed. Response has a single empty page.
-api_mock.route(M(url=TEST_URL),
-               M(params__contains={'status': 'failed'})).mock(
-                   side_effect=[Response(200, json={'subscriptions': []})])
+api_mock.route(M(url=TEST_URL), M(params__contains={'status': 'failed'})).mock(
+    side_effect=[Response(200, json={'subscriptions': []})])
 
 # 3. Request for status: preparing. Response has a single empty page.
 api_mock.route(M(url=TEST_URL),
@@ -70,9 +66,7 @@ api_mock.route(M(url=TEST_URL),
                    side_effect=[Response(200, json={'subscriptions': []})])
 
 # 4. No status requested. Response is the same as for 1.
-api_mock.route(
-    M(url=TEST_URL)
-).mock(
+api_mock.route(M(url=TEST_URL)).mock(
     side_effect=[Response(200, json=page) for page in result_pages(size=40)])
 
 
@@ -100,7 +94,8 @@ cancel_mock.route(M(url=f'{TEST_URL}/test/cancel'),
 
 # Mock the subscription description API endpoint.
 describe_mock = respx.mock()
-describe_mock.route(M(url=f'{TEST_URL}/test'),
+describe_mock.route(
+    M(url=f'{TEST_URL}/test'),
     method='GET').mock(return_value=Response(200,
                                              json={
                                                  'id': '42',
@@ -142,15 +137,12 @@ res_api_mock.route(
     ])
 
 # 2. Request for status: queued. Response has a single empty page.
-res_api_mock.route(
-    M(url__startswith=TEST_URL),
-    M(params__contains={'status': 'queued'})).mock(
-        side_effect=[Response(200, json={'results': []})])
+res_api_mock.route(M(url__startswith=TEST_URL),
+                   M(params__contains={'status': 'queued'})).mock(
+                       side_effect=[Response(200, json={'results': []})])
 
 # 3. No status requested. Response is the same as for 1.
-res_api_mock.route(
-    M(url__startswith=TEST_URL)
-).mock(
+res_api_mock.route(M(url__startswith=TEST_URL)).mock(
     side_effect=[Response(200, json=page) for page in result_pages(size=40)])
 
 
@@ -287,28 +279,24 @@ async def test_get_results_success():
 paging_cycle_api_mock = respx.mock()
 
 # Identical next links is a hangup we want to avoid.
-paging_cycle_api_mock.route(
-    M(url__startswith=TEST_URL)).mock(
-        side_effect=[
-            Response(200,
-                     json={
-                         'subscriptions': [{
-                             'id': '1'
-                         }],
-                         '_links': {
-                             "next": TEST_URL
-                         }
-                     }),
-            Response(200,
-                     json={
-                         'subscriptions': [{
-                             'id': '2'
-                         }],
-                         '_links': {
-                             "next": TEST_URL
-                         }
-                     })
-        ])
+paging_cycle_api_mock.route(M(url__startswith=TEST_URL)).mock(side_effect=[
+    Response(200,
+             json={
+                 'subscriptions': [{
+                     'id': '1'
+                 }], '_links': {
+                     "next": TEST_URL
+                 }
+             }),
+    Response(200,
+             json={
+                 'subscriptions': [{
+                     'id': '2'
+                 }], '_links': {
+                     "next": TEST_URL
+                 }
+             })
+])
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -26,8 +26,8 @@ from test_subscriptions_api import (api_mock,
                                     update_mock,
                                     cancel_mock,
                                     describe_mock,
-                                    res_api_mock)
-
+                                    res_api_mock,
+                                    TEST_URL)
 
 # CliRunner doesn't agree with empty options, so a list of option
 # combinations which omit the empty options is best. For example,
@@ -36,6 +36,19 @@ from test_subscriptions_api import (api_mock,
 # CliRunner().invoke(cli.main, args=['subscriptions', 'list', limit]
 #
 # does not work.
+
+
+@pytest.fixture
+def invoke():
+
+    def _invoke(extra_args, runner=None, **kwargs):
+        runner = runner or CliRunner()
+        args = ['subscriptions', f'--base-url={TEST_URL}'] + extra_args
+        return runner.invoke(cli.main, args=args, **kwargs)
+
+    return _invoke
+
+
 @pytest.mark.parametrize('options,expected_count',
                          [(['--status=running'], 100), ([], 100),
                           (['--limit=1', '--status=running'], 1),
@@ -43,13 +56,11 @@ from test_subscriptions_api import (api_mock,
                           (['--limit=1', '--status=preparing'], 0)])
 @api_mock
 # Remember, parameters come before fixtures in the function definition.
-def test_subscriptions_list_options(options, expected_count):
+def test_subscriptions_list_options(invoke, options, expected_count):
     """Prints the expected sequence of subscriptions."""
     # While developing it is handy to have click's command invoker
     # *not* catch exceptions, so we can use the pytest --pdb option.
-    result = CliRunner().invoke(cli.main,
-                                args=['subscriptions', 'list'] + options,
-                                catch_exceptions=False)
+    result = invoke(['list'] + options, catch_exceptions=False)
     assert result.exit_code == 0  # success.
 
     # For a start, counting the number of "id" strings in the output
@@ -58,7 +69,7 @@ def test_subscriptions_list_options(options, expected_count):
 
 
 @failing_api_mock
-def test_subscriptions_create_failure():
+def test_subscriptions_create_failure(invoke):
     """An invalid subscription request fails to create a new subscription."""
     # This subscription request lacks the required "delivery" and
     # "source" members.
@@ -66,9 +77,8 @@ def test_subscriptions_create_failure():
 
     # The "-" argument says "read from stdin" and the input keyword
     # argument specifies what bytes go to the runner's stdin.
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'create', '-'],
+    result = invoke(
+        ['create', '-'],
         input=json.dumps(sub),
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
@@ -89,13 +99,12 @@ GOOD_SUB_REQUEST = {'name': 'lol', 'delivery': True, 'source': 'wut'}
                          [('-', json.dumps(GOOD_SUB_REQUEST)),
                           (json.dumps(GOOD_SUB_REQUEST), None)])
 @create_mock
-def test_subscriptions_create_success(cmd_arg, runner_input):
+def test_subscriptions_create_success(invoke, cmd_arg, runner_input):
     """Subscriptions creation succeeds with a valid subscription request."""
     # The "-" argument says "read from stdin" and the input keyword
     # argument specifies what bytes go to the runner's stdin.
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'create', cmd_arg],
+    result = invoke(
+        ['create', cmd_arg],
         input=runner_input,
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
@@ -111,13 +120,12 @@ BAD_SUB_REQUEST = '{0: "lolwut"}'
 
 @pytest.mark.parametrize('cmd_arg, runner_input', [('-', BAD_SUB_REQUEST),
                                                    (BAD_SUB_REQUEST, None)])
-def test_subscriptions_bad_request(cmd_arg, runner_input):
+def test_subscriptions_bad_request(invoke, cmd_arg, runner_input):
     """Short circuit and print help message if request is bad."""
     # The "-" argument says "read from stdin" and the input keyword
     # argument specifies what bytes go to the runner's stdin.
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'create', cmd_arg],
+    result = invoke(
+        ['create', cmd_arg],
         input=runner_input,
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
@@ -129,11 +137,10 @@ def test_subscriptions_bad_request(cmd_arg, runner_input):
 
 
 @failing_api_mock
-def test_subscriptions_cancel_failure():
+def test_subscriptions_cancel_failure(invoke):
     """Cancel command exits gracefully from an API error."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'cancel', '42'],
+    result = invoke(
+        ['cancel', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -143,11 +150,10 @@ def test_subscriptions_cancel_failure():
 
 
 @cancel_mock
-def test_subscriptions_cancel_success():
+def test_subscriptions_cancel_success(invoke):
     """Cancel command succeeds."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'cancel', '42'],
+    result = invoke(
+        ['cancel', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -157,11 +163,10 @@ def test_subscriptions_cancel_success():
 
 
 @failing_api_mock
-def test_subscriptions_update_failure():
+def test_subscriptions_update_failure(invoke):
     """Update command exits gracefully from an API error."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'update', '42', json.dumps(GOOD_SUB_REQUEST)],
+    result = invoke(
+        ['update', 'test', json.dumps(GOOD_SUB_REQUEST)],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -171,14 +176,13 @@ def test_subscriptions_update_failure():
 
 
 @update_mock
-def test_subscriptions_update_success():
+def test_subscriptions_update_success(invoke):
     """Update command succeeds."""
     request = GOOD_SUB_REQUEST.copy()
     request['name'] = 'new_name'
 
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'update', '42', json.dumps(request)],
+    result = invoke(
+        ['update', 'test', json.dumps(request)],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -189,11 +193,10 @@ def test_subscriptions_update_success():
 
 
 @failing_api_mock
-def test_subscriptions_describe_failure():
+def test_subscriptions_describe_failure(invoke):
     """Describe command exits gracefully from an API error."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'describe', '42'],
+    result = invoke(
+        ['describe', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -203,11 +206,10 @@ def test_subscriptions_describe_failure():
 
 
 @describe_mock
-def test_subscriptions_describe_success():
+def test_subscriptions_describe_success(invoke):
     """Describe command succeeds."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'describe', '42'],
+    result = invoke(
+        ['describe', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -218,11 +220,10 @@ def test_subscriptions_describe_success():
 
 
 @failing_api_mock
-def test_subscriptions_results_failure():
+def test_subscriptions_results_failure(invoke):
     """Results command exits gracefully from an API error."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'results', '42'],
+    result = invoke(
+        ['results', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -238,11 +239,10 @@ def test_subscriptions_results_failure():
                           (['--limit=1', '--status=queued'], 0)])
 @res_api_mock
 # Remember, parameters come before fixtures in the function definition.
-def test_subscriptions_results_success(options, expected_count):
+def test_subscriptions_results_success(invoke, options, expected_count):
     """Describe command succeeds."""
-    result = CliRunner().invoke(
-        cli.main,
-        args=['subscriptions', 'results', '42'] + options,
+    result = invoke(
+        ['results', 'test'] + options,
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -101,6 +101,7 @@ GOOD_SUB_REQUEST = {'name': 'lol', 'delivery': True, 'source': 'wut'}
 @create_mock
 def test_subscriptions_create_success(invoke, cmd_arg, runner_input):
     """Subscriptions creation succeeds with a valid subscription request."""
+
     # The "-" argument says "read from stdin" and the input keyword
     # argument specifies what bytes go to the runner's stdin.
     result = invoke(


### PR DESCRIPTION
**Related Issue(s):**

Closes #705


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Add support for base_url in subscriptions client

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

Not possible to specify base_url.

New behavior:

can specify base_url with e.g. `planet subscriptions --base-url <BASE_URL> list` and 

```python
async with Session() as sess:
    cl = SubscriptionsClient(sess, base_url=<BASE_URL>)
    ...
```  

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
