### PR TITLE
fix build metadata and wheel name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal: 1
-
 [metadata]
 license_file: LICENSE
 

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,12 @@ setup(
     long_description=Path("README.md").read_text("utf-8"),
     long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development',
         'Topic :: Utilities'


### PR DESCRIPTION
**Related Issue(s):**

Closes # 949


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Fixes the compiled wheel name, removing `py2` from the name.
2. Fixes the package metadata, indicating that it is a stable release and supports Python 3 specifically.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
> nox -s build
...
Successfully built planet-2.0.2.dev0.tar.gz and planet-2.0.2.dev0-py2.py3-none-any.whl
```

New behavior:

```console
> nox -s build
...
Successfully built planet-2.0.2.dev0.tar.gz and planet-2.0.2.dev0-py3-none-any.whl
```


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
