### PR TITLE
change search-update name/filter options/parameters to match search UI

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -468,20 +468,28 @@ async def search_delete(ctx, search_id):
 @translate_exceptions
 @coro
 @click.argument('search_id')
-@click.argument('name')
 @click.argument("item_types",
                 type=types.CommaSeparatedString(),
                 callback=check_item_types)
-@click.argument('filter', type=types.JSON())
+@click.option(
+    '--filter',
+    type=types.JSON(),
+    required=True,
+    help="""Filter to apply to search. Can be a json string, filename,
+         or '-' for stdin.""")
+@click.option('--name',
+              type=str,
+              required=True,
+              help='Name of the saved search.')
 @click.option('--daily-email',
               is_flag=True,
               help='Send a daily email when new results are added.')
 @pretty
 async def search_update(ctx,
                         search_id,
-                        name,
                         item_types,
                         filter,
+                        name,
                         daily_email,
                         pretty):
     """Update a saved search with the given search request.
@@ -491,9 +499,9 @@ async def search_update(ctx,
     """
     async with data_client(ctx) as cl:
         items = await cl.update_search(search_id,
-                                       name,
                                        item_types,
                                        filter,
+                                       name,
                                        daily_email)
         echo_json(items, pretty)
 

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -900,9 +900,9 @@ def test_search_update_success(invoke,
     result = invoke([
         'search-update',
         search_id,
-        name,
         item_types,
-        json.dumps(search_filter)
+        f'--filter={json.dumps(search_filter)}',
+        f'--name={name}'
     ])
 
     assert not result.exception
@@ -921,9 +921,9 @@ def test_search_update_fail(invoke, search_id, search_filter):
     result = invoke([
         'search-update',
         search_id,
-        name,
         item_types,
-        json.dumps(search_filter)
+        f'--filter={json.dumps(search_filter)}',
+        f'--name={name}'
     ])
 
     assert result.output.startswith("Error")


### PR DESCRIPTION
**Related Issue(s):**

Closes #890 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Breaking change: Bring the UI of `planet data search-update` CLI command inline with `planet data search` and `DataClient.search()` by moving name and filter to required options.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet data filter | planet data search-update d7c24f298c4943078cb7cb7808e989a5 test PSScene -
```

New behavior:

```console
planet data filter | planet data search-update d7c24f298c4943078cb7cb7808e989a5 PSScene --filter - --name test
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
