### PR TITLE
Match search_update interface to update-search cli interface

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -219,17 +219,17 @@ class DataClient:
 
     async def update_search(self,
                             search_id: str,
-                            name: str,
                             item_types: List[str],
                             search_filter: dict,
+                            name: str,
                             enable_email: bool = False) -> dict:
         """Update an existing saved search.
 
         Parameters:
             search_id: Saved search identifier.
-            name: The name of the saved search.
             item_types: The item types to include in the search.
             search_filter: Structured search criteria.
+            name: The name of the saved search.
             enable_email: Send a daily email when new results are added.
 
         Returns:

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -352,8 +352,9 @@ async def test_update_search_basic(search_filter, session):
 
     cl = DataClient(session, base_url=TEST_URL)
     search = await cl.update_search(VALID_SEARCH_ID,
-                                    'test', ['PSScene'],
-                                    search_filter)
+                                    item_types=['PSScene'],
+                                    search_filter=search_filter,
+                                    name='test')
 
     # check that request is correct
     expected_request = {


### PR DESCRIPTION
**Related Issue(s):**

Closes #908 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Match search_update interface to update-search cli interface. Fixes CLI bug

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```
search = await cl.update_search(VALID_SEARCH_ID,
                                    'test',
                                    ['PSScene'],
                                    search_filter,
                                    )
```

New behavior:

```
search = await cl.update_search(VALID_SEARCH_ID,
                                    ['PSScene'],
                                    search_filter,
                                    'test')
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
