### PR TITLE
Add more doc help

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -168,7 +168,7 @@ async def get_subscription_cmd(ctx, subscription_id, pretty):
               'csv_flag',
               is_flag=True,
               default=False,
-              help="Get subscription results as an unpaged CSV file.")
+              help="Get subscription results as comma-separated fields.")
 @limit
 # TODO: the following 3 options.
 # –created: timestamp instant or range.
@@ -183,7 +183,26 @@ async def list_subscription_results_cmd(ctx,
                                         status,
                                         csv_flag,
                                         limit):
-    """Gets results of a subscription and prints the API response."""
+    """Print the results of a subscription to stdout.
+
+    The output of this command is a sequence of JSON objects (the
+    default) or a sequence of commna-separated fields (when the --csv
+    option is used), one result per line.
+
+    Examples:
+
+    \b
+        planet subscriptions results SUBSCRIPTION_ID --status=success --limit 10
+
+    where SUBSCRIPTION_ID is the unique identifier for a subscription,
+    prints the last 10 successfully delivered results for that
+    subscription as JSON objects.
+
+    \b
+        planet subscriptions results SUBSCRIPTION_ID --limit 0 --csv > results.csv
+
+    prints all results for a subscription and saves them to a CSV file.
+    """
     async with subscriptions_client(ctx) as client:
         if csv_flag:
             async for result in client.get_results_csv(subscription_id,
@@ -215,10 +234,10 @@ async def list_subscription_results_cmd(ctx,
     '--notifications',
     type=types.JSON(),
     help='Notifications JSON. Can be a string, filename, or - for stdin.')
-@click.option(
-    '--tools',
-    type=types.JSON(),
-    help='Toolchain JSON. Can be a string, filename, or - for stdin.')
+@click.option('--tools',
+              type=types.JSON(),
+              help='Toolchain JSON. Can be a string, filename, or - for stdin.'
+              )
 @pretty
 def request(name, source, delivery, notifications, tools, pretty):
     """Generate a subscriptions request."""
@@ -257,10 +276,10 @@ def request(name, source, delivery, notifications, tools, pretty):
 @click.option('--rrule',
               type=str,
               help='iCalendar recurrance rule to specify recurrances.')
-@click.option(
-    '--filter',
-    type=types.JSON(),
-    help='Search filter.  Can be a string, filename, or - for stdin.')
+@click.option('--filter',
+              type=types.JSON(),
+              help='Search filter.  Can be a string, filename, or - for stdin.'
+              )
 @pretty
 def request_catalog(item_types,
                     asset_types,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -234,10 +234,10 @@ async def list_subscription_results_cmd(ctx,
     '--notifications',
     type=types.JSON(),
     help='Notifications JSON. Can be a string, filename, or - for stdin.')
-@click.option('--tools',
-              type=types.JSON(),
-              help='Toolchain JSON. Can be a string, filename, or - for stdin.'
-              )
+@click.option(
+    '--tools',
+    type=types.JSON(),
+    help='Toolchain JSON. Can be a string, filename, or - for stdin.')
 @pretty
 def request(name, source, delivery, notifications, tools, pretty):
     """Generate a subscriptions request."""
@@ -276,10 +276,10 @@ def request(name, source, delivery, notifications, tools, pretty):
 @click.option('--rrule',
               type=str,
               help='iCalendar recurrance rule to specify recurrances.')
-@click.option('--filter',
-              type=types.JSON(),
-              help='Search filter.  Can be a string, filename, or - for stdin.'
-              )
+@click.option(
+    '--filter',
+    type=types.JSON(),
+    help='Search filter.  Can be a string, filename, or - for stdin.')
 @pretty
 def request_catalog(item_types,
                     asset_types,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -186,7 +186,7 @@ async def list_subscription_results_cmd(ctx,
     """Print the results of a subscription to stdout.
 
     The output of this command is a sequence of JSON objects (the
-    default) or a sequence of commna-separated fields (when the --csv
+    default) or a sequence of comma-separated fields (when the --csv
     option is used), one result per line.
 
     Examples:
@@ -194,14 +194,14 @@ async def list_subscription_results_cmd(ctx,
     \b
         planet subscriptions results SUBSCRIPTION_ID --status=success --limit 10
 
-    where SUBSCRIPTION_ID is the unique identifier for a subscription,
-    prints the last 10 successfully delivered results for that
+    Where SUBSCRIPTION_ID is the unique identifier for a subscription,
+    this prints the last 10 successfully delivered results for that
     subscription as JSON objects.
 
     \b
         planet subscriptions results SUBSCRIPTION_ID --limit 0 --csv > results.csv
 
-    prints all results for a subscription and saves them to a CSV file.
+    Prints all results for a subscription and saves them to a CSV file.
     """
     async with subscriptions_client(ctx) as client:
         if csv_flag:

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -268,21 +268,17 @@ class SubscriptionsClient:
         except ClientError:  # pragma: no cover
             raise
 
-    async def get_results_csv(self,
-                              subscription_id: str,
-                              status: Optional[Sequence[Literal[
-                                  "created",
-                                  "queued",
-                                  "processing",
-                                  "failed",
-                                  "success"]]] = None,
-                              **kwargs) -> AsyncIterator[str]:
+    async def get_results_csv(
+        self,
+        subscription_id: str,
+        status: Optional[Sequence[Literal["created",
+                                          "queued",
+                                          "processing",
+                                          "failed",
+                                          "success"]]] = None,
+        limit: int = 100,
+    ) -> AsyncIterator[str]:
         """Iterate over rows of results CSV for a Subscription.
-
-        Notes:
-            The name of this method is based on the API's method name. This
-            method provides iteration over results, it does not get a
-            single result description or return a list of descriptions.
 
         Parameters:
             subscription_id (str): id of a subscription.


### PR DESCRIPTION
Follow up to #981. Here's what the help looks like

```
$ planet subscriptions results --help
Usage: planet subscriptions results [OPTIONS] SUBSCRIPTION_ID

  Print the results of a subscription to stdout.

  The output of this command is a sequence of JSON objects (the default) or a
  sequence of commna-separated fields (when the --csv option is used), one
  result per line.

  Examples:

      planet subscriptions results SUBSCRIPTION_ID --status=success --limit 10

  where SUBSCRIPTION_ID is the unique identifier for a subscription, prints
  the last 10 successfully delivered results for that subscription as JSON
  objects.

      planet subscriptions results SUBSCRIPTION_ID --limit 0 --csv > results.csv

  prints all results for a subscription and saves them to a CSV file.

Options:
  --pretty                        Format JSON output.
  --status [created|queued|processing|failed|success]
                                  Select subscription results in one or more
                                  states. Default: all.
  --csv                           Get subscription results as comma-separated
                                  fields.
  --limit INTEGER                 Maximum number of results to return. When
                                  set to 0, no maximum is applied.  [default:
                                  100]
  --help                          Show this message and exit.
```