### PR TITLE
change search-create name/filter options/parameters to match search UI 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,13 +3,7 @@
 Added:
 - The Session class can now construct clients by name with its client method
   (#858).
-
-Changed:
 - Updated product bundle spec to 2/24/23 version.
-- `planet.subscription_request.catalog_source` and 
-  `planet subscriptions source-catalog` now simplify geojson given in
-  `geometry` parameter/option to just the geometry, the form required by the
-   subscriptions api (#880).
 
 
 2.0.0-rc.1 (2023-03-06)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,7 +3,13 @@
 Added:
 - The Session class can now construct clients by name with its client method
   (#858).
+
+Changed:
 - Updated product bundle spec to 2/24/23 version.
+- `planet.subscription_request.catalog_source` and 
+  `planet subscriptions source-catalog` now simplify geojson given in
+  `geometry` parameter/option to just the geometry, the form required by the
+   subscriptions api (#880).
 
 
 2.0.0-rc.1 (2023-03-06)

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -325,21 +325,21 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.option('--name',
-              type=str,
-              required=True,
-              help='Name of the saved search.')
 @click.option(
     '--filter',
     type=types.JSON(),
     required=True,
     help="""Filter to apply to search. Can be a json string, filename,
-              # or '-' for stdin.""")
+         or '-' for stdin.""")
+@click.option('--name',
+              type=str,
+              required=True,
+              help='Name of the saved search.')
 @click.option('--daily-email',
               is_flag=True,
               help='Send a daily email when new results are added.')
 @pretty
-async def search_create(ctx, name, item_types, filter, daily_email, pretty):
+async def search_create(ctx, item_types, filter, name, daily_email, pretty):
     """Create a new saved structured item search.
 
     This function outputs a full JSON description of the created search,
@@ -348,9 +348,9 @@ async def search_create(ctx, name, item_types, filter, daily_email, pretty):
     ITEM_TYPES is a comma-separated list of item-types to search.
     """
     async with data_client(ctx) as cl:
-        items = await cl.create_search(name=name,
-                                       item_types=item_types,
+        items = await cl.create_search(item_types=item_types,
                                        search_filter=filter,
+                                       name=name,
                                        enable_email=daily_email)
         echo_json(items, pretty)
 

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -283,7 +283,8 @@ def filter(ctx,
                 callback=check_item_types)
 @click.option('--filter',
               type=types.JSON(),
-              help='Apply specified filter to search.')
+              help="""Apply specified filter to search. Can be a json string,
+              filename, or '-' for stdin.""")
 @limit
 @click.option('--name', type=str, help='Name of the saved search.')
 @click.option('--sort',
@@ -321,11 +322,19 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
 @click.pass_context
 @translate_exceptions
 @coro
-@click.argument('name')
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.argument("filter", type=types.JSON())
+@click.option('--name',
+              type=str,
+              required=True,
+              help='Name of the saved search.')
+@click.option(
+    '--filter',
+    type=types.JSON(),
+    required=True,
+    help="""Filter to apply to search. Can be a json string, filename,
+              # or '-' for stdin.""")
 @click.option('--daily-email',
               is_flag=True,
               help='Send a daily email when new results are added.')
@@ -336,12 +345,7 @@ async def search_create(ctx, name, item_types, filter, daily_email, pretty):
     This function outputs a full JSON description of the created search,
     optionally pretty-printed.
 
-    NAME is the name to give the search.
-
     ITEM_TYPES is a comma-separated list of item-types to search.
-
-    FILTER must be JSON and can be specified a json string, filename, or '-'
-    for stdin.
     """
     async with data_client(ctx) as cl:
         items = await cl.create_search(name=name,

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -167,8 +167,8 @@ class DataClient:
             yield i
 
     async def create_search(self,
-                            name: str,
                             item_types: List[str],
+                            name: str,
                             search_filter: dict,
                             enable_email: bool = False) -> dict:
         """Create a new saved structured item search.
@@ -190,8 +190,8 @@ class DataClient:
 
 
         Parameters:
-            name: The name of the saved search.
             item_types: The item types to include in the search.
+            name: The name of the saved search.
             search_filter: Structured search criteria.
             enable_email: Send a daily email when new results are added.
 

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -168,8 +168,8 @@ class DataClient:
 
     async def create_search(self,
                             item_types: List[str],
-                            name: str,
                             search_filter: dict,
+                            name: str,
                             enable_email: bool = False) -> dict:
         """Create a new saved structured item search.
 
@@ -191,8 +191,8 @@ class DataClient:
 
         Parameters:
             item_types: The item types to include in the search.
-            name: The name of the saved search.
             search_filter: Structured search criteria.
+            name: The name of the saved search.
             enable_email: Send a daily email when new results are added.
 
         Returns:

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -246,8 +246,8 @@ async def test_create_search_basic(search_filter, session):
 
     cl = DataClient(session, base_url=TEST_URL)
     search = await cl.create_search(['PSScene'],
-                                    name='test',
-                                    search_filter=search_filter)
+                                    search_filter=search_filter,
+                                    name='test')
 
     # check that request is correct
     expected_request = {
@@ -284,8 +284,8 @@ async def test_create_search_email(search_filter, session):
 
     cl = DataClient(session, base_url=TEST_URL)
     search = await cl.create_search(['PSScene'],
-                                    name='test',
                                     search_filter=search_filter,
+                                    name='test',
                                     enable_email=True)
 
     # check that request is correct

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -245,7 +245,9 @@ async def test_create_search_basic(search_filter, session):
     respx.post(TEST_SEARCHES_URL).return_value = mock_resp
 
     cl = DataClient(session, base_url=TEST_URL)
-    search = await cl.create_search('test', ['PSScene'], search_filter)
+    search = await cl.create_search(['PSScene'],
+                                    name='test',
+                                    search_filter=search_filter)
 
     # check that request is correct
     expected_request = {
@@ -281,8 +283,9 @@ async def test_create_search_email(search_filter, session):
     respx.post(TEST_SEARCHES_URL).return_value = mock_resp
 
     cl = DataClient(session, base_url=TEST_URL)
-    search = await cl.create_search('test', ['PSScene'],
-                                    search_filter,
+    search = await cl.create_search(['PSScene'],
+                                    name='test',
+                                    search_filter=search_filter,
                                     enable_email=True)
 
     # check that request is correct

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -572,7 +572,13 @@ def test_data_search_create_filter_invalid_json(invoke, item_types, filter):
     name = "temp"
 
     runner = CliRunner()
-    result = invoke(["search-create", name, item_types, filter], runner=runner)
+    result = invoke([
+        "search-create",
+        item_types,
+        f'--name={name}',
+        f'--filter={json.dumps(filter)}'
+    ],
+                    runner=runner)
     assert result.exit_code == 2
 
 
@@ -599,7 +605,12 @@ def test_data_search_create_filter_success(invoke, item_types):
     respx.post(TEST_SEARCHES_URL).return_value = mock_resp
 
     runner = CliRunner()
-    result = invoke(["search-create", name, item_types, json.dumps(filter)],
+    result = invoke([
+        "search-create",
+        item_types,
+        f'--name={name}',
+        f'--filter={json.dumps(filter)}'
+    ],
                     runner=runner)
 
     assert result.exit_code == 0
@@ -621,9 +632,9 @@ def test_data_search_create_daily_email(invoke, search_result):
 
     result = invoke([
         'search-create',
-        'temp',
         'SkySatScene',
-        json.dumps(filter),
+        '--name=temp',
+        f'--filter={json.dumps(filter)}',
         '--daily-email'
     ])
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #884 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Breaking change: Bring the UI of `planet data search-create` and `DataClient.create_search()` inline with `planet data search` and `DataClient.search()` by moving name and filter to required options in the CLI and rearranging the order of the parameters to `(item_types, search_filter, name)` in the Python library.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet data search-create name PSScene filter.json
```

```python
dataclient.create_search(name, ['PSScene'], search_filter)
```

New behavior:

```console
planet data search-create PSScene --filter filter.json --name search_name
```

```python
dataclient.create_search(['PSScene'],  search_filter=search_filter, name=name)
```

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
There are no docs for these functions so there was nothing to update. #885 addresses adding them.