### PR TITLE
Have calculate_wait stop just shy of 1sec offset to optimize distribution

### DIFF
--- a/planet/http.py
+++ b/planet/http.py
@@ -335,7 +335,7 @@ class Session(BaseSession):
         """Calculates retry wait
 
         Base wait period is calculated as a exponential based on the number of
-        tries. Then, a random jitter of up to 1s is added to the base wait
+        tries. Then, a random jitter of up to 999ms is added to the base wait
         to avoid waves of requests in the case of multiple requests. Finally,
         the wait is thresholded to the maximum retry backoff.
 
@@ -347,7 +347,7 @@ class Session(BaseSession):
         * https://developers.planet.com/docs/data/api-mechanics/
         * https://cloud.google.com/iot/docs/how-tos/exponential-backoff
         """
-        random_number_milliseconds = random.randint(0, 1000) / 1000.0
+        random_number_milliseconds = random.randint(0, 999) / 1000.0
         calc_wait = 2**num_tries + random_number_milliseconds
         return min(calc_wait, max_retry_backoff)
 


### PR DESCRIPTION
The step size between calls is 1s and the random offset is called to avoid waves, so have it stop just shy of 1s. This addresses the random failing test in test_http caused when the random offset was 1s.

**Related Issue(s):**

Closes #723


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. 

Not intended for changelog:

1. Have calculate_wait stop just shy of 1sec offset

**Diff of User Interface**

Old behavior:

running the test 5000 times resulted in 37 failed tests


New behavior:

running the test 5000 times resulted in 0 failed tests


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
