### PR TITLE
Don't ensurepip: no longer needed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 Next (TDB)
 
+Changed:
+- Running ensurepip and upgrading setuptools is no longer required to test with
+  Python 3.12 on GHA (#1008).
+
 2.1.1 (2023-07-20)
 
 Changed:

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,8 +39,9 @@ def coverage(session):
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
 def test(session):
-    session.run('python', '-m', 'ensurepip', '--upgrade')
-    session.install('-U', 'setuptools')
+    if session.python == "3.13":
+        session.run('python', '-m', 'ensurepip', '--upgrade')
+        session.install('-U', 'setuptools')
     session.install(".[test]")
 
     options = session.posargs

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,9 +39,6 @@ def coverage(session):
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
 def test(session):
-    if session.python == "3.13":
-        session.run('python', '-m', 'ensurepip', '--upgrade')
-        session.install('-U', 'setuptools')
     session.install(".[test]")
 
     options = session.posargs


### PR DESCRIPTION
Was needed with GHA Python 3.12.0-beta.3 but not since [beta.4](https://github.com/actions/python-versions/releases/tag/3.12.0-beta.4-5528170069).

Resolves #1006