### PR TITLE
Broken cli docs geom inputs 951

### DIFF
--- a/docs/cli/cli-data.md
+++ b/docs/cli/cli-data.md
@@ -223,7 +223,7 @@ planet data filter --geom geometry.geojson | planet data search --limit 500 PSSc
 ```
 
 Creating geometries for search can be annoying in a command-line workflow, but there are some ideas in the
-[Advanced CLI Tutorial](cli-plus-tutorial.md#geometry-inputs).
+[Advanced CLI Tutorial](cli-tips-tricks.md#geometry-inputs).
 
 ### Date Filter
 

--- a/docs/cli/cli-data.md
+++ b/docs/cli/cli-data.md
@@ -132,7 +132,7 @@ planet data search PSScene | planet collect - > planet-search.geojson
 ```
 
 This you can then open with your favorite GIS program, or see this 
-[geometry visualization](cli-plus-tutorial.md#geometry-inputs) section for some ideas that flow a bit better with 
+[geometry visualization](cli-tips-tricks.md#geometry-inputs) section for some ideas that flow a bit better with 
 the command-line.
 
 ### Sort


### PR DESCRIPTION
**Related Issue(s):**

Closes #951 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Fixed broken links on "CLI for Data API Tutorial" page.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
Broken link: https://planet-sdk-for-python-v2.readthedocs.io/en/latest/cli/cli-data/cli-plus-tutorial.md#geometry-inputs

New behavior:
Fixed with this link: https://planet-sdk-for-python-v2.readthedocs.io/en/latest/cli/cli-tips-tricks/#geometry-visualization



**PR Checklist:**

- [] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
