### PR TITLE
Protect against injecting javascript:URI into edited href tags

### DIFF
--- a/docs/custom_theme/home.html
+++ b/docs/custom_theme/home.html
@@ -7,10 +7,10 @@
         <div class="mdx-hero__content">
           <h1>Welcome to the {{ config.site_name }}</h1>
           <p>{{ config.site_description }}</p>
-          <a href="{{ 'get-started/quick-start-guide' | url }}" title="Get Started" class="md-button md-button--primary md-button--teriary">
+          <a href="/{{ 'get-started/quick-start-guide' | url }}" title="Get Started" class="md-button md-button--primary md-button--teriary">
             Get started
           </a>
-          <a href="{{ 'get-started/get-your-planet-account' | url }}" title="Get your Planet account" class="md-button md-button--secondary">
+          <a href="/{{ 'get-started/get-your-planet-account' | url }}" title="Get your Planet account" class="md-button md-button--secondary">
             Get a Planet account
           </a>
         </div>

--- a/docs/custom_theme/home.html
+++ b/docs/custom_theme/home.html
@@ -10,7 +10,7 @@
           <a href="/{{ 'get-started/quick-start-guide' | url }}" title="Get Started" class="md-button md-button--primary md-button--teriary">
             Get started
           </a>
-          <a href="/{{ 'get-started/get-your-planet-account' | url }}" title="Get your Planet account" class="md-button md-button--secondary">
+          <a href="./{{ 'get-started/get-your-planet-account' | url }}" title="Get your Planet account" class="md-button md-button--secondary">
             Get a Planet account
           </a>
         </div>

--- a/docs/custom_theme/home.html
+++ b/docs/custom_theme/home.html
@@ -7,7 +7,7 @@
         <div class="mdx-hero__content">
           <h1>Welcome to the {{ config.site_name }}</h1>
           <p>{{ config.site_description }}</p>
-          <a href="/{{ 'get-started/quick-start-guide' | url }}" title="Get Started" class="md-button md-button--primary md-button--teriary">
+          <a href="./{{ 'get-started/quick-start-guide' | url }}" title="Get Started" class="md-button md-button--primary md-button--teriary">
             Get started
           </a>
           <a href="./{{ 'get-started/get-your-planet-account' | url }}" title="Get your Planet account" class="md-button md-button--secondary">


### PR DESCRIPTION
Eliminates the chance that someone could make an evil custom theme. Potentially someone could add a javascript:URI into the edited href tags, which could allow them to craft a malicious custom theme which links to a fake planet website.