### PR TITLE
Ensure support for Python 3.10 and 3.11 by testing against these versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     steps:
     - name: Checkout code

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,7 @@ def coverage(session):
     session.run('coverage', 'report')
 
 
-@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def test(session):
     session.install(".[test]")
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -71,4 +71,4 @@ def test_str_to_datetime_success(string, expected):
 
 def test_str_to_datetime_failure():
     with pytest.raises(exceptions.PlanetError):
-        io.str_to_datetime('20210101')
+        io.str_to_datetime('notadate')


### PR DESCRIPTION
**Related Issue(s):**

Closes #841


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Ensures support for Python 3.10 and 3.11 by testing against these versions.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
nox only tested against 3.7, 3.8, 3.9

New behavior:
nox tests against 3.7, 3.8, 3.9, 3.10, and 3.11



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [-] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [-] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
