### PR TITLE
Updated order delivery config for zipped orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ coverage.xml
 
 # Editors
 .vscode/
-
+.idea/
 # Docs build
 site

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,5 @@ coverage.xml
 
 # Editors
 .vscode/
-.idea/
 # Docs build
 site

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -199,9 +199,9 @@ def delivery(archive_type: Optional[str] = None,
     if archive_type:
         archive_type = specs.validate_archive_type(archive_type)
 
-        # for missing archive options set single_archive to false
-        if archive_filename is None and single_archive is False:
-            single_archive = True
+        # for missing archive file name
+        if archive_filename is None:
+            archive_filename = "{{name}}_{{order_id}}.zip"
 
     fields = ['archive_type', 'single_archive', 'archive_filename']
     values = [archive_type, single_archive, archive_filename]

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -199,6 +199,10 @@ def delivery(archive_type: Optional[str] = None,
     if archive_type:
         archive_type = specs.validate_archive_type(archive_type)
 
+        # for missing archive options set single_archive to false
+        if archive_filename is None and single_archive is False:
+            single_archive = True
+
     fields = ['archive_type', 'single_archive', 'archive_filename']
     values = [archive_type, single_archive, archive_filename]
 

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -174,7 +174,7 @@ def test_delivery_missing_archive_details():
 
     expected = {
         'archive_type': 'zip',
-        'single_archive': True,
+        'archive_filename': "{{name}}_{{order_id}}.zip",
         'amazon_s3': {
             'aws_access_key_id': 'aws_access_key_id',
             'aws_secret_access_key': 'aws_secret_access_key',

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -169,8 +169,7 @@ def test_delivery_missing_archive_details():
             'aws_region': 'aws_region'
         }
     }
-    delivery_config = order_request.delivery('zip',
-                                             False,
+    delivery_config = order_request.delivery(archive_type='zip',
                                              cloud_config=as3_config)
 
     expected = {

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -160,6 +160,32 @@ def test_delivery():
     assert delivery_config == expected
 
 
+def test_delivery_missing_archive_details():
+    as3_config = {
+        'amazon_s3': {
+            'aws_access_key_id': 'aws_access_key_id',
+            'aws_secret_access_key': 'aws_secret_access_key',
+            'bucket': 'bucket',
+            'aws_region': 'aws_region'
+        }
+    }
+    delivery_config = order_request.delivery('zip',
+                                             False,
+                                             cloud_config=as3_config)
+
+    expected = {
+        'archive_type': 'zip',
+        'single_archive': True,
+        'amazon_s3': {
+            'aws_access_key_id': 'aws_access_key_id',
+            'aws_secret_access_key': 'aws_secret_access_key',
+            'bucket': 'bucket',
+            'aws_region': 'aws_region'
+        }
+    }
+    assert delivery_config == expected
+
+
 def test_amazon_s3():
     as3_config = order_request.amazon_s3('aws_access_key_id',
                                          'aws_secret_access_key',


### PR DESCRIPTION
**Related Issue(s):**

Closes #963 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Orders now deliver zipped to cloud storage, even when `archive_filename` and `single_archive` are undefined. 

Not intended for changelog:

1.  

**Diff of User Interface**

Old behavior:
In `order_request.delivery()`, if `archive_type` was set to `zip`, but `archive_filename` and `single_archive` were both undefined, data was not delivered zipped.

New behavior:
Now, in `order_request.delivery()`, if `archive_type` is set to `zip`, but `archive_filename` and `single_archive` are both undefined, data will deliver as zipped.



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
