### PR TITLE
Support for CSV formatted results of subscriptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,11 @@
 2.1.0 (TBD)
 
 Added:
-- A subscription_request.planetary_variable_source function has been added ().
+- A subscription_request.planetary_variable_source function has been added
+  (#976).
 - The subscription_request.build_request function has a new option to clip to
-  the subscription's source geometry. This is a preview of the default
-  behavior of the next version of the Subscriptions API ().
+  the subscription's source geometry. This is a preview of the default behavior
+  of the next version of the Subscriptions API (#971).
 
 2.0.3 (2023-06-28)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 2.1.0 (TBD)
 
 Added:
+- Add the option to get Planetary Variable subscription results as a CSV file ().
 - A subscription_request.planetary_variable_source function has been added
   (#976).
 - The subscription_request.build_request function has a new option to clip to

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 2.1.0 (TBD)
 
 Added:
+- A subscription_request.planetary_variable_source function has been added ().
 - The subscription_request.build_request function has a new option to clip to
   the subscription's source geometry. This is a preview of the default
-  behavior of the next version of the Subscriptions API.
+  behavior of the next version of the Subscriptions API ().
 
 2.0.3 (2023-06-28)
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -162,10 +162,13 @@ async def get_subscription_cmd(ctx, subscription_id, pretty):
                        "success"]),
     multiple=True,
     default=None,
-    callback=lambda ctx,
-    param,
-    value: set(value),
+    callback=(lambda ctx, param, value: set(value)),
     help="Select subscription results in one or more states. Default: all.")
+@click.option('--csv',
+              'csv_flag',
+              is_flag=True,
+              default=False,
+              help="Get subscription results as an unpaged CSV file.")
 @limit
 # TODO: the following 3 options.
 # –created: timestamp instant or range.
@@ -178,13 +181,20 @@ async def list_subscription_results_cmd(ctx,
                                         subscription_id,
                                         pretty,
                                         status,
+                                        csv_flag,
                                         limit):
     """Gets results of a subscription and prints the API response."""
     async with subscriptions_client(ctx) as client:
-        async for result in client.get_results(subscription_id,
-                                               status=status,
-                                               limit=limit):
-            echo_json(result, pretty)
+        if csv_flag:
+            async for result in client.get_results_csv(subscription_id,
+                                                       status=status,
+                                                       limit=limit):
+                click.echo(result)
+        else:
+            async for result in client.get_results(subscription_id,
+                                                   status=status,
+                                                   limit=limit):
+                echo_json(result, pretty)
 
 
 @subscriptions.command()  # type: ignore

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -49,7 +49,7 @@ def build_request(name: str,
                   delivery: Mapping,
                   notifications: Optional[Mapping] = None,
                   tools: Optional[List[Mapping]] = None,
-                  clip_to_source=False) -> dict:
+                  clip_to_source: Optional[bool] = False) -> dict:
     """Construct a Subscriptions API request.
 
     The return value can be passed to
@@ -267,15 +267,11 @@ def planetary_variable_source(
         ...     "SWC-AMSR2-C_V1.0_100",
         ...     geometry={
         ...         "type": "Polygon",
-        ...         "coordinates": [
-        ...             [
-        ...                 [37.791595458984375, 14.84923123791421],
-        ...                 [37.90214538574219, 14.84923123791421],
-        ...                 [37.90214538574219, 14.945448293647944],
-        ...                 [37.791595458984375, 14.945448293647944],
-        ...                 [37.791595458984375, 14.84923123791421]
-        ...             ]
-        ...         ]
+        ...         "coordinates": [[[37.791595458984375, 14.84923123791421],
+        ...                         [37.90214538574219, 14.84923123791421],
+        ...                         [37.90214538574219, 14.945448293647944],
+        ...                         [37.791595458984375, 14.945448293647944],
+        ...                         [37.791595458984375, 14.84923123791421]]]
         ...     },
         ...     start_time=datetime(2021, 3, 1)
         ... )

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -306,3 +306,11 @@ def test_request_catalog_success(invoke, geom_geojson):
     ])
     assert json.loads(result.output) == source
     assert result.exit_code == 0  # success.
+
+
+@res_api_mock
+def test_subscriptions_results_csv(invoke):
+    """Get results as CSV."""
+    result = invoke(['results', 'test', '--csv'])
+    assert result.exit_code == 0  # success.
+    assert result.output.splitlines() == ['id,status', '1234-abcd,SUCCESS']

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -346,3 +346,23 @@ def test_toar_tool_success():
 
     expected = {"type": "toar", "parameters": {"scale_factor": 12345}}
     assert res == expected
+
+
+def test_pv_source_success(geom_geojson):
+    """Configure a planetary variable subscription source."""
+    # NOTE: this function does not yet validate type and id.
+    # The nonsense values are intended to fail when the function does
+    # add validation.
+    source = subscription_request.planetary_variable_source(
+        "var1",
+        "VAR1-abcd",
+        geometry=geom_geojson,
+        start_time=datetime(2021, 3, 1),
+        end_time=datetime(2021, 3, 2),
+    )
+
+    assert source["type"] == "var1"
+    params = source["parameters"]
+    assert params["id"] == "VAR1-abcd"
+    assert params["geometry"] == geom_geojson
+    assert params["start_time"].startswith("2021-03-01")


### PR DESCRIPTION
Resolves #933. The big choice here is to make CSV format access its own method instead of a flag on the existing method. I feel like this is warranted by the API split between JSON (paged) and CSV (not paged).

Sanity check @kevinlacaille @cpaulik ?