### PR TITLE
document list order ordering

### DIFF
--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -63,6 +63,9 @@ async def list(ctx, state, limit, pretty):
 
     This command prints a sequence of the returned order descriptions,
     optionally pretty-printed.
+
+    Order descriptions are sorted by creation date with the last created order
+    returned first.
     '''
     async with orders_client(ctx) as cl:
         async for o in cl.list_orders(state=state, limit=limit):

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -465,7 +465,10 @@ class OrdersClient:
     async def list_orders(self,
                           state: Optional[str] = None,
                           limit: int = 100) -> AsyncIterator[dict]:
-        """Iterate over the list of stored order requests.
+        """Iterate over the list of stored orders.
+
+        Order descriptions are sorted by creation date with the last created
+        order returned first.
 
         Note:
             The name of this method is based on the API's method name. This


### PR DESCRIPTION
**Related Issue(s):**

Closes #305


**Proposed Changes:**

For inclusion in changelog (if applicable):

1.

Not intended for changelog:

1. document list order ordering in cli and api commands.