### PR TITLE
Allow item types specified to be case insensitive in Data API and CLI

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -204,7 +204,7 @@ class DataClient:
         """
         url = self._searches_url()
 
-        # TODO: validate item_types
+        item_types = [validate_item_type(item) for item in item_types]
         request = {
             'name': name,
             'filter': search_filter,
@@ -237,6 +237,7 @@ class DataClient:
         """
         url = f'{self._searches_url()}/{search_id}'
 
+        item_types = [validate_item_type(item) for item in item_types]
         request = {
             'name': name,
             'filter': search_filter,
@@ -395,6 +396,7 @@ class DataClient:
 
         url = f'{self._base_url}{STATS_PATH}'
 
+        item_types = [validate_item_type(item) for item in item_types]
         request = {
             'interval': interval,
             'filter': search_filter,

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -25,6 +25,7 @@ from .. import exceptions
 from ..constants import PLANET_BASE_URL
 from ..http import Session
 from ..models import Paged, StreamingBody
+from ..specs import validate_item_type
 
 BASE_URL = f'{PLANET_BASE_URL}/data/v1/'
 SEARCHES_PATH = '/searches'
@@ -146,7 +147,7 @@ class DataClient:
 
         search_filter = search_filter or empty_filter()
 
-        # TODO: validate item_types
+        item_types = [validate_item_type(item) for item in item_types]
         request_json = {'filter': search_filter, 'item_types': item_types}
         if name:
             request_json['name'] = name


### PR DESCRIPTION
**Related Issue(s):**

Closes #599 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Added validation for `item_type` in the Data client, which allows item types to be case insensitive. Functions affected: 
- **client:** `search()`; **CLI:** `search`
- **client:** `create_search()`; **CLI:** `search-create`
- **client:** `update_search()`; **CLI:** `search-update`
- **client:** `get_stats()`; **CLI:** `stats`

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
```console
> planet data search psscene                                     
Error: {"general": [], "field": {"item_types": [{"message": "Not all item types requested exist or are accessible"}]}}
```
New behavior:
```console
> planet data search psscene                                     
{"_links": {"_self": "https://api.planet.com/data/v1/item-types/PSScene/items/20230328_161317_49_241a", "assets": "https://api.planet.com/data/v1/item-types/PSScene/items/20230328_161317_49_241a/assets/", ...}
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
