### PR TITLE
Update Subscriptions CLI describe function naming

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -120,7 +120,7 @@ async def update_subscription_cmd(ctx, subscription_id, request, pretty):
 @translate_exceptions
 @coro
 async def get_subscription_cmd(ctx, subscription_id, pretty):
-    """Gets the description of a subscription and prints the API response."""
+    """Get the description of a subscription."""
     async with subscriptions_client(ctx) as client:
         sub = await client.get_subscription(subscription_id)
         echo_json(sub, pretty)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -113,13 +113,13 @@ async def update_subscription_cmd(ctx, subscription_id, request, pretty):
         echo_json(sub, pretty)
 
 
-@subscriptions.command(name='describe')
+@subscriptions.command(name='get')
 @click.argument('subscription_id')
 @pretty
 @click.pass_context
 @translate_exceptions
 @coro
-async def describe_subscription_cmd(ctx, subscription_id, pretty):
+async def get_subscription_cmd(ctx, subscription_id, pretty):
     """Gets the description of a subscription and prints the API response."""
     async with subscriptions_client(ctx) as client:
         sub = await client.get_subscription(subscription_id)

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -93,8 +93,8 @@ cancel_mock.route(M(url=f'{TEST_URL}/test/cancel'),
                   method='POST').mock(side_effect=modify_response)
 
 # Mock the subscription description API endpoint.
-describe_mock = respx.mock()
-describe_mock.route(
+get_mock = respx.mock()
+get_mock.route(
     M(url=f'{TEST_URL}/test'),
     method='GET').mock(return_value=Response(200,
                                              json={
@@ -247,7 +247,7 @@ async def test_get_subscription_failure():
 
 
 @pytest.mark.anyio
-@describe_mock
+@get_mock
 async def test_get_subscription_success(monkeypatch):
     """Subscription description fetched, has the expected items."""
     async with Session() as session:

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -3,7 +3,7 @@
 There are 6 subscriptions commands:
 
 [x] planet subscriptions list
-[x] planet subscriptions describe
+[x] planet subscriptions get
 [x] planet subscriptions results
 [x] planet subscriptions create
 [x] planet subscriptions update
@@ -24,7 +24,7 @@ from test_subscriptions_api import (api_mock,
                                     create_mock,
                                     update_mock,
                                     cancel_mock,
-                                    describe_mock,
+                                    get_mock,
                                     res_api_mock,
                                     TEST_URL)
 
@@ -192,10 +192,10 @@ def test_subscriptions_update_success(invoke):
 
 
 @failing_api_mock
-def test_subscriptions_describe_failure(invoke):
+def test_subscriptions_get_failure(invoke):
     """Describe command exits gracefully from an API error."""
     result = invoke(
-        ['describe', 'test'],
+        ['get', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.
@@ -204,11 +204,11 @@ def test_subscriptions_describe_failure(invoke):
     assert result.exit_code == 1  # failure.
 
 
-@describe_mock
-def test_subscriptions_describe_success(invoke):
+@get_mock
+def test_subscriptions_get_success(invoke):
     """Describe command succeeds."""
     result = invoke(
-        ['describe', 'test'],
+        ['get', 'test'],
         # Note: catch_exceptions=True (the default) is required if we want
         # to exercise the "translate_exceptions" decorator and test for
         # failure.


### PR DESCRIPTION
**Related Issue(s):**

Closes #889


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Changed the Subscriptions CLI command `describe` to `get`, to be consistent with the rest of our CLI command nomenclature. 

Not intended for changelog:

1. Updated CLI command name
2. Updated CLI tests
3. Updated API tests
4. Updated API mocking decorator names

**Diff of User Interface**

Old behavior:
`planet subscriptions describe`
New behavior:
`planet subscriptions get`



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
    - Didn't update docs, waiting for that to be done here: https://github.com/planetlabs/planet-client-python/pull/878/files#r1147981477
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@JuLeeAtPlanet 