### PR TITLE
Implement CLI commands planet data search-run and planet data search-list

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -359,16 +359,21 @@ async def search_list(ctx, sort, search_type, limit, pretty):
 @translate_exceptions
 @coro
 @click.argument('search_id', callback=check_search_id)
+@click.option('--sort',
+              type=click.Choice(SEARCH_SORT),
+              default=SEARCH_SORT_DEFAULT,
+              show_default=True,
+              help='Field and direction to order results by.')
 @limit
 @pretty
-async def search_run(ctx, search_id, limit, pretty):
+async def search_run(ctx, search_id, sort, limit, pretty):
     """Execute a saved structured item search.
 
     This function outputs a series of GeoJSON descriptions, one for each of the
     returned items, optionally pretty-printed.
     """
     async with data_client(ctx) as cl:
-        async for item in cl.run_search(search_id, limit=limit):
+        async for item in cl.run_search(search_id, sort=sort, limit=limit):
             echo_json(item, pretty)
 
 

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -234,10 +234,11 @@ class DataClient:
                                                json=request)
         return response.json()
 
-    async def list_searches(self,
-                            sort: Optional[str] = LIST_SORT_DEFAULT,
-                            search_type: Optional[str] = LIST_SEARCH_TYPE_DEFAULT,
-                            limit: int = 100) -> AsyncIterator[dict]:
+    async def list_searches(
+            self,
+            sort: Optional[str] = LIST_SORT_DEFAULT,
+            search_type: Optional[str] = LIST_SEARCH_TYPE_DEFAULT,
+            limit: int = 100) -> AsyncIterator[dict]:
         """Iterate through list of searches available to the user.
 
         Note:

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -248,7 +248,7 @@ class DataClient:
             self,
             sort: Optional[str] = LIST_SORT_DEFAULT,
             search_type: Optional[str] = LIST_SEARCH_TYPE_DEFAULT,
-            limit: int = 100) -> AsyncIterator[dict]:
+            limit: Optional[int] = 100) -> AsyncIterator[dict]:
         """Iterate through list of searches available to the user.
 
         Note:

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -113,7 +113,7 @@ class DataClient:
                      search_filter: dict,
                      name: Optional[str] = None,
                      sort: Optional[str] = None,
-                     limit: Optional[int] = 100) -> AsyncIterator[dict]:
+                     limit: int = 100) -> AsyncIterator[dict]:
         """Iterate over results from a quick search.
 
         Quick searches are saved for a short period of time (~month). The
@@ -244,11 +244,10 @@ class DataClient:
                                                json=request)
         return response.json()
 
-    async def list_searches(
-            self,
-            sort: Optional[str] = LIST_SORT_DEFAULT,
-            search_type: Optional[str] = LIST_SEARCH_TYPE_DEFAULT,
-            limit: Optional[int] = 100) -> AsyncIterator[dict]:
+    async def list_searches(self,
+                            sort: str = LIST_SORT_DEFAULT,
+                            search_type: str = LIST_SEARCH_TYPE_DEFAULT,
+                            limit: int = 100) -> AsyncIterator[dict]:
         """Iterate through list of searches available to the user.
 
         Note:
@@ -326,7 +325,7 @@ class DataClient:
     async def run_search(self,
                          search_id: str,
                          sort: Optional[str] = None,
-                         limit: Optional[int] = 100) -> AsyncIterator[dict]:
+                         limit: int = 100) -> AsyncIterator[dict]:
         """Iterate over results from a saved search.
 
         Note:

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -33,7 +33,7 @@ TEST_URL = 'http://www.mocknotrealurl.com/api/path'
 TEST_SEARCHES_URL = f'{TEST_URL}/searches'
 TEST_STATS_URL = f'{TEST_URL}/stats'
 
-VALID_SEARCH_ID = '39a6e871-3b8a-4b5a-831a-28d42da9599e'
+VALID_SEARCH_ID = '286469f0b27c476e96c3c4e561f59664'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -265,7 +265,6 @@ async def test_get_search_id_doesnt_exist(search_id, session):
 @respx.mock
 @pytest.mark.asyncio
 async def test_update_search_basic(search_filter, session):
-    sid = 'search_id'
 
     page_response = {
         "__daily_email_enabled": False,
@@ -274,16 +273,19 @@ async def test_update_search_basic(search_filter, session):
         },
         "created": "2019-08-24T14:15:22Z",
         "filter": search_filter,
-        "id": sid,
+        "id": VALID_SEARCH_ID,
         "last_executed": "2019-08-24T14:15:22Z",
         "name": "test",
         "updated": "2019-08-24T14:15:22Z"
     }
     mock_resp = httpx.Response(HTTPStatus.OK, json=page_response)
-    respx.put(f'{TEST_SEARCHES_URL}/{sid}').return_value = mock_resp
+    respx.put(
+        f'{TEST_SEARCHES_URL}/{VALID_SEARCH_ID}').return_value = mock_resp
 
     cl = DataClient(session, base_url=TEST_URL)
-    search = await cl.update_search(sid, 'test', ['PSScene'], search_filter)
+    search = await cl.update_search(VALID_SEARCH_ID,
+                                    'test', ['PSScene'],
+                                    search_filter)
 
     # check that request is correct
     expected_request = {
@@ -380,14 +382,13 @@ async def test_list_searches_args_do_not_match(sort,
                          [(204, does_not_raise()),
                           (404, pytest.raises(exceptions.APIError))])
 async def test_delete_search(retcode, expectation, session):
-    sid = 'search_id'
     mock_resp = httpx.Response(retcode)
-    route = respx.delete(f'{TEST_SEARCHES_URL}/{sid}')
+    route = respx.delete(f'{TEST_SEARCHES_URL}/{VALID_SEARCH_ID}')
     route.return_value = mock_resp
     cl = DataClient(session, base_url=TEST_URL)
 
     with expectation:
-        await cl.delete_search(sid)
+        await cl.delete_search(VALID_SEARCH_ID)
 
     assert route.called
 
@@ -473,13 +474,12 @@ async def test_run_search_sort(item_descriptions,
 @respx.mock
 @pytest.mark.asyncio
 async def test_run_search_doesnotexist(session):
-    sid = 'search_id'
-    route = respx.get(f'{TEST_SEARCHES_URL}/{sid}/results')
+    route = respx.get(f'{TEST_SEARCHES_URL}/{VALID_SEARCH_ID}/results')
     route.return_value = httpx.Response(404)
 
     cl = DataClient(session, base_url=TEST_URL)
     with pytest.raises(exceptions.APIError):
-        [i async for i in cl.run_search(sid)]
+        [i async for i in cl.run_search(VALID_SEARCH_ID)]
 
     assert route.called
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -730,7 +730,7 @@ def test_data_search_run_sort(invoke, item_descriptions, sort, rel_url, valid):
     mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
     respx.get(next_page_url).return_value = mock_resp2
 
-    result = invoke(['search-list', f'--sort={sort}'])
+    result = invoke(['search-run', f'--sort={sort}', VALID_SEARCH_ID])
     expected_code = 0 if valid else 2
     assert result.exit_code == expected_code
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -23,7 +23,9 @@ from click.testing import CliRunner
 import pytest
 
 from planet.cli import cli
-from planet.clients.data import LIST_SEARCH_TYPE_DEFAULT, LIST_SORT_DEFAULT
+from planet.clients.data import (LIST_SEARCH_TYPE_DEFAULT,
+                                 LIST_SORT_DEFAULT,
+                                 SEARCH_SORT_DEFAULT)
 from planet.specs import get_item_types
 
 LOGGER = logging.getLogger(__name__)
@@ -33,16 +35,29 @@ TEST_QUICKSEARCH_URL = f'{TEST_URL}/quick-search'
 TEST_SEARCHES_URL = f'{TEST_URL}/searches'
 TEST_STATS_URL = f'{TEST_URL}/stats'
 
+VALID_SEARCH_ID = '286469f0b27c476e96c3c4e561f59664'
+
 
 @pytest.fixture
 def invoke():
 
-    def _invoke(extra_args, runner=None):
+    def _invoke(extra_args, runner=None, **kwargs):
         runner = runner or CliRunner()
         args = ['data'] + extra_args
-        return runner.invoke(cli.main, args=args)
+        return runner.invoke(cli.main, args=args, **kwargs)
 
     return _invoke
+
+
+@pytest.fixture
+def item_descriptions(get_test_file_json):
+    item_ids = [
+        '20220125_075509_67_1061',
+        '20220125_075511_17_1061',
+        '20220125_075650_17_1061'
+    ]
+    items = [get_test_file_json(f'data_item_{id}.json') for id in item_ids]
+    return items
 
 
 def test_data_command_registered(invoke):
@@ -650,6 +665,72 @@ def test_data_search_list_searchtype(invoke,
     route.return_value = httpx.Response(200, json=page1_response)
 
     result = invoke(['search-list', f'--search-type={search_type}'])
+    expected_code = 0 if valid else 2
+    assert result.exit_code == expected_code
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search_id, valid", [(VALID_SEARCH_ID, True),
+                                              ('invalid', False)])
+@pytest.mark.parametrize("limit, expected_count", [(0, 3), (2, 2)])
+def test_data_search_run_basic(invoke,
+                               item_descriptions,
+                               search_id,
+                               valid,
+                               limit,
+                               expected_count):
+    """Ensure planet data search-run runs successfully and handles search id
+    and limit."""
+    next_page_url = f'{TEST_URL}/blob/?page_marker=IAmATest'
+    item1, item2, item3 = item_descriptions
+    page1_response = {
+        "_links": {
+            "_next": next_page_url
+        }, "features": [item1, item2]
+    }
+
+    route = respx.get(f'{TEST_SEARCHES_URL}/{search_id}/results')
+    route.return_value = httpx.Response(204, json=page1_response)
+
+    page2_response = {"_links": {"_self": next_page_url}, "features": [item3]}
+    mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
+    respx.get(next_page_url).return_value = mock_resp2
+
+    result = invoke(['search-run', f'--limit={limit}', search_id])
+
+    if valid:
+        assert result.exit_code == 0
+        assert len(result.output.strip().split('\n')) == expected_count
+    else:
+        assert result.exit_code == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sort, rel_url, valid",
+                         [(SEARCH_SORT_DEFAULT, '', True),
+                          ('acquired asc', '?_sort=acquired+asc', True),
+                          ('invalid', '', False)])
+def test_data_search_run_sort(invoke, item_descriptions, sort, rel_url, valid):
+    """Ensure planet data search-run handles sort."""
+    next_page_url = f'{TEST_URL}/blob/?page_marker=IAmATest'
+    item1, item2, item3 = item_descriptions
+    page1_response = {
+        "_links": {
+            "_next": next_page_url
+        }, "features": [item1, item2]
+    }
+
+    route = respx.get(
+        f'{TEST_SEARCHES_URL}/{VALID_SEARCH_ID}/results{rel_url}')
+    route.return_value = httpx.Response(204, json=page1_response)
+
+    page2_response = {"_links": {"_self": next_page_url}, "features": [item3]}
+    mock_resp2 = httpx.Response(HTTPStatus.OK, json=page2_response)
+    respx.get(next_page_url).return_value = mock_resp2
+
+    result = invoke(['search-list', f'--sort={sort}'])
     expected_code = 0 if valid else 2
     assert result.exit_code == expected_code
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -560,7 +560,7 @@ def test_data_search_create_filter_success(invoke, item_types):
 
 
 @respx.mock
-def test_search_create_daily_email(invoke, search_result):
+def test_data_search_create_daily_email(invoke, search_result):
     mock_resp = httpx.Response(HTTPStatus.OK, json=search_result)
     respx.post(TEST_SEARCHES_URL).return_value = mock_resp
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -602,10 +602,10 @@ def test_data_search_create_daily_email(invoke, search_result):
 @respx.mock
 @pytest.mark.asyncio
 @pytest.mark.parametrize("limit, expected_list_length", [(0, 4), (3, 3)])
-def test_data_list_searches_basic(invoke,
-                                  search_result,
-                                  limit,
-                                  expected_list_length):
+def test_data_search_list_basic(invoke,
+                                search_result,
+                                limit,
+                                expected_list_length):
     """Ensure planet data search-list runs successfully and respects limit."""
     page1_response = {"_links": {}, "searches": [search_result] * 4}
     route = respx.get(TEST_SEARCHES_URL)
@@ -622,7 +622,7 @@ def test_data_list_searches_basic(invoke,
                          [(LIST_SORT_DEFAULT, '', True),
                           ('created asc', '?_sort=created+asc', True),
                           ('notvalid', '', False)])
-def test_data_list_searches_sort(invoke, search_result, sort, rel_url, valid):
+def test_data_search_list_sort(invoke, search_result, sort, rel_url, valid):
     """Ensure planet data search-list handles sort."""
     page1_response = {"_links": {}, "searches": [search_result] * 4}
     route = respx.get(f'{TEST_SEARCHES_URL}{rel_url}')
@@ -639,11 +639,11 @@ def test_data_list_searches_sort(invoke, search_result, sort, rel_url, valid):
                          [(LIST_SEARCH_TYPE_DEFAULT, '', True),
                           ('saved', '?search_type=saved', True),
                           ('notvalid', '', False)])
-def test_data_list_searches_searchtype(invoke,
-                                       search_result,
-                                       search_type,
-                                       rel_url,
-                                       valid):
+def test_data_search_list_searchtype(invoke,
+                                     search_result,
+                                     search_type,
+                                     rel_url,
+                                     valid):
     """Ensure planet data search-list handles search-type."""
     page1_response = {"_links": {}, "searches": [search_result] * 4}
     route = respx.get(f'{TEST_SEARCHES_URL}{rel_url}')


### PR DESCRIPTION
**Related Issue(s):**

Closes #502  #503 #839


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Implement CLI commands planet data search-run and planet data search-list
2. Add full support for options in Python api DataClient.run_search() and DataClient.list_searches()

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

n/a

New behavior:

```bash
> planet data search-list --limit 1 | jq -r .id
286469f0b27c476e96c3c4e561f59664
```

```bash
> planet data search-run 286469f0b27c476e96c3c4e561f59664 --limit 1 --pretty
{
  "_links": {
    "_self": "https://api.planet.com/data/v1/item-types/PSScene/items/20230201_111310_54_2405",
    "assets": "https://api.planet.com/data/v1/item-types/PSScene/items/20230201_111310_54_2405/assets/",
    "thumbnail": "https://tiles.planet.com/data/v1/item-types/PSScene/items/20230201_111310_54_2405/thumb"
  },
...
}
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
