### PR TITLE
Fix notifications entry layout

### DIFF
--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -15,7 +15,7 @@
 """Functionality for preparing order details for use in creating an order"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
 import logging
-from typing import Optional, Any, Dict, List
+from typing import Optional, Any, Dict, List, Union
 
 from . import geojson, specs
 from .exceptions import ClientError
@@ -143,19 +143,21 @@ def notifications(email: Optional[bool] = None,
         webhook_per_order: Request a single webhook call per order instead
             of one call per each delivered item.
     '''
-    notifications_dict = {}
+    notifications_dict: Dict[str, Union[dict, bool]] = {}
 
     if webhook_url:
-        webhook_dict = {
-            'url': webhook_url
-            }
+        webhook_dict: Dict[str, Union[str, bool]] = {
+            'url': webhook_url,
+        }
         if webhook_per_order is not None:
-            webhook_dict['per_order'] = webhook_per_order
+            wpo: bool = webhook_per_order
+            webhook_dict['per_order'] = wpo
 
         notifications_dict['webhook'] = webhook_dict
 
     if email is not None:
-        notifications_dict['email'] = email
+        val: bool = email
+        notifications_dict['email'] = val
 
     return notifications_dict
 

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -143,7 +143,21 @@ def notifications(email: Optional[bool] = None,
         webhook_per_order: Request a single webhook call per order instead
             of one call per each delivered item.
     '''
-    return dict((k, v) for k, v in locals().items() if v)
+    notifications_dict = {}
+
+    if webhook_url:
+        webhook_dict = {
+            'url': webhook_url
+            }
+        if webhook_per_order is not None:
+            webhook_dict['per_order'] = webhook_per_order
+
+        notifications_dict['webhook'] = webhook_dict
+
+    if email is not None:
+        notifications_dict['email'] = email
+
+    return notifications_dict
 
 
 def delivery(archive_type: Optional[str] = None,

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -46,9 +46,9 @@ def test_build_request():
         }
     }
     notifications = {
-        'email': 'email',
-        'webhook_url': 'webhookurl',
-        'webhook_per_order': True
+        'email': 'email', 'webhook': {
+            'url': 'webhookurl', 'per_order': True
+        }
     }
     order_type = 'partial'
     tool = {'bandmath': 'jsonstring'}
@@ -121,9 +121,9 @@ def test_notifications():
     notifications_config = order_request.notifications(
         email='email', webhook_url='webhookurl', webhook_per_order=True)
     expected = {
-        'email': 'email',
-        'webhook_url': 'webhookurl',
-        'webhook_per_order': True
+        'email': 'email', 'webhook': {
+            'url': 'webhookurl', 'per_order': True
+        }
     }
     assert notifications_config == expected
 

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -119,9 +119,9 @@ def test_product():
 
 def test_notifications():
     notifications_config = order_request.notifications(
-        email='email', webhook_url='webhookurl', webhook_per_order=True)
+        email=True, webhook_url='webhookurl', webhook_per_order=True)
     expected = {
-        'email': 'email', 'webhook': {
+        'email': True, 'webhook': {
             'url': 'webhookurl', 'per_order': True
         }
     }


### PR DESCRIPTION
**Related Issue(s):**

Closes #916


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Fix order request notification entry layout.

Not intended for changelog:

1. 

**Diff of User Interface**

Script:
```python
import json

from planet import order_request

notification = True
order_uuid = 'test_order'
products = [
        order_request.product(['20230412_054952_10_24cc'], item_type='psscene', product_bundle='analytic_udm2')]
tools = None

if notification:
    notifications = order_request.notifications(
        webhook_per_order=True,
        webhook_url="http://webhookurl",
        email=False,
    )

request = order_request.build_request(
    order_uuid,
    products=products,
    tools=tools,
    notifications=notifications if notifications else None,
)

print(json.dumps(request))
```

Old behavior:

notifications entry is incorrect:
```
{
  "name": "test_order",
  "products": [
    {
      "item_ids": [
        "20230412_054952_10_24cc"
      ],
      "item_type": "PSScene",
      "product_bundle": "analytic_udm2"
    }
  ],
  "notifications": {
    "webhook_url": "http://webhookurl",
    "webhook_per_order": true
  }
}
```

New behavior:

notifications entry is corrected:
```
{
  "name": "test_order",
  "products": [
    {
      "item_ids": [
        "20230412_054952_10_24cc"
      ],
      "item_type": "PSScene",
      "product_bundle": "analytic_udm2"
    }
  ],
  "notifications": {
    "webhook": {
      "url": "http://webhookurl",
      "per_order": true
    },
    "email": false
  }
}
```



**PR Checklist:**

- [] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
