### PR TITLE
Add AssetStatusBar reporter, use in data asset-wait cli command

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import click
 
-from planet.reporting import StateBar
+from planet.reporting import AssetStatusBar
 from planet import data_filter, DataClient, exceptions
 from planet.clients.data import (SEARCH_SORT,
                                  LIST_SEARCH_TYPE,
@@ -589,18 +589,19 @@ async def asset_wait(ctx,
                      max_attempts):
     '''Wait for an asset to be activated.
 
-    Returns when the asset state has reached "activated" and the asset is
+    Returns when the asset status has reached "activated" and the asset is
     available.
     '''
     quiet = ctx.obj['QUIET']
     async with data_client(ctx) as cl:
         asset = await cl.get_asset(item_type.pop(), item_id, asset_type_id)
-        with StateBar(order_id="my asset", disable=quiet) as bar:
-            state = await cl.wait_asset(asset,
-                                        delay,
-                                        max_attempts,
-                                        callback=bar.update_state)
-    click.echo(state)
+        with AssetStatusBar(item_type, item_id, asset_type_id,
+                            disable=quiet) as bar:
+            status = await cl.wait_asset(asset,
+                                         delay,
+                                         max_attempts,
+                                         callback=bar.update)
+    click.echo(status)
 
 
 # @data.command()

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -145,11 +145,13 @@ class AssetStatusBar(ProgressBar):
     def update(self, status: str):
         self.status = status
 
-        try:
-            self.bar.postfix[1] = self.status
-        except AttributeError:
-            # If the bar is disabled, attempting to access self.bar.postfix
-            # will result in an error. In this case, just skip it.
-            pass
+        if self.bar is not None:
+            try:
+                self.bar.postfix[1] = self.status
+            except AttributeError:
+                # If the bar is disabled, attempting to access self.bar.postfix
+                # will result in an error. In this case, just skip it.
+                pass
 
-        self.bar.refresh()
+        if self.bar is not None:
+            self.bar.refresh()

--- a/planet/reporting.py
+++ b/planet/reporting.py
@@ -110,3 +110,46 @@ class StateBar(ProgressBar):
 
         if self.bar is not None:
             self.bar.refresh()
+
+
+class AssetStatusBar(ProgressBar):
+    """Bar reporter of asset status."""
+
+    def __init__(
+        self,
+        item_type,
+        item_id,
+        asset_type,
+        disable: bool = False,
+    ):
+        """Initialize the object.
+        """
+        self.item_type = item_type
+        self.item_id = item_id
+        self.asset_type = asset_type
+        self.status = ''
+        super().__init__(disable=disable)
+
+    def open_bar(self):
+        """Initialize and start the progress bar."""
+        self.bar = tqdm(
+            bar_format="{elapsed} - {desc} - {postfix[0]}: {postfix[1]}",
+            desc=self.desc,
+            postfix=["status", self.status],
+            disable=self.disable)
+
+    @property
+    def desc(self):
+        return f'{self.item_type} {self.item_id} {self.asset_type}'
+
+    def update(self, status: str):
+        self.status = status
+
+        try:
+            self.bar.postfix[1] = self.status
+        except AttributeError:
+            # If the bar is disabled, attempting to access self.bar.postfix
+            # will result in an error. In this case, just skip it.
+            pass
+
+        self.bar.refresh()

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -1051,7 +1051,7 @@ def test_asset_wait(invoke,
         runner=runner)
 
     assert not result.exception
-    assert "state: active" in result.output
+    assert "status: active" in result.output
 
 
 # @respx.mock

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -72,6 +72,7 @@ def test_AssetStatusBar_disabled():
 
 
 def test_AssetStatusBar_update():
+    """Status is changed with update"""
     with reporting.AssetStatusBar('item-type', 'item_id', 'asset_type') as bar:
         assert ('status: init') not in str(bar)
 

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -37,6 +37,7 @@ def test_StateBar___init___stateandorder():
 
 
 def test_StateBar___init___disabled():
+    """Make sure it doesn't error out when disabled"""
     with reporting.StateBar(disable=True) as bar:
         assert bar.bar.disable
 
@@ -56,3 +57,23 @@ def test_StateBar_update_state():
         expected_update = '..:.. - order  - state: init'
         bar.update_state('init')
         assert (re.fullmatch(expected_update, str(bar)))
+
+
+def test_AssetStatusBar_disabled():
+    """Make sure it doesn't error out when disabled"""
+    with reporting.AssetStatusBar('item-type',
+                                  'item_id',
+                                  'asset_type',
+                                  disable=True) as bar:
+        assert bar.bar.disable
+
+        # just make sure this doesn't error out
+        bar.update(status='init')
+
+
+def test_AssetStatusBar_update():
+    with reporting.AssetStatusBar('item-type', 'item_id', 'asset_type') as bar:
+        assert ('status: init') not in str(bar)
+
+        bar.update(status='init')
+        assert ('status: init') in str(bar)


### PR DESCRIPTION
This PR is to be merged *after* #864 and assumes the item-type argument type is changed to str.

**Related Issue(s):**

Part of #506


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Add AssetStatusBar reporter, use in data asset-wait cli command

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

New behavior:

```
> planet data asset-wait PSScene 20221003_002705_38_2461 basic_udm2
00:00 - [] 20221003_002705_38_2461 basic_udm2 - status: active
{'_links': {'_self': 'https://api.planet.com/data/v1/assets/eyJpIjogIjIwMjIxMDAzXzAwMjcwNV8zOF8yNDYxIiwgImMiOiAiUFNTY2VuZSIsICJ0IjogImJhc2ljX3VkbTIiLCAiY3QiOiAiaXRlbS10eXBlIn0', 'activate': 'https://api.planet.com/data/v1/assets/eyJpIjogIjIwMjIxMDAzXzAwMjcwNV8zOF8yNDYxIiwgImMiOiAiUFNTY2VuZSIsICJ0IjogImJhc2ljX3VkbTIiLCAiY3QiOiAiaXRlbS10eXBlIn0/activate', 'type': 'https://api.planet.com/data/v1/asset-types/basic_udm2'}, '_permissions': ['download'], 'expires_at': '2023-03-03T05:32:20.238271', 'location': 'https://api.planet.com/data/v1/download?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjYkVGOTFxdXZjZ0E3Y0NIci1oUURxbHlmQ1M0WmJTNWZmWUEzdlFGYzVMcndCb0R5Tk1MbksyU2VHMnBlbThPTnVtZEtlczNiNXpWbk8yTXE5d0REUT09IiwiZXhwIjoxNjc3ODIxNTQwLCJ0b2tlbl90eXBlIjoidHlwZWQtaXRlbSIsIml0ZW1fdHlwZV9pZCI6IlBTU2NlbmUiLCJpdGVtX2lkIjoiMjAyMjEwMDNfMDAyNzA1XzM4XzI0NjEiLCJhc3NldF90eXBlIjoiYmFzaWNfdWRtMiJ9.J95vYO7ZXQho3pt47yZzfm3BRrrEqOH9d2k6jdJGQD4IKEOLzrpgEr0dGbjtSSyHuS5nopX23WX1_mYPN3yz3Q', 'md5_digest': '3a9f7dd1ce500f699d0a96afdd0e3aa2', 'status': 'active', 'type': 'basic_udm2'}
```
There is a [] entry above that will actually display the item-type (aka PSScene) when the `item-type` type is changed to str.

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
