### PR TITLE
do not show source in python api reference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ plugins:
         python:
           rendering:
             show_root_heading: true
+            show_source: false
           selection:
             inherited_members: true
             filters:


### PR DESCRIPTION
Docs no longer include the sourcecode in the python api reference page