### PR TITLE
Removed checksum argument from download_order

### DIFF
--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -265,8 +265,7 @@ class OrdersClient:
                              order_id: str,
                              directory: Path = Path('.'),
                              overwrite: bool = False,
-                             progress_bar: bool = False,
-                             checksum: Optional[str] = None) -> List[Path]:
+                             progress_bar: bool = False) -> List[Path]:
         """Download all assets in an order.
 
         Parameters:


### PR DESCRIPTION
**Related Issue(s):**

Closes #856 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Removed checksum argument from download_order.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
```python
async with orders_client(ctx) as cl:
    await cl.download_order(
        str(order_id),
        directory=Path(directory),
        overwrite=overwrite,
        progress_bar=not quiet,
    )
    if checksum:
        cl.validate_checksum(Path(directory, str(order_id)), checksum)
```
New behavior:
Same as before



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
