### PR TITLE
Force stac to false for GEE deliveries

### DIFF
--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -602,7 +602,7 @@ planet orders request \
     --name 'No STAC' \
     --no-stac \
     20220605_124027_64_242b
-``` 
+```
 
 Currently this needs to be done for any 'composite' operation, as STAC output from composites is not yet 
 supported (but is coming). You can explicitly add `--stac`, but it is the default, so does not need to

--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -602,11 +602,13 @@ planet orders request \
     --name 'No STAC' \
     --no-stac \
     20220605_124027_64_242b
-```
+``` 
 
 Currently this needs to be done for any 'composite' operation, as STAC output from composites is not yet 
 supported (but is coming). You can explicitly add `--stac`, but it is the default, so does not need to
 be included. For more information about Planet’s STAC output see the [Orders API documentation](https://developers.planet.com/apis/orders/delivery/#stac-metadata).
+
+Orders with Google Earth Engine delivery will force the STAC flag to false.
 
 ### Cloud Delivery
 

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -263,7 +263,8 @@ async def create(ctx, request: str, pretty):
     default=True,
     is_flag=True,
     help="""Include or exclude metadata in SpatioTemporal Asset Catalog (STAC)
-    format. Not specifying either defaults to including it (--stac).""")
+    format. Not specifying either defaults to including it (--stac), except
+    for orders with google_earth_engine delivery""")
 @pretty
 async def request(ctx,
                   item_type,

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -304,6 +304,8 @@ async def request(ctx,
 
     if cloudconfig:
         delivery = planet.order_request.delivery(cloud_config=cloudconfig)
+        if "google_earth_engine" in cloudconfig:
+            stac = False
     else:
         delivery = None
 


### PR DESCRIPTION
Related Issue(s):

Closes https://github.com/planetlabs/planet-client-python/issues/958

**Proposed Changes:**

The Orders API will soon surface validation errors when stac is specified for GEE orders. It may be ergonomic for the CLI to force the stac flag to false, rather than requiring users to specify `--no-stac` for GEE orders.
For inclusion in changelog (if applicable):

1. Orders cli will force stac flag to false for GEE deliveries

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
```
$ planet orders request --name "gee_order" --bundle analytic_8b_sr_udm2 20220913_095949_35_24a5,20220829_095558_47_2479,20220824_101550_14_2403 --item-type PSScene --cloudconfig cloudconfig.json
{"name": "gee_order", "products": [{"item_ids": ["20220913_095949_35_24a5", "20220829_095558_47_2479", "20220824_101550_14_2403"], "item_type": "PSScene", "product_bundle": "analytic_8b_sr_udm2"}], "metadata": {"stac": {}}, "delivery": {<REDACTED>}}}
```
After creating the waiting for the order to complete, we won't see our images available in earth engine

```
$ earthengine ls projects/<project>/assets/<collection> | grep 20220913_095949_35_24a5
$
```

New behavior:
```
$ planet orders request --name "gee_order" --bundle analytic_8b_sr_udm2 20220913_095949_35_24a5,20220829_095558_47_2479,20220824_101550_14_2403 --item-type PSScene --cloudconfig cloudconfig.json
{"name": "gee_order", "products": [{"item_ids": ["20220913_095949_35_24a5", "20220829_095558_47_2479", "20220824_101550_14_2403"], "item_type": "PSScene", "product_bundle": "analytic_8b_sr_udm2"}], "delivery": {<REDACTED>}}}
```

After waiting for the order to complete, our images are available in earth engine
```
$ earthengine ls projects/<project>/assets/<collection> | grep 20220913_095949_35_24a5
projects/<project>/assets/<collection>/20220913_095949_35_24a5_3B_AnalyticMS_SR_8b
```