### PR TITLE
move planet data stats interval and filter args to required options

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -418,19 +418,27 @@ async def search_run(ctx, search_id, sort, limit, pretty):
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.argument('interval', type=click.Choice(STATS_INTERVAL))
-@click.argument("filter", type=types.JSON())
-async def stats(ctx, item_types, interval, filter):
+@click.option(
+    '--filter',
+    type=types.JSON(),
+    required=True,
+    help="""Filter to apply to search. Can be a json string, filename,
+         or '-' for stdin.""")
+@click.option('--interval',
+              type=click.Choice(STATS_INTERVAL),
+              required=True,
+              help='The size of the histogram date buckets.')
+async def stats(ctx, item_types, filter, interval):
     """Get a bucketed histogram of items matching the filter.
 
     This function returns a bucketed histogram of results based on the
-    item_types, interval, and json filter specified (using file or stdin).
+    item_types, interval, and filter specified.
 
     """
     async with data_client(ctx) as cl:
         items = await cl.get_stats(item_types=item_types,
-                                   interval=interval,
-                                   search_filter=filter)
+                                   search_filter=filter,
+                                   interval=interval)
         echo_json(items)
 
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -771,16 +771,18 @@ def test_data_stats_invalid_filter(invoke, filter):
     interval = "hour"
     item_type = 'PSScene'
     runner = CliRunner()
-    result = invoke(["stats", item_type, interval, filter], runner=runner)
+    result = invoke(
+        ["stats", item_type, f'--interval={interval}', f'--filter={filter}'],
+        runner=runner)
     assert result.exit_code == 2
 
 
 @respx.mock
 @pytest.mark.parametrize("item_types",
                          ['PSScene', 'SkySatScene', 'PSScene, SkySatScene'])
-@pytest.mark.parametrize("interval, exit_code", [(None, 1), ('hou', 2),
+@pytest.mark.parametrize("interval, exit_code", [(None, 2), ('hou', 2),
                                                  ('hour', 0)])
-def test_data_stats_invalid_interval(invoke, item_types, interval, exit_code):
+def test_data_stats_interval(invoke, item_types, interval, exit_code):
     """Test for planet data stats. Test with multiple item_types.
     Test should succeed with valid interval, and fail with invalid interval."""
     filter = {
@@ -797,10 +799,11 @@ def test_data_stats_invalid_interval(invoke, item_types, interval, exit_code):
                                }]})
     respx.post(TEST_STATS_URL).return_value = mock_resp
 
-    runner = CliRunner()
-    result = invoke(["stats", item_types, interval, json.dumps(filter)],
-                    runner=runner)
+    args = ["stats", item_types, f'--filter={json.dumps(filter)}']
+    if interval:
+        args.append(f'--interval={interval}')
 
+    result = invoke(args)
     assert result.exit_code == exit_code
 
 
@@ -828,9 +831,12 @@ def test_data_stats_success(invoke, item_types, interval):
                                }]})
     respx.post(TEST_STATS_URL).return_value = mock_resp
 
-    runner = CliRunner()
-    result = invoke(["stats", item_types, interval, json.dumps(filter)],
-                    runner=runner)
+    result = invoke([
+        "stats",
+        item_types,
+        f'--interval={interval}',
+        f'--filter={json.dumps(filter)}'
+    ])
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #887 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. move planet data stats interval and filter args to required options

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet data stats PSScene hour filter.json
```

New behavior:

```console
planet data stats PSScene --interval hour --filter filter.json
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@cholmes I don't see anywhere where the docs reference `planet data stats` so I didn't update nor add any.