### PR TITLE
Implement CLI commands planet data search-delete

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -352,8 +352,20 @@ async def search_get(ctx, search_id, pretty):
         echo_json(items, pretty)
 
 
+@data.command()
+@click.pass_context
+@translate_exceptions
+@coro
+@pretty
+@click.argument('search_id')
+async def search_delete(ctx, search_id):
+    """Delete an existing saved search.
+    """
+    async with data_client(ctx) as cl:
+        await cl.delete_search(search_id)
+
+
 # TODO: search_update()".
-# TODO: search_delete()".
 # TODO: search_run()".
 # TODO: item_get()".
 # TODO: asset_activate()".

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -356,7 +356,6 @@ async def search_get(ctx, search_id, pretty):
 @click.pass_context
 @translate_exceptions
 @coro
-@pretty
 @click.argument('search_id')
 async def search_delete(ctx, search_id):
     """Delete an existing saved search.

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -701,9 +701,18 @@ def test_search_get_id_not_found(invoke, search_id):
     assert 'Error: {"message": "Error message"}\n' == result.output
 
 
+@respx.mock
+def test_search_delete(invoke, search_id, search_result):
+    delete_url = f'{TEST_SEARCHES_URL}/{search_id}'
+    mock_resp = httpx.Response(HTTPStatus.NO_CONTENT, json=search_result)
+    respx.delete(delete_url).return_value = mock_resp
+
+    result = invoke(['search-delete', search_id])
+
+    assert not result.exception
+
 # TODO: basic test for "planet data search-create".
 # TODO: basic test for "planet data search-update".
-# TODO: basic test for "planet data search-delete".
 # TODO: basic test for "planet data search-get".
 # TODO: basic test for "planet data search-list".
 # TODO: basic test for "planet data search-run".

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -703,7 +703,7 @@ def test_search_get_id_not_found(invoke, search_id):
 
 
 @respx.mock
-def test_search_delete(invoke, search_id, search_result):
+def test_search_delete_success(invoke, search_id, search_result):
     delete_url = f'{TEST_SEARCHES_URL}/{search_id}'
     mock_resp = httpx.Response(HTTPStatus.NO_CONTENT, json=search_result)
     respx.delete(delete_url).return_value = mock_resp
@@ -714,7 +714,7 @@ def test_search_delete(invoke, search_id, search_result):
 
 
 @respx.mock
-def test_search_delete_invalid_id(invoke, search_id, search_result):
+def test_search_delete_nonexistant_search_id(invoke, search_id, search_result):
     delete_url = f'{TEST_SEARCHES_URL}/{search_id}'
     mock_resp = httpx.Response(404, json=search_result)
     respx.delete(delete_url).return_value = mock_resp

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -53,6 +53,7 @@ def test_data_command_registered(invoke):
     assert "search" in result.output
     assert "search-create" in result.output
     assert "search-get" in result.output
+    assert "search-delete" in result.output
     # Add other sub-commands here.
 
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -712,6 +712,18 @@ def test_search_delete(invoke, search_id, search_result):
 
     assert not result.exception
 
+
+@respx.mock
+def test_search_delete_invalid_id(invoke, search_id, search_result):
+    delete_url = f'{TEST_SEARCHES_URL}/{search_id}'
+    mock_resp = httpx.Response(404, json=search_result)
+    respx.delete(delete_url).return_value = mock_resp
+
+    result = invoke(['search-delete', search_id])
+
+    assert result.exception
+    assert result.exit_code == 1
+
 # TODO: basic test for "planet data search-create".
 # TODO: basic test for "planet data search-update".
 # TODO: basic test for "planet data search-get".

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -724,6 +724,7 @@ def test_search_delete_invalid_id(invoke, search_id, search_result):
     assert result.exception
     assert result.exit_code == 1
 
+
 # TODO: basic test for "planet data search-create".
 # TODO: basic test for "planet data search-update".
 # TODO: basic test for "planet data search-get".


### PR DESCRIPTION
**Related Issue(s):**

Closes #500 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Implement CLI commands planet data search-delete

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

N/A

New behavior:
```console
❯ planet data search-delete 14aab90bb19749f483bfa929938a8382
# try and delete the same search ID again
❯ planet data search-delete 14aab90bb19749f483bfa929938a8382 
Error: {"general": [{"message": "The requested search id does not exist"}], "field": {}}
```





**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
