### PR TITLE
Update CI to add 3.12 and change yapf check to use 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Pip cache
       uses: actions/cache@v2
       with:
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Pip cache
       uses: actions/cache@v2
       with:
@@ -53,15 +53,16 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Pip cache
       uses: actions/cache@v2
       with:
@@ -79,11 +80,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Pip cache
       uses: actions/cache@v2
       with:
@@ -101,11 +102,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Pip cache
       uses: actions/cache@v2
       with:

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,7 +37,7 @@ def coverage(session):
     session.run('coverage', 'report')
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def test(session):
     session.install(".[test]")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,13 @@ def test(session):
     # -W=error raises pytest warnings to errors so they are caught by CI
     # to exclude some warnings, see
     # https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings
-    session.run('pytest', '--ignore', 'examples/', '-v', '-W=error', '-W=ignore::DeprecationWarning:tqdm', *options)
+    session.run('pytest',
+                '--ignore',
+                'examples/',
+                '-v',
+                '-W=error',
+                '-W=ignore::DeprecationWarning:tqdm',
+                *options)
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,18 +39,22 @@ def coverage(session):
 
 @nox.session(python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def test(session):
+    session.run('python', '-m', 'ensurepip', '--upgrade')
+    session.install('-U', 'setuptools')
     session.install(".[test]")
 
     options = session.posargs
     # -W=error raises pytest warnings to errors so they are caught by CI
     # to exclude some warnings, see
     # https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings
-    session.run('pytest',
+    session.run('python',
+                '-m',
+                'pytest',
                 '--ignore',
                 'examples/',
                 '-v',
-                '-W=error',
-                '-W=ignore::DeprecationWarning:tqdm',
+                '-Werror',
+                '-Wignore::DeprecationWarning:tqdm.std',
                 *options)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ def test(session):
     # -W=error raises pytest warnings to errors so they are caught by CI
     # to exclude some warnings, see
     # https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings
-    session.run('pytest', '--ignore', 'examples/', '-v', '-W=error', *options)
+    session.run('pytest', '--ignore', 'examples/', '-v', '-W=error', '-W=ignore::DeprecationWarning:tqdm', *options)
 
 
 @nox.session

--- a/planet/__version__.py
+++ b/planet/__version__.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.3'
+__version__ = '2.1.0dev'

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -205,10 +205,10 @@ async def list_subscription_results_cmd(ctx,
     '--notifications',
     type=types.JSON(),
     help='Notifications JSON. Can be a string, filename, or - for stdin.')
-@click.option('--tools',
-              type=types.JSON(),
-              help='Toolchain JSON. Can be a string, filename, or - for stdin.'
-              )
+@click.option(
+    '--tools',
+    type=types.JSON(),
+    help='Toolchain JSON. Can be a string, filename, or - for stdin.')
 @pretty
 def request(name, source, delivery, notifications, tools, pretty):
     """Generate a subscriptions request."""
@@ -247,10 +247,10 @@ def request(name, source, delivery, notifications, tools, pretty):
 @click.option('--rrule',
               type=str,
               help='iCalendar recurrance rule to specify recurrances.')
-@click.option('--filter',
-              type=types.JSON(),
-              help='Search filter.  Can be a string, filename, or - for stdin.'
-              )
+@click.option(
+    '--filter',
+    type=types.JSON(),
+    help='Search filter.  Can be a string, filename, or - for stdin.')
 @pretty
 def request_catalog(item_types,
                     asset_types,

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -875,11 +875,11 @@ async def test_download_asset(exists,
 
 @respx.mock
 @pytest.mark.anyio
-@pytest.mark.parametrize("hashes_match, md5_entry, expectation",
-                         [(True, True, does_not_raise()),
-                          (False, True, pytest.raises(exceptions.ClientError)),
-                          (True, False, pytest.raises(exceptions.ClientError))]
-                         )
+@pytest.mark.parametrize(
+    "hashes_match, md5_entry, expectation",
+    [(True, True, does_not_raise()),
+     (False, True, pytest.raises(exceptions.ClientError)),
+     (True, False, pytest.raises(exceptions.ClientError))])
 async def test_validate_checksum(hashes_match, md5_entry, expectation, tmpdir):
     test_bytes = b'foo bar'
     testfile = Path(tmpdir / 'test.txt')


### PR DESCRIPTION
Yapf 0.40.1 has different behavior for Python versions 3.7 and 3.8. Since 3.7 is EOL, we'll make 3.8 the new baseline.