### PR TITLE
simplify geojson specified as geometry in catalog_source

### DIFF
--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -133,7 +133,7 @@ def catalog_source(
     parameters = {
         "item_types": item_types,
         "asset_types": asset_types,
-        "geometry": geometry,
+        "geometry": geojson.as_geom(geometry),
     }
 
     try:

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -90,6 +90,30 @@ def test_catalog_source_success(geom_geojson):
     assert res == expected
 
 
+def test_catalog_source_featurecollection(featurecollection_geojson,
+                                          geom_geojson):
+    '''geojson specified as featurecollection is simplified down to just
+    the geometry'''
+    res = subscription_request.catalog_source(
+        item_types=["PSScene"],
+        asset_types=["ortho_analytic_4b"],
+        geometry=featurecollection_geojson,
+        start_time=datetime(2021, 3, 1),
+    )
+
+    expected = {
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    }
+
+    assert res == expected
+
+
 def test_catalog_source_invalid_start_time(geom_geojson):
     with pytest.raises(exceptions.ClientError):
         subscription_request.catalog_source(


### PR DESCRIPTION
**Related Issue(s):**

Closes #871 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. `planet.subscription_request.catalog_source` and `planet subscriptions source-catalog` now simplify geojson given in `geometry` parameter/option to just the geometry, the form required by the subscriptions api.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet subscriptions request-catalog \
        --item-types PSScene \
        --asset-types ortho_analytic_8b_sr,ortho_udm2 \
        --geometry aoi.geojson \
        --start-time 2022-01-01 | jq

{
  "type": "catalog",
  "parameters": {
    "item_types": [
      "PSScene"
    ],
    "asset_types": [
      "ortho_analytic_8b_sr",
      "ortho_udm2"
    ],
    "geometry": {
      "type": "FeatureCollection",
      "features": [
        {
          "type": "Feature",
          "properties": {},
          "geometry": {
            "type": "Polygon",
            "coordinates": [
              [
                [
                  7.05322265625,
                  46.81509864599243
                ],
                [
                  7.580566406250001,
                  46.81509864599243
                ],
                [
                  7.580566406250001,
                  47.17477833929903
                ],
                [
                  7.05322265625,
                  47.17477833929903
                ],
                [
                  7.05322265625,
                  46.81509864599243
                ]
              ]
            ]
          }
        }
      ]
    },
    "start_time": "2022-01-01T00:00:00Z"
  }
}
```


New behavior:

```console
planet subscriptions request-catalog \
        --item-types PSScene \
        --asset-types ortho_analytic_8b_sr,ortho_udm2 \
        --geometry aoi.geojson \
        --start-time 2022-01-01 | jq

{
  "type": "catalog",
  "parameters": {
    "item_types": [
      "PSScene"
    ],
    "asset_types": [
      "ortho_analytic_8b_sr",
      "ortho_udm2"
    ],
    "geometry": {
      "type": "Polygon",
      "coordinates": [
        [
          [
            7.05322265625,
            46.81509864599243
          ],
          [
            7.580566406250001,
            46.81509864599243
          ],
          [
            7.580566406250001,
            47.17477833929903
          ],
          [
            7.05322265625,
            47.17477833929903
          ],
          [
            7.05322265625,
            46.81509864599243
          ]
        ]
      ]
    },
    "start_time": "2022-01-01T00:00:00Z"
  }
}
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
