### PR TITLE
Update Subscriptions API data layers with forest_carbon_diligence_30m

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -346,7 +346,8 @@ def request_catalog(item_types,
         "biomass_proxy",
         "land_surface_temperature",
         "soil_water_content",
-        "vegetation_optical_depth"
+        "vegetation_optical_depth",
+        "forest_carbon_diligence_30m"
     ]),
 )
 @click.option('--var-id', required=True, help='Planetary variable id.')

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -266,7 +266,8 @@ def planetary_variable_source(
     var_type: Literal["biomass_proxy",
                       "land_surface_temperature",
                       "soil_water_content",
-                      "vegetation_optical_depth"],
+                      "vegetation_optical_depth",
+                      "forest_carbon_diligence_30m"],
     var_id: str,
     geometry: Mapping,
     start_time: datetime,
@@ -286,7 +287,8 @@ def planetary_variable_source(
 
     Parameters:
         var_type: one of "biomass_proxy", "land_surface_temperature",
-            "soil_water_content", or "vegetation_optical_depth".
+            "soil_water_content", "vegetation_optical_depth", or
+            "forest_carbon_diligence_30m".
         var_id: a value such as "SWC-AMSR2-C_V1.0_100" for soil water
             content derived from AMSR2 C band.
         geometry: The area of interest of the subscription that will be


### PR DESCRIPTION
**Related Issue(s):**

Closes # DND-721


**Proposed Changes:**

For inclusion in changelog (if applicable):

1.  Update Subscriptions API data layers with forest_carbon_diligence_30m

Not intended for changelog:

1. N/A

**Diff of User Interface**

Old behavior:  Data layer forest_carbon_diligence_30m was not enabled as a source type for Subscriptions API.

New behavior:  Data layer forest_carbon_diligence_30m is enabled as a source type for Subscriptions API.




**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
