### PR TITLE
Add SkySatVideo as a valid data api item type

### DIFF
--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -28,7 +28,7 @@ from planet.clients.data import (SEARCH_SORT,
                                  SEARCH_SORT_DEFAULT,
                                  STATS_INTERVAL)
 
-from planet.specs import (get_item_types,
+from planet.specs import (get_data_item_types,
                           validate_data_item_type,
                           SpecificationException)
 
@@ -38,8 +38,8 @@ from .io import echo_json
 from .options import limit, pretty
 from .session import CliSession
 
-ALL_ITEM_TYPES = get_item_types()
-valid_item_string = "Valid entries for ITEM_TYPES: " + "|".join(ALL_ITEM_TYPES)
+valid_item_string = "Valid entries for ITEM_TYPES: " + "|".join(
+    get_data_item_types())
 
 
 @asynccontextmanager

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -29,7 +29,7 @@ from planet.clients.data import (SEARCH_SORT,
                                  STATS_INTERVAL)
 
 from planet.specs import (get_item_types,
-                          validate_item_type,
+                          validate_data_item_type,
                           SpecificationException)
 
 from . import types
@@ -75,7 +75,7 @@ def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
     item types.'''
     try:
         for item_type in item_types:
-            validate_item_type(item_type)
+            validate_data_item_type(item_type)
         return item_types
     except SpecificationException as e:
         raise click.BadParameter(str(e))
@@ -85,7 +85,7 @@ def check_item_type(ctx, param, item_type) -> Optional[List[dict]]:
     '''Validates the item type provided by comparing it to all supported
     item types.'''
     try:
-        validate_item_type(item_type)
+        validate_data_item_type(item_type)
     except SpecificationException as e:
         raise click.BadParameter(str(e))
 

--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -25,7 +25,7 @@ from .. import exceptions
 from ..constants import PLANET_BASE_URL
 from ..http import Session
 from ..models import Paged, StreamingBody
-from ..specs import validate_item_type
+from ..specs import validate_data_item_type
 
 BASE_URL = f'{PLANET_BASE_URL}/data/v1/'
 SEARCHES_PATH = '/searches'
@@ -147,7 +147,7 @@ class DataClient:
 
         search_filter = search_filter or empty_filter()
 
-        item_types = [validate_item_type(item) for item in item_types]
+        item_types = [validate_data_item_type(item) for item in item_types]
         request_json = {'filter': search_filter, 'item_types': item_types}
         if name:
             request_json['name'] = name
@@ -204,7 +204,7 @@ class DataClient:
         """
         url = self._searches_url()
 
-        item_types = [validate_item_type(item) for item in item_types]
+        item_types = [validate_data_item_type(item) for item in item_types]
         request = {
             'name': name,
             'filter': search_filter,
@@ -237,7 +237,7 @@ class DataClient:
         """
         url = f'{self._searches_url()}/{search_id}'
 
-        item_types = [validate_item_type(item) for item in item_types]
+        item_types = [validate_data_item_type(item) for item in item_types]
         request = {
             'name': name,
             'filter': search_filter,
@@ -396,7 +396,7 @@ class DataClient:
 
         url = f'{self._base_url}{STATS_PATH}'
 
-        item_types = [validate_item_type(item) for item in item_types]
+        item_types = [validate_data_item_type(item) for item in item_types]
         request = {
             'interval': interval,
             'filter': search_filter,
@@ -450,7 +450,7 @@ class DataClient:
             planet.exceptions.ClientError: If asset type identifier is not
             valid.
         """
-        item_type_id = validate_item_type(item_type_id)
+        item_type_id = validate_data_item_type(item_type_id)
         assets = await self.list_item_assets(item_type_id, item_id)
 
         try:

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -73,10 +73,14 @@ def validate_item_type(item_type):
 def validate_data_item_type(item_type):
     '''Item types supported by the data api.'''
     # This is a quick-fix for gh-956
-    # Ideally, data api will provide it's own source
-    orders_supported_item_types = get_item_types()
-    supported_item_types = orders_supported_item_types | {'SkySatVideo'}
-    return _validate_field(item_type, supported_item_types, 'item_type')
+    return _validate_field(item_type, get_data_item_types(), 'item_type')
+
+
+def get_data_item_types():
+    # This is a quick-fix for gh-956
+    orders_item_types = get_item_types()
+    data_item_types = orders_item_types | {'SkySatVideo'}
+    return data_item_types
 
 
 def validate_order_type(order_type):

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -71,16 +71,14 @@ def validate_item_type(item_type):
 
 
 def validate_data_item_type(item_type):
-    '''Item types supported by the data api.'''
-    # This is a quick-fix for gh-956
+    '''Validate and correct capitalization of data api item type.'''
     return _validate_field(item_type, get_data_item_types(), 'item_type')
 
 
 def get_data_item_types():
-    # This is a quick-fix for gh-956
-    orders_item_types = get_item_types()
-    data_item_types = orders_item_types | {'SkySatVideo'}
-    return data_item_types
+    '''Item types supported by the data api.'''
+    # This is a quick-fix for gh-956, to be superseded by gh-960
+    return get_item_types() | {'SkySatVideo'}
 
 
 def validate_order_type(order_type):

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -70,6 +70,15 @@ def validate_item_type(item_type):
     return _validate_field(item_type, supported_item_types, 'item_type')
 
 
+def validate_data_item_type(item_type):
+    '''Item types supported by the data api.'''
+    # This is a quick-fix for gh-956
+    # Ideally, data api will provide it's own source
+    orders_supported_item_types = get_item_types()
+    supported_item_types = orders_supported_item_types | {'SkySatVideo'}
+    return _validate_field(item_type, supported_item_types, 'item_type')
+
+
 def validate_order_type(order_type):
     return _validate_field(order_type, SUPPORTED_ORDER_TYPES, 'order_type')
 

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -103,6 +103,11 @@ def test_validate_item_type_notsupported_itemtype():
         specs.validate_item_type('notsupported')
 
 
+def test_validate_data_item_type():
+    '''ensure skysatvideo is included'''
+    specs.validate_data_item_type('skysatvideo')
+
+
 def test_validate_order_type_supported():
     assert 'full' == specs.validate_order_type('FULL')
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #956


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Separate data api item type validation from orders api item type validation, add SkySatVideo as a valid data api item type

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

```console
planet-client-python$> planet data search --help
Usage: planet data search [OPTIONS] ITEM_TYPES

...

  Valid entries for ITEM_TYPES: MYD09GA|MOD09GA|Sentinel1|Landsat8
  L1G|PSScene|SkySatCollect|MYD09GQ|PSOrthoTile|MOD09GQ|REScene|Sentinel2L1C|S
  kySatScene|REOrthoTile
```

```console
planet data search skysatvideo
Usage: planet data search [OPTIONS] ITEM_TYPES
Try 'planet data search --help' for help.

Error: Invalid value for 'ITEM_TYPES': item_type - 'skysatvideo' is not one of 'REOrthoTile', 'REScene', 'MOD09GA', 'Landsat8L1G', 'SkySatScene', 'MYD09GQ', 'MYD09GA', 'MOD09GQ', 'PSScene', 'SkySatCollect', 'Sentinel1', 'PSOrthoTile', 'Sentinel2L1C'.
```

New behavior:

SkySatVideo listed as a valid entry for ITEM_TYPE
```console
planet-client-python$> planet data search --help
Usage: planet data search [OPTIONS] ITEM_TYPES

...

  Valid entries for ITEM_TYPES: MYD09GA|MOD09GA|Sentinel1|SkySatVideo|Landsat8
  L1G|PSScene|SkySatCollect|MYD09GQ|PSOrthoTile|MOD09GQ|REScene|Sentinel2L1C|S
  kySatScene|REOrthoTile
```

```console
planet data search skysatvideo
<VALID_SKYSATVIDEO_ITEM_DESCRIPTIONS>
```


**PR Checklist:**

- [] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
