### PR TITLE
Added --ids-only option

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -294,7 +294,7 @@ def filter(ctx,
               help='Field and direction to order results by.')
 @click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def search(ctx, item_types, filter, limit, name, sort, pretty, ids_only):
+async def search(ctx, item_types, filter, limit, name, sort, ids_only, pretty):
     """Execute a structured item search.
 
     This function outputs a series of GeoJSON descriptions, one for each of the

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -292,8 +292,9 @@ def filter(ctx,
               default=SEARCH_SORT_DEFAULT,
               show_default=True,
               help='Field and direction to order results by.')
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def search(ctx, item_types, filter, limit, name, sort, pretty):
+async def search(ctx, item_types, filter, limit, name, sort, pretty, ids_only):
     """Execute a structured item search.
 
     This function outputs a series of GeoJSON descriptions, one for each of the
@@ -315,7 +316,10 @@ async def search(ctx, item_types, filter, limit, name, sort, pretty):
                                     name=name,
                                     sort=sort,
                                     limit=limit):
-            echo_json(item, pretty)
+            if ids_only:
+                echo_json(item['id'], pretty)
+            else:
+                echo_json(item, pretty)
 
 
 @data.command(epilog=valid_item_string)

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -375,26 +375,19 @@ async def search_create(ctx, item_types, filter, name, daily_email, pretty):
               default=LIST_SEARCH_TYPE_DEFAULT,
               show_default=True,
               help='Search type filter.')
-@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @limit
 @pretty
-async def search_list(ctx, sort, search_type, limit, ids_only, pretty):
+async def search_list(ctx, sort, search_type, limit, pretty):
     """List saved searches.
 
     This function outputs a full JSON description of the saved searches,
     optionally pretty-printed.
     """
     async with data_client(ctx) as cl:
-        item_ids = []
         async for item in cl.list_searches(sort=sort,
                                            search_type=search_type,
                                            limit=limit):
-            if ids_only:
-                item_ids.append(item['id'])
-            else:
-                echo_json(item, pretty)
-        if ids_only:
-            click.echo(','.join(item_ids))
+            echo_json(item, pretty)
 
 
 @data.command()
@@ -408,16 +401,23 @@ async def search_list(ctx, sort, search_type, limit, ids_only, pretty):
               show_default=True,
               help='Field and direction to order results by.')
 @limit
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def search_run(ctx, search_id, sort, limit, pretty):
+async def search_run(ctx, search_id, sort, limit, ids_only, pretty):
     """Execute a saved structured item search.
 
     This function outputs a series of GeoJSON descriptions, one for each of the
     returned items, optionally pretty-printed.
     """
     async with data_client(ctx) as cl:
+        item_ids = []
         async for item in cl.run_search(search_id, sort=sort, limit=limit):
-            echo_json(item, pretty)
+            if ids_only:
+                item_ids.append(item['id'])
+            else:
+                echo_json(item, pretty)
+        if ids_only:
+            click.echo(','.join(item_ids))
 
 
 @data.command(epilog=valid_item_string)

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -321,7 +321,7 @@ async def search(ctx, item_types, filter, limit, name, sort, ids_only, pretty):
             else:
                 echo_json(item, pretty)
         if ids_only:
-            click.echo(', '.join(item_ids))
+            click.echo(','.join(item_ids))
 
 
 @data.command(epilog=valid_item_string)
@@ -375,19 +375,26 @@ async def search_create(ctx, item_types, filter, name, daily_email, pretty):
               default=LIST_SEARCH_TYPE_DEFAULT,
               show_default=True,
               help='Search type filter.')
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @limit
 @pretty
-async def search_list(ctx, sort, search_type, limit, pretty):
+async def search_list(ctx, sort, search_type, limit, ids_only, pretty):
     """List saved searches.
 
     This function outputs a full JSON description of the saved searches,
     optionally pretty-printed.
     """
     async with data_client(ctx) as cl:
+        item_ids = []
         async for item in cl.list_searches(sort=sort,
                                            search_type=search_type,
                                            limit=limit):
-            echo_json(item, pretty)
+            if ids_only:
+                item_ids.append(item['id'])
+            else:
+                echo_json(item, pretty)
+        if ids_only:
+            click.echo(','.join(item_ids))
 
 
 @data.command()

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -310,16 +310,18 @@ async def search(ctx, item_types, filter, limit, name, sort, ids_only, pretty):
     parameter will be applied to the stored quick search.
     """
     async with data_client(ctx) as cl:
-
+        item_ids = []
         async for item in cl.search(item_types,
                                     search_filter=filter,
                                     name=name,
                                     sort=sort,
                                     limit=limit):
             if ids_only:
-                echo_json(item['id'], pretty)
+                item_ids.append(item['id'])
             else:
                 echo_json(item, pretty)
+        if ids_only:
+            click.echo(', '.join(item_ids))
 
 
 @data.command(epilog=valid_item_string)

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -209,8 +209,9 @@ async def download(ctx, order_id, overwrite, directory, checksum):
 @translate_exceptions
 @coro
 @click.argument("request", type=types.JSON())
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def create(ctx, request: str, pretty):
+async def create(ctx, request: str, ids_only, pretty):
     '''Create an order.
 
     This command outputs the created order description, optionally
@@ -221,6 +222,10 @@ async def create(ctx, request: str, pretty):
     '''
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
+    if ids_only:
+        item_ids = order['products'][0]['item_ids']
+        click.echo(','.join(item_ids))
+    else:
         echo_json(order, pretty)
 
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -77,16 +77,20 @@ async def list(ctx, state, limit, pretty):
 @translate_exceptions
 @coro
 @click.argument('order_id', type=click.UUID)
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def get(ctx, order_id, pretty):
+async def get(ctx, order_id, ids_only, pretty):
     """Get order
 
     This command outputs the order description, optionally pretty-printed.
     """
     async with orders_client(ctx) as cl:
         order = await cl.get_order(str(order_id))
-
-    echo_json(order, pretty)
+    if ids_only:
+        item_ids = order['products'][0]['item_ids']
+        click.echo(','.join(item_ids))
+    else:
+        echo_json(order, pretty)
 
 
 @orders.command()
@@ -205,8 +209,9 @@ async def download(ctx, order_id, overwrite, directory, checksum):
 @translate_exceptions
 @coro
 @click.argument("request", type=types.JSON())
+@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def create(ctx, request: str, pretty):
+async def create(ctx, request: str, ids_only, pretty):
     '''Create an order.
 
     This command outputs the created order description, optionally
@@ -217,8 +222,11 @@ async def create(ctx, request: str, pretty):
     '''
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
-
-    echo_json(order, pretty)
+    if ids_only:
+        item_ids = order['products'][0]['item_ids']
+        click.echo(','.join(item_ids))
+    else:
+        echo_json(order, pretty)
 
 
 @orders.command()

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -209,9 +209,8 @@ async def download(ctx, order_id, overwrite, directory, checksum):
 @translate_exceptions
 @coro
 @click.argument("request", type=types.JSON())
-@click.option('--ids-only', is_flag=True, help='Returns only the item IDs.')
 @pretty
-async def create(ctx, request: str, ids_only, pretty):
+async def create(ctx, request: str, pretty):
     '''Create an order.
 
     This command outputs the created order description, optionally
@@ -222,10 +221,6 @@ async def create(ctx, request: str, ids_only, pretty):
     '''
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
-    if ids_only:
-        item_ids = order['products'][0]['item_ids']
-        click.echo(','.join(item_ids))
-    else:
         echo_json(order, pretty)
 
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -77,14 +77,23 @@ def subscriptions(ctx, base_url):
     default=None,
     help="Select subscriptions in one or more states. Default is all.")
 @limit
+@click.option('--ids-only',
+              is_flag=True,
+              help='Returns only the subscription ID.')
 @click.pass_context
 @translate_exceptions
 @coro
-async def list_subscriptions_cmd(ctx, status, limit, pretty):
+async def list_subscriptions_cmd(ctx, status, limit, ids_only, pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
     async with subscriptions_client(ctx) as client:
+        subscription_ids = []
         async for sub in client.list_subscriptions(status=status, limit=limit):
-            echo_json(sub, pretty)
+            if ids_only:
+                subscription_ids.append(sub['id'])
+            else:
+                echo_json(sub, pretty)
+        if ids_only:
+            click.echo(','.join(subscription_ids))
 
 
 @subscriptions.command(name='create')

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -77,23 +77,14 @@ def subscriptions(ctx, base_url):
     default=None,
     help="Select subscriptions in one or more states. Default is all.")
 @limit
-@click.option('--ids-only',
-              is_flag=True,
-              help='Returns only the subscription ID.')
 @click.pass_context
 @translate_exceptions
 @coro
-async def list_subscriptions_cmd(ctx, status, limit, ids_only, pretty):
+async def list_subscriptions_cmd(ctx, status, limit, pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
     async with subscriptions_client(ctx) as client:
-        subscription_ids = []
         async for sub in client.list_subscriptions(status=status, limit=limit):
-            if ids_only:
-                subscription_ids.append(sub['id'])
-            else:
-                echo_json(sub, pretty)
-        if ids_only:
-            click.echo(','.join(subscription_ids))
+            echo_json(sub, pretty)
 
 
 @subscriptions.command(name='create')


### PR DESCRIPTION
**Related Issue(s):**

Closes #645 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Added a flag, `ids-only`, which returns only the item IDs from a search or order, to the following functions: `data search`, `data search-run`, `orders get`

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
❯ planet <command>  | jq -r .id | tr '\n' ',' | sed 's/.$//'
Comma separate list of item ids
```

_For example,_ **data search**
```console
❯ planet data search psscene --limit 10 | jq -r .id | tr '\n' ',' | sed 's/.$//'                      
20230427_104445_51_248b,20230427_072107_90_242e,20230427_071646_44_248c,20230303_161806_29_24bb,20230303_161803_87_24bb,20230427_104441_19_248b,20230427_104126_76_248b,20230427_103940_90_248b,20230427_100416_94_249a,20230427_082511_30_24bc%                                                                                    
```

New behavior:

```console
❯ planet <command>  --ids-only
Comma separate list of item ids
```

**data search**
```console
❯ planet data search psscene --limit 10 --ids-only                                                      
20230426_065727_44_2479,20230426_171106_48_2423,20230426_174958_25_24b9,20230426_170845_64_2423,20230426_170834_96_2423,20230426_165943_74_2416,20230426_161130_11_24b5,20230426_161044_90_24b5,20230426_092428_35_2432,20230426_085011_34_2465
```

**data search-run**
```console
❯ planet data search-run 42b0e1ff085d4a57a34236d36674703e --limit 10 --ids-only   
20230427_072359_07_2458,20230427_072754_74_242b,20230427_061032_97_2473,20230427_071806_81_242b,20230427_052015_19_2446,20230426_140020_91_2276,20230426_135909_86_2276,20230427_025450_23_2415,20230427_072850_11_242b,20230427_070835_13_24af
```

**orders get**
```console
❯ planet orders get 38d89352-e90a-4cd7-9964-dfe629d5081b --ids-only
20230409_100344_03_2484,20230409_100341_88_2484,20230409_101856_12_2414,20230409_101854_08_2414,20230406_100337_05_2488
```

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
