### PR TITLE
Remove stdin from default for CLI commands, require `-` to specify

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -245,7 +245,7 @@ def filter(ctx,
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.argument("filter", type=types.JSON(), default="-", required=False)
+@click.argument("filter", type=types.JSON())
 @limit
 @click.option('--name', type=str, help='Name of the saved search.')
 @click.option('--sort',
@@ -263,7 +263,7 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
     ITEM_TYPES is a comma-separated list of item-types to search.
 
     FILTER must be JSON and can be specified a json string, filename, or '-'
-    for stdin. It defaults to reading from stdin.
+    for stdin.
 
     Quick searches are stored for approximately 30 days and the --name
     parameter will be applied to the stored quick search.
@@ -286,7 +286,7 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.argument("filter", type=types.JSON(), default="-", required=False)
+@click.argument("filter", type=types.JSON())
 @click.option('--daily-email',
               is_flag=True,
               help='Send a daily email when new results are added.')
@@ -302,7 +302,7 @@ async def search_create(ctx, name, item_types, filter, daily_email, pretty):
     ITEM_TYPES is a comma-separated list of item-types to search.
 
     FILTER must be JSON and can be specified a json string, filename, or '-'
-    for stdin. It defaults to reading from stdin.
+    for stdin.
     """
     async with data_client(ctx) as cl:
         items = await cl.create_search(name=name,
@@ -320,7 +320,7 @@ async def search_create(ctx, name, item_types, filter, daily_email, pretty):
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
 @click.argument('interval', type=click.Choice(STATS_INTERVAL))
-@click.argument("filter", type=types.JSON(), default="-", required=False)
+@click.argument("filter", type=types.JSON())
 async def stats(ctx, item_types, interval, filter):
     """Get a bucketed histogram of items matching the filter.
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -201,7 +201,7 @@ async def download(ctx, order_id, overwrite, directory, checksum):
 @click.pass_context
 @translate_exceptions
 @coro
-@click.argument("request", type=types.JSON(), default="-", required=False)
+@click.argument("request", type=types.JSON())
 @pretty
 async def create(ctx, request: str, pretty):
     '''Create an order.

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -417,17 +417,8 @@ def test_cli_orders_download_state(invoke, order_description, oid):
     assert 'order state (running) is not a final state.' in result.output
 
 
-# TODO: add tests of "create --pretty" (gh-491).
-@pytest.mark.parametrize(
-    "id_string, expected_ids",
-    [('4500474_2133707_2021-05-20_2419', ['4500474_2133707_2021-05-20_2419']),
-     ('4500474_2133707_2021-05-20_2419,4500474_2133707_2021-05-20_2420',
-      ['4500474_2133707_2021-05-20_2419', '4500474_2133707_2021-05-20_2420'])])
 @respx.mock
-def test_cli_orders_create_basic_success(expected_ids,
-                                         id_string,
-                                         invoke,
-                                         order_description):
+def test_cli_orders_create_basic_success(invoke, order_description):
     mock_resp = httpx.Response(HTTPStatus.OK, json=order_description)
     respx.post(TEST_ORDERS_URL).return_value = mock_resp
 
@@ -435,7 +426,7 @@ def test_cli_orders_create_basic_success(expected_ids,
         "name":
         "test",
         "products": [{
-            "item_ids": expected_ids,
+            "item_ids": ['4500474_2133707_2021-05-20_2419'],
             "item_type": "PSOrthoTile",
             "product_bundle": "analytic"
         }],

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -134,7 +134,6 @@ def test_subscriptions_bad_request(invoke, cmd_arg, runner_input):
         catch_exceptions=True)
 
     assert result.exit_code == 2  # bad parameter.
-    assert "Request does not contain valid json" in result.output
 
 
 @failing_api_mock


### PR DESCRIPTION
**Related Issue(s):**

Closes #835 #682 #598


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Remove stdin from default for CLI commands, require `-` to specify.

Not intended for changelog:

1. Update subscriptions client to re-use JSON CLI type.

**Diff of User Interface**

Old behavior:
```bash
cat request.json | planet orders create
``` 
would work

```bash
planet orders create
``` 
would appear to hang, as it is waiting for stdin

New behavior:

```bash
planet orders create
``` 
returns the errror `Error: Missing argument 'REQUEST'`

```bash
cat request.json | planet orders create -
``` 
works

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@mkshah605 
