### PR TITLE
Replace single- with double-quote for docstrings, as per PEP-257

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -85,7 +85,7 @@ def docs(session):
 
 @nox.session
 def watch(session):
-    '''Build and serve live docs for editing'''
+    """Build and serve live docs for editing"""
     session.install("-e", ".[docs]")
 
     session.run("mkdocs", "serve")
@@ -104,7 +104,7 @@ def examples(session):
 
 @nox.session
 def build(session):
-    '''Build package'''
+    """Build package"""
     # check preexisting
     exist_but_should_not = [p for p in BUILD_DIRS if Path(p).is_dir()]
     if exist_but_should_not:
@@ -119,7 +119,7 @@ def build(session):
 
 @nox.session
 def clean(session):
-    '''Remove build directories'''
+    """Remove build directories"""
     to_remove = [Path(d) for d in BUILD_DIRS if Path(d).is_dir()]
     for p in to_remove:
         shutil.rmtree(p)
@@ -127,13 +127,13 @@ def clean(session):
 
 @nox.session
 def publish_testpypi(session):
-    '''Publish to TestPyPi using API token'''
+    """Publish to TestPyPi using API token"""
     _publish(session, 'testpypi')
 
 
 @nox.session
 def publish_pypi(session):
-    '''Publish to PyPi using API token'''
+    """Publish to PyPi using API token"""
     _publish(session, 'pypi')
 
 

--- a/planet/auth.py
+++ b/planet/auth.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''Manage authentication with Planet APIs'''
+"""Manage authentication with Planet APIs"""
 from __future__ import annotations  # https://stackoverflow.com/a/33533514
 import abc
 import json
@@ -38,15 +38,15 @@ AuthType = httpx.Auth
 
 
 class Auth(metaclass=abc.ABCMeta):
-    '''Handle authentication information for use with Planet APIs.'''
+    """Handle authentication information for use with Planet APIs."""
 
     @staticmethod
     def from_key(key: str) -> AuthType:
-        '''Obtain authentication from api key.
+        """Obtain authentication from api key.
 
         Parameters:
             key: Planet API key
-        '''
+        """
         auth = APIKeyAuth(key=key)
         LOGGER.debug('Auth obtained from api key.')
         return auth
@@ -55,7 +55,7 @@ class Auth(metaclass=abc.ABCMeta):
     def from_file(
         filename: Optional[typing.Union[str,
                                         pathlib.Path]] = None) -> AuthType:
-        '''Create authentication from secret file.
+        """Create authentication from secret file.
 
         The secret file is named `.planet.json` and is stored in the user
         directory. The file has a special format and should have been created
@@ -64,7 +64,7 @@ class Auth(metaclass=abc.ABCMeta):
         Parameters:
             filename: Alternate path for the planet secret file.
 
-        '''
+        """
         filename = filename or SECRET_FILE_PATH
 
         try:
@@ -80,13 +80,13 @@ class Auth(metaclass=abc.ABCMeta):
 
     @staticmethod
     def from_env(variable_name: Optional[str] = None) -> AuthType:
-        '''Create authentication from environment variable.
+        """Create authentication from environment variable.
 
         Reads the `PL_API_KEY` environment variable
 
         Parameters:
             variable_name: Alternate environment variable.
-        '''
+        """
         variable_name = variable_name or ENV_API_KEY
         api_key = os.getenv(variable_name, '')
         try:
@@ -102,7 +102,7 @@ class Auth(metaclass=abc.ABCMeta):
     def from_login(email: str,
                    password: str,
                    base_url: Optional[str] = None) -> AuthType:
-        '''Create authentication from login email and password.
+        """Create authentication from login email and password.
 
         Note: To keep your password secure, the use of `getpass` is
         recommended.
@@ -112,7 +112,7 @@ class Auth(metaclass=abc.ABCMeta):
             password: Planet account password.
             base_url: The base URL to use. Defaults to production
                 authentication API base url.
-        '''
+        """
         cl = AuthClient(base_url=base_url)
         auth_data = cl.login(email, password)
 
@@ -137,11 +137,11 @@ class Auth(metaclass=abc.ABCMeta):
 
     def store(self,
               filename: Optional[typing.Union[str, pathlib.Path]] = None):
-        '''Store authentication information in secret file.
+        """Store authentication information in secret file.
 
         Parameters:
             filename: Alternate path for the planet secret file.
-        '''
+        """
         filename = filename or SECRET_FILE_PATH
         secret_file = _SecretFile(filename)
         secret_file.write(self.to_dict())
@@ -160,7 +160,7 @@ class AuthClient:
             self._base_url = self._base_url[:-1]
 
     def login(self, email: str, password: str) -> dict:
-        '''Login using email identity and credentials.
+        """Login using email identity and credentials.
 
         Note: To keep your password secure, the use of `getpass` is
         recommended.
@@ -172,7 +172,7 @@ class AuthClient:
         Returns:
              A JSON object containing an `api_key` property with the user's
         API_KEY.
-        '''
+        """
         url = f'{self._base_url}/login'
         data = {'email': email, 'password': password}
 
@@ -182,29 +182,29 @@ class AuthClient:
 
     @staticmethod
     def decode_response(response):
-        '''Decode the token JWT'''
+        """Decode the token JWT"""
         token = response.json()['token']
         return jwt.decode(token, options={'verify_signature': False})
 
 
 class APIKeyAuthException(Exception):
-    '''exceptions thrown by APIKeyAuth'''
+    """exceptions thrown by APIKeyAuth"""
     pass
 
 
 class APIKeyAuth(httpx.BasicAuth, Auth):
-    '''Planet API Key authentication.'''
+    """Planet API Key authentication."""
     DICT_KEY = 'key'
 
     def __init__(self, key: str):
-        '''Initialize APIKeyAuth.
+        """Initialize APIKeyAuth.
 
         Parameters:
             key: API key.
 
         Raises:
             APIKeyException: If API key is None or empty string.
-        '''
+        """
         if not key:
             raise APIKeyAuthException('API key cannot be empty.')
         self._key = key
@@ -212,12 +212,12 @@ class APIKeyAuth(httpx.BasicAuth, Auth):
 
     @classmethod
     def from_dict(cls, data: dict) -> APIKeyAuth:
-        '''Instantiate APIKeyAuth from a dict.'''
+        """Instantiate APIKeyAuth from a dict."""
         api_key = data[cls.DICT_KEY]
         return cls(api_key)
 
     def to_dict(self):
-        '''Represent APIKeyAuth as a dict.'''
+        """Represent APIKeyAuth as a dict."""
         return {self.DICT_KEY: self._key}
 
     @property
@@ -262,7 +262,7 @@ class _SecretFile:
         return contents
 
     def _enforce_permissions(self):
-        '''if the file's permissions are not what they should be, fix them'''
+        """if the file's permissions are not what they should be, fix them"""
         if self.path.exists():
             # in octal, permissions is the last three bits of the mode
             file_permissions = self.path.stat().st_mode & 0o777

--- a/planet/cli/auth.py
+++ b/planet/cli/auth.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
               default=None,
               help='Assign custom base Auth API URL.')
 def auth(ctx, base_url):
-    '''Commands for working with Planet authentication'''
+    """Commands for working with Planet authentication"""
     ctx.obj['BASE_URL'] = base_url
 
 
@@ -47,7 +47,7 @@ def auth(ctx, base_url):
                        confirmation_prompt=False,
                        help=('Account password. Will not be saved.'))
 def init(ctx, email, password):
-    '''Obtain and store authentication information'''
+    """Obtain and store authentication information"""
     base_url = ctx.obj['BASE_URL']
     plauth = planet.Auth.from_login(email, password, base_url=base_url)
     plauth.store()
@@ -61,7 +61,7 @@ def init(ctx, email, password):
 @auth.command()
 @translate_exceptions
 def value():
-    '''Print the stored authentication information'''
+    """Print the stored authentication information"""
     click.echo(planet.Auth.from_file().value)
 
 
@@ -69,7 +69,7 @@ def value():
 @translate_exceptions
 @click.argument('key')
 def store(key):
-    '''Store authentication information'''
+    """Store authentication information"""
     plauth = planet.Auth.from_key(key)
     if click.confirm('This overrides the stored value. Continue?'):
         plauth.store()

--- a/planet/cli/data.py
+++ b/planet/cli/data.py
@@ -56,7 +56,7 @@ async def data_client(ctx):
               default=None,
               help='Assign custom base Orders API URL.')
 def data(ctx, base_url):
-    '''Commands for interacting with the Data API'''
+    """Commands for interacting with the Data API"""
     ctx.obj['BASE_URL'] = base_url
 
 
@@ -71,8 +71,8 @@ def assets_to_filter(ctx, param, assets: List[str]) -> Optional[dict]:
 
 
 def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
-    '''Validates each item types provided by comparing them to all supported
-    item types.'''
+    """Validates each item types provided by comparing them to all supported
+    item types."""
     try:
         for item_type in item_types:
             validate_data_item_type(item_type)
@@ -82,8 +82,8 @@ def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
 
 
 def check_item_type(ctx, param, item_type) -> Optional[List[dict]]:
-    '''Validates the item type provided by comparing it to all supported
-    item types.'''
+    """Validates the item type provided by comparing it to all supported
+    item types."""
     try:
         validate_data_item_type(item_type)
     except SpecificationException as e:
@@ -93,7 +93,7 @@ def check_item_type(ctx, param, item_type) -> Optional[List[dict]]:
 
 
 def check_search_id(ctx, param, search_id) -> str:
-    '''Ensure search id is a valix hex string'''
+    """Ensure search id is a valix hex string"""
     try:
         _ = DataClient._check_search_id(search_id)
     except exceptions.ClientError as e:
@@ -580,7 +580,7 @@ async def asset_download(ctx,
 @click.argument("item_id")
 @click.argument("asset_type")
 async def asset_activate(ctx, item_type, item_id, asset_type):
-    '''Activate an asset.'''
+    """Activate an asset."""
     async with data_client(ctx) as cl:
         asset = await cl.get_asset(item_type, item_id, asset_type)
         await cl.activate_asset(asset)
@@ -603,11 +603,11 @@ async def asset_activate(ctx, item_type, item_id, asset_type):
               show_default=True,
               help='Maximum number of polls. Set to zero for no limit.')
 async def asset_wait(ctx, item_type, item_id, asset_type, delay, max_attempts):
-    '''Wait for an asset to be activated.
+    """Wait for an asset to be activated.
 
     Returns when the asset status has reached "activated" and the asset is
     available.
-    '''
+    """
     quiet = ctx.obj['QUIET']
     async with data_client(ctx) as cl:
         asset = await cl.get_asset(item_type, item_id, asset_type)
@@ -629,7 +629,7 @@ async def asset_wait(ctx, item_type, item_id, asset_type, delay, max_attempts):
 # @click.argument("asset_type_id")
 # @pretty
 # async def asset_get(ctx, item_type, item_id, asset_type_id, pretty):
-#     '''Get an item asset.'''
+#     """Get an item asset."""
 #     async with data_client(ctx) as cl:
 #         asset = await cl.get_asset(item_type, item_id, asset_type_id)
 #     echo_json(asset, pretty)

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -44,7 +44,7 @@ async def orders_client(ctx):
               default=None,
               help='Assign custom base Orders API URL.')
 def orders(ctx, base_url):
-    '''Commands for interacting with the Orders API'''
+    """Commands for interacting with the Orders API"""
     ctx.obj['BASE_URL'] = base_url
 
 
@@ -59,14 +59,14 @@ def orders(ctx, base_url):
 @limit
 @pretty
 async def list(ctx, state, limit, pretty):
-    '''List orders
+    """List orders
 
     This command prints a sequence of the returned order descriptions,
     optionally pretty-printed.
 
     Order descriptions are sorted by creation date with the last created order
     returned first.
-    '''
+    """
     async with orders_client(ctx) as cl:
         async for o in cl.list_orders(state=state, limit=limit):
             echo_json(o, pretty)
@@ -95,11 +95,11 @@ async def get(ctx, order_id, pretty):
 @coro
 @click.argument('order_id', type=click.UUID)
 async def cancel(ctx, order_id):
-    '''Cancel order by order ID.
+    """Cancel order by order ID.
 
     This command cancels a queued order and outputs the cancelled order
     details.
-    '''
+    """
     async with orders_client(ctx) as cl:
         json_resp = await cl.cancel_order(str(order_id))
 
@@ -207,14 +207,14 @@ async def download(ctx, order_id, overwrite, directory, checksum):
 @click.argument("request", type=types.JSON())
 @pretty
 async def create(ctx, request: str, pretty):
-    '''Create an order.
+    """Create an order.
 
     This command outputs the created order description, optionally
     pretty-printed.
 
     REQUEST is the full description of the order to be created. It must be JSON
     and can be specified a json string, filename, or '-' for stdin.
-    '''
+    """
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -18,8 +18,8 @@ valid_item_string = "Valid entries for ITEM_TYPES: " + "|".join(ALL_ITEM_TYPES)
 
 
 def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
-    '''Validates each item types provided by comparing them to all supported
-    item types.'''
+    """Validates each item types provided by comparing them to all supported
+    item types."""
     try:
         for item_type in item_types:
             validate_item_type(item_type)
@@ -29,8 +29,8 @@ def check_item_types(ctx, param, item_types) -> Optional[List[dict]]:
 
 
 def check_item_type(ctx, param, item_type) -> Optional[List[dict]]:
-    '''Validates the item type provided by comparing it to all supported
-    item types.'''
+    """Validates the item type provided by comparing it to all supported
+    item types."""
     try:
         validate_item_type(item_type)
     except SpecificationException as e:
@@ -53,7 +53,7 @@ async def subscriptions_client(ctx):
               default=None,
               help='Assign custom base Subscriptions API URL.')
 def subscriptions(ctx, base_url):
-    '''Commands for interacting with the Subscriptions API'''
+    """Commands for interacting with the Subscriptions API"""
     ctx.obj['BASE_URL'] = base_url
 
 

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -41,8 +41,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Orders(Paged):
-    '''Asynchronous iterator over Orders from a paged response describing
-    orders.'''
+    """Asynchronous iterator over Orders from a paged response describing
+    orders."""
     ITEMS_KEY = 'orders'
 
 
@@ -113,7 +113,7 @@ class OrdersClient:
         return f'{self._base_url}{STATS_PATH}'
 
     async def create_order(self, request: dict) -> dict:
-        '''Create an order request.
+        """Create an order request.
 
         Example:
 
@@ -143,7 +143,7 @@ class OrdersClient:
 
         Raises:
             planet.exceptions.APIError: On API error.
-        '''
+        """
         url = self._orders_url()
         response = await self._session.request(method='POST',
                                                url=url,
@@ -151,7 +151,7 @@ class OrdersClient:
         return response.json()
 
     async def get_order(self, order_id: str) -> dict:
-        '''Get order details by Order ID.
+        """Get order details by Order ID.
 
         Parameters:
             order_id: The ID of the order
@@ -162,7 +162,7 @@ class OrdersClient:
         Raises:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
             planet.exceptions.APIError: On API error.
-        '''
+        """
         self._check_order_id(order_id)
         url = f'{self._orders_url()}/{order_id}'
 
@@ -170,7 +170,7 @@ class OrdersClient:
         return response.json()
 
     async def cancel_order(self, order_id: str) -> dict:
-        '''Cancel a queued order.
+        """Cancel a queued order.
 
         Parameters:
             order_id: The ID of the order
@@ -181,7 +181,7 @@ class OrdersClient:
         Raises:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
             planet.exceptions.APIError: On API error.
-        '''
+        """
         self._check_order_id(order_id)
         url = f'{self._orders_url()}/{order_id}'
 
@@ -190,7 +190,7 @@ class OrdersClient:
 
     async def cancel_orders(self,
                             order_ids: Optional[List[str]] = None) -> dict:
-        '''Cancel queued orders in bulk.
+        """Cancel queued orders in bulk.
 
         Parameters:
             order_ids: The IDs of the orders. If empty or None, all orders in a
@@ -203,7 +203,7 @@ class OrdersClient:
             planet.exceptions.ClientError: If an entry in order_ids is not a
                 valid UUID.
             planet.exceptions.APIError: On API error.
-        '''
+        """
         url = f'{self._base_url}{BULK_PATH}/cancel'
         cancel_body = {}
         if order_ids:
@@ -218,14 +218,14 @@ class OrdersClient:
         return response.json()
 
     async def aggregated_order_stats(self) -> dict:
-        '''Get aggregated counts of active orders.
+        """Get aggregated counts of active orders.
 
         Returns:
             Aggregated order counts
 
         Raises:
             planet.exceptions.APIError: On API error.
-        '''
+        """
         url = self._stats_url()
         response = await self._session.request(method='GET', url=url)
         return response.json()

--- a/planet/constants.py
+++ b/planet/constants.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''Constants used across the code base'''
+"""Constants used across the code base"""
 import os
 from pathlib import Path
 

--- a/planet/exceptions.py
+++ b/planet/exceptions.py
@@ -20,56 +20,56 @@ class PlanetError(Exception):
 
 
 class APIError(PlanetError):
-    '''General unexpected API response'''
+    """General unexpected API response"""
 
 
 class BadQuery(APIError):
-    '''Invalid inputs, HTTP 400'''
+    """Invalid inputs, HTTP 400"""
     pass
 
 
 class InvalidAPIKey(APIError):
-    '''Invalid key, HTTP 401'''
+    """Invalid key, HTTP 401"""
     pass
 
 
 class NoPermission(APIError):
-    '''Insufficient permissions, HTTP 403'''
+    """Insufficient permissions, HTTP 403"""
     pass
 
 
 class MissingResource(APIError):
-    '''Request for non existing resource, HTTP 404'''
+    """Request for non existing resource, HTTP 404"""
     pass
 
 
 class Conflict(APIError):
-    '''Request conflict with current state of the target resource, HTTP 409'''
+    """Request conflict with current state of the target resource, HTTP 409"""
     pass
 
 
 class TooManyRequests(APIError):
-    '''Too many requests, HTTP 429'''
+    """Too many requests, HTTP 429"""
     pass
 
 
 class OverQuota(APIError):
-    '''Quota exceeded, HTTP 429'''
+    """Quota exceeded, HTTP 429"""
     pass
 
 
 class ServerError(APIError):
-    '''Unexpected internal server error, HTTP 500'''
+    """Unexpected internal server error, HTTP 500"""
     pass
 
 
 class BadGateway(APIError):
-    '''Bad gateway, HTTP 502'''
+    """Bad gateway, HTTP 502"""
     pass
 
 
 class InvalidIdentity(APIError):
-    '''Raised when logging in with invalid credentials'''
+    """Raised when logging in with invalid credentials"""
     pass
 
 
@@ -79,12 +79,12 @@ class ClientError(PlanetError):
 
 
 class AuthException(ClientError):
-    '''Exceptions encountered during authentication'''
+    """Exceptions encountered during authentication"""
     pass
 
 
 class PagingError(ClientError):
-    '''For errors that occur during paging.'''
+    """For errors that occur during paging."""
     pass
 
 

--- a/planet/http.py
+++ b/planet/http.py
@@ -192,7 +192,7 @@ class _Limiter:
 
 
 class Session(BaseSession):
-    '''Context manager for asynchronous communication with the Planet service.
+    """Context manager for asynchronous communication with the Planet service.
 
     The default behavior is to read authentication information stored in the
     secret file. This behavior can be overridden by providing an `auth.Auth`
@@ -226,7 +226,7 @@ class Session(BaseSession):
     >>> asyncio.run(main())
 
     ```
-    '''
+    """
 
     def __init__(self, auth: Optional[AuthType] = None):
         """Initialize a Session.

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -31,7 +31,7 @@ def build_request(name: str,
                   order_type: Optional[str] = None,
                   tools: Optional[List[dict]] = None,
                   stac: Optional[dict] = None) -> dict:
-    '''Prepare an order request.
+    """Prepare an order request.
 
     ```python
     >>> from planet.order_request import (
@@ -69,7 +69,7 @@ def build_request(name: str,
     Raises:
         planet.specs.SpecificationException: If order_type is not a valid
             order type.
-    '''
+    """
     details: Dict[str, Any] = {'name': name, 'products': products}
 
     if subscription_id:
@@ -98,7 +98,7 @@ def product(item_ids: List[str],
             product_bundle: str,
             item_type: str,
             fallback_bundle: Optional[str] = None) -> dict:
-    '''Product description for an order detail.
+    """Product description for an order detail.
 
     Parameters:
         item_ids: IDs of the catalog items to include in the order.
@@ -113,7 +113,7 @@ def product(item_ids: List[str],
         planet.specs.SpecificationException: If bundle or fallback bundle
             are not valid bundles or if item_type is not valid for the given
             bundle or fallback bundle.
-    '''
+    """
     item_type = specs.validate_item_type(item_type)
     validated_product_bundle = specs.validate_bundle(item_type, product_bundle)
 
@@ -135,14 +135,14 @@ def product(item_ids: List[str],
 def notifications(email: Optional[bool] = None,
                   webhook_url: Optional[str] = None,
                   webhook_per_order: Optional[bool] = None) -> dict:
-    '''Notifications description for an order detail.
+    """Notifications description for an order detail.
 
     Parameters:
         email: Enable email notifications for an order.
         webhook_url: URL for notification when the order is ready.
         webhook_per_order: Request a single webhook call per order instead
             of one call per each delivered item.
-    '''
+    """
     notifications_dict: Dict[str, Union[dict, bool]] = {}
 
     if webhook_url:
@@ -166,7 +166,7 @@ def delivery(archive_type: Optional[str] = None,
              single_archive: bool = False,
              archive_filename: Optional[str] = None,
              cloud_config: Optional[dict] = None) -> dict:
-    '''Order delivery configuration.
+    """Order delivery configuration.
 
     Example:
         ```python
@@ -195,7 +195,7 @@ def delivery(archive_type: Optional[str] = None,
 
     Raises:
         planet.specs.SpecificationException: If archive_type is not valid.
-    '''
+    """
     if archive_type:
         archive_type = specs.validate_archive_type(archive_type)
 
@@ -214,7 +214,7 @@ def amazon_s3(aws_access_key_id: str,
               bucket: str,
               aws_region: str,
               path_prefix: Optional[str] = None) -> dict:
-    '''Amazon S3 Cloud configuration.
+    """Amazon S3 Cloud configuration.
 
     Parameters:
         aws_access_key_id: S3 account access key.
@@ -224,7 +224,7 @@ def amazon_s3(aws_access_key_id: str,
         path_prefix: Custom string to prepend to the files delivered to the
             bucket. A slash (/) character will be treated as a "folder".
             Any other characters will be added as a prefix to the files.
-    '''
+    """
     cloud_details = {
         'aws_access_key_id': aws_access_key_id,
         'aws_secret_access_key': aws_secret_access_key,
@@ -243,7 +243,7 @@ def azure_blob_storage(account: str,
                        sas_token: str,
                        storage_endpoint_suffix: Optional[str] = None,
                        path_prefix: Optional[str] = None) -> dict:
-    '''Azure Blob Storage configuration.
+    """Azure Blob Storage configuration.
 
     Parameters:
         account: Azure account.
@@ -254,7 +254,7 @@ def azure_blob_storage(account: str,
         path_prefix: Custom string to prepend to the files delivered to the
             bucket. A slash (/) character will be treated as a "folder".
             Any other characters will be added as a prefix to the files.
-    '''
+    """
     cloud_details = {
         'account': account,
         'container': container,
@@ -273,7 +273,7 @@ def azure_blob_storage(account: str,
 def google_cloud_storage(bucket: str,
                          credentials: str,
                          path_prefix: Optional[str] = None) -> dict:
-    '''Google Cloud Storage configuration.
+    """Google Cloud Storage configuration.
 
     Parameters:
         bucket: GCS bucket name.
@@ -281,7 +281,7 @@ def google_cloud_storage(bucket: str,
         path_prefix: Custom string to prepend to the files delivered to the
             bucket. A slash (/) character will be treated as a "folder".
             Any other characters will be added as a prefix to the files.
-    '''
+    """
     cloud_details = {
         'bucket': bucket,
         'credentials': credentials,
@@ -294,12 +294,12 @@ def google_cloud_storage(bucket: str,
 
 
 def google_earth_engine(project: str, collection: str) -> dict:
-    '''Google Earth Engine configuration.
+    """Google Earth Engine configuration.
 
     Parameters:
         project: GEE project name.
         collection: GEE Image Collection name.
-    '''
+    """
     cloud_details = {
         'project': project,
         'collection': collection,
@@ -308,7 +308,7 @@ def google_earth_engine(project: str, collection: str) -> dict:
 
 
 def _tool(name: str, parameters: dict) -> dict:
-    '''Create the API spec representation of a tool.
+    """Create the API spec representation of a tool.
 
     See [Tools and Toolchains](
     https://developers.planet.com/docs/orders/tools-toolchains/)
@@ -321,13 +321,13 @@ def _tool(name: str, parameters: dict) -> dict:
     Raises:
         planet.specs.SpecificationException: If name is not the name of a valid
             Orders API tool.
-    '''
+    """
     name = specs.validate_tool(name)
     return {name: parameters}
 
 
 def clip_tool(aoi: dict) -> dict:
-    '''Create the API spec representation of a clip tool.
+    """Create the API spec representation of a clip tool.
 
     Example:
         ```python
@@ -350,7 +350,7 @@ def clip_tool(aoi: dict) -> dict:
     Raises:
         planet.exceptions.ClientError: If GeoJSON is not a valid polygon or
             multipolygon.
-    '''
+    """
     valid_types = ['Polygon', 'MultiPolygon']
 
     geom = geojson.as_geom(aoi)
@@ -361,23 +361,23 @@ def clip_tool(aoi: dict) -> dict:
 
 
 def composite_tool() -> dict:
-    '''Create the API spec representation of a composite tool.
-    '''
+    """Create the API spec representation of a composite tool.
+    """
     return _tool('composite', {})
 
 
 def coregister_tool(anchor_item: str) -> dict:
-    '''Create the API spec representation of a coregister tool.
+    """Create the API spec representation of a coregister tool.
 
     Parameters:
         anchor_item: The item_id of the item to which all other items should be
             coregistered.
-    '''
+    """
     return _tool('coregister', {'anchor_item': anchor_item})
 
 
 def file_format_tool(file_format: str) -> dict:
-    '''Create the API spec representation of a file format tool.
+    """Create the API spec representation of a file format tool.
 
     Parameters:
         file_format: The format of the tool output. Either 'COG' or 'PL_NITF'.
@@ -385,7 +385,7 @@ def file_format_tool(file_format: str) -> dict:
     Raises:
         planet.specs.SpecificationException: If file_format is not one of
             'COG' or 'PL_NITF'
-    '''
+    """
     file_format = specs.validate_file_format(file_format)
     return _tool('file_format', {'format': file_format})
 
@@ -393,7 +393,7 @@ def file_format_tool(file_format: str) -> dict:
 def reproject_tool(projection: str,
                    resolution: Optional[float] = None,
                    kernel: Optional[str] = None) -> dict:
-    '''Create the API spec representation of a reproject tool.
+    """Create the API spec representation of a reproject tool.
 
     Parameters:
         projection: A coordinate system in the form EPSG:n. (ex. EPSG:4326 for
@@ -406,7 +406,7 @@ def reproject_tool(projection: str,
         kernel: The resampling kernel used. The API default is "near". This
             parameter also supports "bilinear", "cubic", "cubicspline",
             "lanczos", "average" and "mode".
-    '''
+    """
     parameters = dict((k, v) for k, v in locals().items() if v)
     return _tool('reproject', parameters)
 
@@ -417,7 +417,7 @@ def tile_tool(tile_size: int,
               pixel_size: Optional[float] = None,
               name_template: Optional[str] = None,
               conformal_x_scaling: Optional[bool] = None) -> dict:
-    '''Create the API spec representation of a reproject tool.
+    """Create the API spec representation of a reproject tool.
 
     Parameters:
         tile_size: Height and width of output tiles in pixels and lines
@@ -432,20 +432,20 @@ def tile_tool(tile_size: int,
             The API default is "{tilex}_{tiley}.tif" resulting in filenames
             like 128_200.tif. The {tilex} and {tiley} parameters can be of the
             form {tilex:06d} to produce a fixed width field with leading zeros.
-    '''
+    """
     parameters = dict((k, v) for k, v in locals().items() if v)
     return _tool('tile', parameters)
 
 
 def toar_tool(scale_factor: Optional[int] = None) -> dict:
-    '''Create the API spec representation of a TOAR tool.
+    """Create the API spec representation of a TOAR tool.
 
     Parameters:
         scale_factor: Scale factor applied to convert 0.0 to 1.0 reflectance
             floating point values to a value that fits in 16bit integer pixels.
             The API default is 10000. Values over 65535 could result in high
             reflectances not fitting in 16bit integers.
-    '''
+    """
     parameters = {}
     if scale_factor:
         parameters['scale_factor'] = scale_factor
@@ -453,7 +453,7 @@ def toar_tool(scale_factor: Optional[int] = None) -> dict:
 
 
 def harmonize_tool(target_sensor: str) -> dict:
-    '''Create the API spec representation of a harmonize tool.
+    """Create the API spec representation of a harmonize tool.
 
     Parameters:
         target_sensor: A value indicating to what sensor the input asset types
@@ -461,7 +461,7 @@ def harmonize_tool(target_sensor: str) -> dict:
 
     Raises:
         planet.exceptions.ClientError: If target_sensor is not valid.
-    '''
+    """
 
     try:
         target_sensor = specs.get_match(target_sensor,
@@ -489,7 +489,7 @@ def band_math_tool(b1: str,
                    b14: Optional[str] = None,
                    b15: Optional[str] = None,
                    pixel_type: str = specs.BAND_MATH_PIXEL_TYPE_DEFAULT):
-    '''Specify an Orders API band math tool.
+    """Specify an Orders API band math tool.
 
     The parameters of the bandmath tool define how each output band in the
     derivative product should be produced, referencing the product inputs’
@@ -518,7 +518,7 @@ def band_math_tool(b1: str,
 
     Raises:
         planet.exceptions.ClientError: If pixel_type is not valid.
-    '''  # noqa
+    """  # noqa
     try:
         pixel_type = specs.get_match(pixel_type,
                                      specs.BAND_MATH_PIXEL_TYPE,

--- a/planet/specs.py
+++ b/planet/specs.py
@@ -41,12 +41,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class NoMatchException(Exception):
-    '''No match was found'''
+    """No match was found"""
     pass
 
 
 class SpecificationException(Exception):
-    '''No match was found'''
+    """No match was found"""
 
     def __init__(self, value, supported, field_name):
         self.value = value
@@ -71,12 +71,12 @@ def validate_item_type(item_type):
 
 
 def validate_data_item_type(item_type):
-    '''Validate and correct capitalization of data api item type.'''
+    """Validate and correct capitalization of data api item type."""
     return _validate_field(item_type, get_data_item_types(), 'item_type')
 
 
 def get_data_item_types():
-    '''Item types supported by the data api.'''
+    """Item types supported by the data api."""
     # This is a quick-fix for gh-956, to be superseded by gh-960
     return get_item_types() | {'SkySatVideo'}
 
@@ -121,7 +121,7 @@ def validate_supported_bundles(item_type, bundle, all_product_bundles):
 
 
 def validate_asset_type(item_type, asset_type):
-    '''Validates an asset type for a given item type.'''
+    """Validates an asset type for a given item type."""
     item_type = validate_item_type(item_type)
     supported_assets = get_supported_assets(item_type)
 
@@ -135,11 +135,11 @@ def _get_product_bundle_spec():
 
 
 def get_match(test_entry, spec_entries, field_name):
-    '''Find and return matching spec entry regardless of capitalization.
+    """Find and return matching spec entry regardless of capitalization.
 
     This is helpful for working with the API spec, where the capitalization
     is hard to remember but must be exact otherwise the API throws an
-    exception.'''
+    exception."""
     try:
         match = next(e for e in spec_entries
                      if e.lower() == test_entry.lower())
@@ -150,7 +150,7 @@ def get_match(test_entry, spec_entries, field_name):
 
 
 def get_product_bundles(item_type=None):
-    '''Get product bundles supported by Orders API.'''
+    """Get product bundles supported by Orders API."""
     spec = _get_product_bundle_spec()
 
     if item_type:
@@ -168,8 +168,8 @@ def get_product_bundles(item_type=None):
 
 
 def get_item_types(product_bundle=None):
-    '''If given product bundle, get specific item types supported by Orders
-    API. Otherwise, get all item types supported by Orders API.'''
+    """If given product bundle, get specific item types supported by Orders
+    API. Otherwise, get all item types supported by Orders API."""
     spec = _get_product_bundle_spec()
 
     if product_bundle:
@@ -184,7 +184,7 @@ def get_item_types(product_bundle=None):
 
 
 def get_supported_assets(item_type):
-    '''Get all assets supported by a given item type.'''
+    """Get all assets supported by a given item type."""
     item_type = validate_item_type(item_type)
     supported_bundles = get_product_bundles(item_type)
     spec = _get_product_bundle_spec()

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -105,7 +105,7 @@ def catalog_source(
     end_time: Optional[datetime] = None,
     rrule: Optional[str] = None,
 ) -> dict:
-    '''Catalog subscription source.
+    """Catalog subscription source.
 
     Parameters:
     item_types: The class of spacecraft and processing level of the
@@ -126,7 +126,7 @@ def catalog_source(
     Raises:
         planet.exceptions.ClientError: If start_time or end_time are not valid
             datetimes
-    '''
+    """
     if len(item_types) > 1:
         raise ClientError(
             "Subscription can only be successfully created if one item type",
@@ -182,14 +182,14 @@ def amazon_s3(aws_access_key_id: str,
               aws_secret_access_key: str,
               bucket: str,
               aws_region: str) -> dict:
-    '''Delivery to Amazon S3.
+    """Delivery to Amazon S3.
 
     Parameters:
         aws_access_key_id: S3 account access key.
         aws_secret_access_key: S3 account secret key.
         bucket: The name of the bucket that will receive the order output.
         aws_region: The region where the bucket lives in AWS.
-    '''
+    """
     parameters = {
         'aws_access_key_id': aws_access_key_id,
         'aws_secret_access_key': aws_secret_access_key,
@@ -204,7 +204,7 @@ def azure_blob_storage(account: str,
                        container: str,
                        sas_token: str,
                        storage_endpoint_suffix: Optional[str] = None) -> dict:
-    '''Delivery to Azure Blob Storage.
+    """Delivery to Azure Blob Storage.
 
     Parameters:
         account: Azure account.
@@ -213,7 +213,7 @@ def azure_blob_storage(account: str,
             without a leading '?'.
         storage_endpoint_suffix: Deliver order to a sovereign cloud. The
             default is "core.windows.net".
-    '''
+    """
     parameters = {
         'account': account,
         'container': container,
@@ -227,12 +227,12 @@ def azure_blob_storage(account: str,
 
 
 def google_cloud_storage(credentials: str, bucket: str) -> dict:
-    '''Delivery to Google Cloud Storage.
+    """Delivery to Google Cloud Storage.
 
     Parameters:
         credentials: JSON-string of service account for bucket.
         bucket: GCS bucket name.
-    '''
+    """
     parameters = {
         'bucket': bucket,
         'credentials': credentials,
@@ -246,7 +246,7 @@ def oracle_cloud_storage(customer_access_key_id: str,
                          bucket: str,
                          region: str,
                          namespace: str) -> dict:
-    '''Delivery to Oracle Cloud Storage.
+    """Delivery to Oracle Cloud Storage.
 
     Parameters:
         customer_access_key_id: Customer Secret Key credentials.
@@ -254,7 +254,7 @@ def oracle_cloud_storage(customer_access_key_id: str,
         bucket: The name of the bucket that will receive the order output.
         region: The region where the bucket lives in Oracle.
         namespace: Object Storage namespace name.
-    '''
+    """
     parameters = {
         'customer_access_key_id': customer_access_key_id,
         'customer_secret_key': customer_secret_key,
@@ -267,7 +267,7 @@ def oracle_cloud_storage(customer_access_key_id: str,
 
 
 def notifications(url: str, topics: List[str]) -> dict:
-    '''Specify a subscriptions API notification.
+    """Specify a subscriptions API notification.
 
     Webhook notifications proactively notify you when a subscription matches
     and delivers an item so you have confidence that you have all the expected
@@ -276,7 +276,7 @@ def notifications(url: str, topics: List[str]) -> dict:
     Parameters:
         url: location of webhook/callback where you expect to receive updates.
         topics: Event types that you can choose to be notified about.
-    '''
+    """
     for i, t in enumerate(topics):
         try:
             topics[i] = specs.get_match(t, NOTIFICATIONS_TOPICS, 'topic')
@@ -306,7 +306,7 @@ def band_math_tool(b1: str,
                    b14: Optional[str] = None,
                    b15: Optional[str] = None,
                    pixel_type: str = specs.BAND_MATH_PIXEL_TYPE_DEFAULT):
-    '''Specify a subscriptions API band math tool.
+    """Specify a subscriptions API band math tool.
 
     The parameters of the bandmath tool define how each output band in the
     derivative product should be produced, referencing the product inputs’
@@ -335,7 +335,7 @@ def band_math_tool(b1: str,
 
     Raises:
         planet.exceptions.ClientError: If pixel_type is not valid.
-    '''  # noqa
+    """  # noqa
     try:
         pixel_type = specs.get_match(pixel_type,
                                      specs.BAND_MATH_PIXEL_TYPE,
@@ -349,7 +349,7 @@ def band_math_tool(b1: str,
 
 
 def clip_tool(aoi: dict) -> dict:
-    '''Specify a subscriptions API clip tool.
+    """Specify a subscriptions API clip tool.
 
     Imagery and udm files will be clipped to your area of interest. nodata
     pixels will be preserved. Xml file attributes “filename”, “numRows”,
@@ -367,7 +367,7 @@ def clip_tool(aoi: dict) -> dict:
     Raises:
         planet.exceptions.ClientError: If aoi is not a valid polygon or
             multipolygon.
-    '''
+    """
     valid_types = ['Polygon', 'MultiPolygon']
 
     geom = geojson.as_geom(aoi)
@@ -379,14 +379,14 @@ def clip_tool(aoi: dict) -> dict:
 
 
 def file_format_tool(file_format: str) -> dict:
-    '''Specify a subscriptions API file format tool.
+    """Specify a subscriptions API file format tool.
 
     Parameters:
         file_format: The format of the tool output. Either "COG" or "PL_NITF".
 
     Raises:
         planet.exceptions.ClientError: If file_format is not valid.
-    '''
+    """
     try:
         file_format = specs.validate_file_format(file_format)
     except specs.SpecificationException as e:
@@ -396,7 +396,7 @@ def file_format_tool(file_format: str) -> dict:
 
 
 def harmonize_tool(target_sensor: str) -> dict:
-    '''Specify a subscriptions API harmonize tool.
+    """Specify a subscriptions API harmonize tool.
 
     Each sensor value transforms items captured by a defined set of instrument
     IDs. Items which have not been captured by that defined set of instrument
@@ -408,7 +408,7 @@ def harmonize_tool(target_sensor: str) -> dict:
 
     Raises:
         planet.exceptions.ClientError: If target_sensor is not valid.
-    '''
+    """
     try:
         target_sensor = specs.get_match(target_sensor,
                                         specs.HARMONIZE_TOOL_TARGET_SENSORS,
@@ -422,7 +422,7 @@ def harmonize_tool(target_sensor: str) -> dict:
 def reproject_tool(projection: str,
                    resolution: Optional[float] = None,
                    kernel: str = REPROJECT_KERNEL_DEFAULT) -> dict:
-    '''Specify a subscriptions API reproject tool.
+    """Specify a subscriptions API reproject tool.
 
     Parameters:
         projection: A coordinate system in the form EPSG:n (for example,
@@ -437,7 +437,7 @@ def reproject_tool(projection: str,
 
     Raises:
         planet.exceptions.ClientError: If kernel is not valid.
-    '''
+    """
     try:
         kernel = specs.get_match(kernel, REPROJECT_KERNEL, 'kernel')
     except specs.SpecificationException as e:
@@ -451,7 +451,7 @@ def reproject_tool(projection: str,
 
 
 def toar_tool(scale_factor: int = 10000) -> dict:
-    '''Specify a subscriptions API reproject tool.
+    """Specify a subscriptions API reproject tool.
 
     The toar tool supports the analytic asset type for PSScene, PSOrthoTile,
     and REOrthoTile item types. In addition to the analytic asset, the
@@ -462,5 +462,5 @@ def toar_tool(scale_factor: int = 10000) -> dict:
             floating point values to a value that fits in 16bit integer pixels.
             The API default is 10000. Values over 65535 could result in high
             reflectances not fitting in 16bit integers.
-    '''
+    """
     return _tool('toar', {'scale_factor': scale_factor})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ _test_data_path = _here / 'data'
 
 @pytest.fixture(autouse=True, scope='module')
 def test_secretfile_read():
-    '''Returns valid auth results as if reading a secret file'''
+    """Returns valid auth results as if reading a secret file"""
 
     def mockreturn(self):
         return {'key': 'testkey'}

--- a/tests/integration/test_auth_cli.py
+++ b/tests/integration/test_auth_cli.py
@@ -36,10 +36,10 @@ def test_secretfile_read():
 
 @pytest.fixture
 def redirect_secretfile(tmp_path):
-    '''patch the cli so it works with a temporary secretfile
+    """patch the cli so it works with a temporary secretfile
 
     this is to avoid collisions with the actual planet secretfile
-    '''
+    """
     secretfile_path = tmp_path / 'secret.json'
 
     with pytest.MonkeyPatch.context() as mp:

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -52,9 +52,9 @@ def original_content():
 
 @pytest.fixture
 def create_download_mock(downloaded_content, order_description, oid):
-    '''
+    """
     Mock an HTTP response for download.
-    '''
+    """
 
     def f():
         # Create mock HTTP response
@@ -776,10 +776,10 @@ async def test_download_order_overwrite_true_preexisting_data(
         create_download_mock,
         original_content,
         downloaded_content):
-    '''
+    """
     Test if download_order() overwrites pre-existing data with
     overwrite flag set to True.
-    '''
+    """
 
     # Save JSON to a temporary file
     with open(Path(tmpdir, 'file.json'), "a") as out_file:
@@ -798,10 +798,10 @@ async def test_download_order_overwrite_true_preexisting_data(
 @pytest.mark.anyio
 async def test_download_order_overwrite_false_preexisting_data(
         tmpdir, oid, session, create_download_mock, original_content):
-    '''
+    """
     Test if download_order() does not overwrite pre-existing
     data with overwrite flag set to False.
-    '''
+    """
 
     # Save JSON to a temporary file
     with open(Path(tmpdir, 'file.json'), "a") as out_file:
@@ -820,10 +820,10 @@ async def test_download_order_overwrite_false_preexisting_data(
 @pytest.mark.anyio
 async def test_download_order_overwrite_true_nonexisting_data(
         tmpdir, oid, session, create_download_mock, downloaded_content):
-    '''
+    """
     Test if download_order() downloads data with overwrite flag
     set to true without pre-existing data.
-    '''
+    """
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)
@@ -837,10 +837,10 @@ async def test_download_order_overwrite_true_nonexisting_data(
 @pytest.mark.anyio
 async def test_download_order_overwrite_false_nonexisting_data(
         tmpdir, oid, session, create_download_mock, downloaded_content):
-    '''
+    """
     Test if download_order() downloads data with overwrite flag
     set to false without pre-existing data.
-    '''
+    """
 
     create_download_mock()
     cl = OrdersClient(session, base_url=TEST_URL)

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -11,7 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-'''Test Orders CLI'''
+"""Test Orders CLI"""
 import copy
 import hashlib
 from http import HTTPStatus
@@ -342,7 +342,7 @@ def test_cli_orders_download_default(invoke, mock_download_response, oid):
 
 @respx.mock
 def test_cli_orders_download_checksum(invoke, mock_download_response, oid):
-    '''checksum is successful'''
+    """checksum is successful"""
     mock_download_response()
 
     runner = CliRunner()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -141,12 +141,12 @@ def test_Auth_store_exists(tmp_path):
 
 
 def test__SecretFile_permissions_doesnotexist(secret_path):
-    '''No exception is raised if the file doesn't exist'''
+    """No exception is raised if the file doesn't exist"""
     auth._SecretFile(secret_path)
 
 
 def test__SecretFile_permissions_incorrect(secret_path):
-    '''Incorrect permissions are fixed'''
+    """Incorrect permissions are fixed"""
     with open(secret_path, 'w') as fp:
         fp.write('{"existing": "exists"}')
 

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -235,8 +235,8 @@ def test_clip_tool_multipolygon(multipolygon_geom_geojson):
 
 
 def test_clip_tool_invalid(point_geom_geojson):
-    '''Confirm an exception is raised if an invalid geometry type is supplied.
-    '''
+    """Confirm an exception is raised if an invalid geometry type is supplied.
+    """
     with pytest.raises(exceptions.ClientError):
         order_request.clip_tool(point_geom_geojson)
 

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -104,7 +104,7 @@ def test_validate_item_type_notsupported_itemtype():
 
 
 def test_validate_data_item_type():
-    '''ensure skysatvideo is included'''
+    """ensure skysatvideo is included"""
     specs.validate_data_item_type('skysatvideo')
 
 
@@ -181,8 +181,8 @@ def test_get_supported_assets_not_supported_item_type():
 
 
 def test_validate_asset_type_supported():
-    '''Ensures that a validated asset type for a given item type matches the
-    the given asset type.'''
+    """Ensures that a validated asset type for a given item type matches the
+    the given asset type."""
     assert TEST_ASSET_TYPE == specs.validate_asset_type(
         TEST_ITEM_TYPE, TEST_ASSET_TYPE)
 

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -92,8 +92,8 @@ def test_catalog_source_success(geom_geojson):
 
 def test_catalog_source_featurecollection(featurecollection_geojson,
                                           geom_geojson):
-    '''geojson specified as featurecollection is simplified down to just
-    the geometry'''
+    """geojson specified as featurecollection is simplified down to just
+    the geometry"""
     res = subscription_request.catalog_source(
         item_types=["PSScene"],
         asset_types=["ortho_analytic_4b"],


### PR DESCRIPTION
**Related Issue(s):**

Closes #319 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Replacement of all single quotes  by double quotes in docstrings.

Not intended for changelog:

1. This PR replaces all occurrences of `'''` with `"""` in order to comply with PEP-257 as outlined in #319 

**Diff of User Interface**

Old behavior: No diff

New behavior: No diff


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**

**Remark**
I was looking for a small/easy issue to start with and found #319. However, after browsing through the code base, I couldn't find any docstrings that used only a single (opposed of triple) quote (please let me know if there are yet any and I simply overlooked them). Thus, technically the description of #319:

> docstrings should use triple-quotes

is already fulfilled. However [PEP-257](https://peps.python.org/pep-0257/#specification) requires triple-double quotes

>  always use """triple double quotes""" around docstrings

which is why I took the liberty to tackle this exact specification in the scope of the linked issue. Basically, all I did was to find and  replace `'''` with `"""` throughout the code base.

Note, I would totally understand if you do not want to take care of such a cosmetic change.

Please review with care, as this is my first contribution to this repo. Thanks!