### PR TITLE
New take on retrying order asset downloads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'httpx>=0.23.0',
     'jsonschema',
     'pyjwt>=2.1',
+    'stamina',
     'tqdm>=4.56',
     'typing-extensions',
 ]

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -566,7 +566,7 @@ async def test_download_asset_md(tmpdir, session):
 
 @respx.mock
 @pytest.mark.anyio
-async def test_download_asset_img(tmpdir, open_test_img, session):
+async def test_download_asset_img_with_retry(tmpdir, open_test_img, session):
     dl_url = TEST_DOWNLOAD_URL + '/1?token=IAmAToken'
 
     img_headers = {
@@ -587,9 +587,7 @@ async def test_download_asset_img(tmpdir, open_test_img, session):
     # an error caused by respx and not this code
     # https://github.com/lundberg/respx/issues/130
     respx.get(dl_url).side_effect = [
-        httpx.Response(HTTPStatus.OK,
-                       headers=img_headers,
-                       request='donotcloneme'),
+        httpx.ReadError("no can do!"),
         httpx.Response(HTTPStatus.OK,
                        stream=_stream_img(),
                        headers=img_headers,


### PR DESCRIPTION
Wraps the entire orders.download_asset() in a retry, eliminating the double download and concentrating the retry complexity instead of spreading it over several modules.

Resolves #1010