### PR TITLE
Support Subscriptions API `PATCH` requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ git checkout -b new-branch-name
 
 #### Branch Naming
 
-Please use the following naming convention for development branchs:
+Please use the following naming convention for development branches:
 
 `{up to 3-word summary of topic, separated by a dash)-{ticket number}`
 
@@ -41,7 +41,7 @@ For example: `release-contributing-691` for [ticket 691](https://github.com/plan
 
 ### Pull Requests
 
-NOTE: Make sure to set the appropriate base branch for PRs. See Development Branch above for appriopriate branch.
+NOTE: Make sure to set the appropriate base branch for PRs. See Development Branch above for appropriate branch.
 
 The Pull Request requirements are included in the pull request template as a list of checkboxes.
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -127,7 +127,7 @@ async def cancel_subscription_cmd(ctx, subscription_id, pretty):
 @translate_exceptions
 @coro
 async def update_subscription_cmd(ctx, subscription_id, request, pretty):
-    """Update a subscription.
+    """Update a subscription via PUT.
 
     Updates a subscription and prints the updated subscription description,
     optionally pretty-printed.
@@ -137,6 +137,27 @@ async def update_subscription_cmd(ctx, subscription_id, request, pretty):
     """
     async with subscriptions_client(ctx) as client:
         sub = await client.update_subscription(subscription_id, request)
+        echo_json(sub, pretty)
+
+
+@subscriptions.command(name='patch')  # type: ignore
+@click.argument('subscription_id')
+@click.argument('request', type=types.JSON())
+@pretty
+@click.pass_context
+@translate_exceptions
+@coro
+async def patch_subscription_cmd(ctx, subscription_id, request, pretty):
+    """Update a subscription via PATCH.
+
+    Updates a subscription and prints the updated subscription description,
+    optionally pretty-printed.
+
+    REQUEST only requires the attributes to be changed. It must be
+    JSON and can be specified a json string, filename, or '-' for stdin.
+    """
+    async with subscriptions_client(ctx) as client:
+        sub = await client.patch_subscription(subscription_id, request)
         echo_json(sub, pretty)
 
 

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -160,11 +160,12 @@ class SubscriptionsClient:
 
     async def update_subscription(self, subscription_id: str,
                                   request: dict) -> dict:
-        """Update (edit) a Subscription.
+        """Update (edit) a Subscription via PUT.
 
         Args
             subscription_id (str): id of the subscription to update.
-            request (dict): subscription content for update.
+            request (dict): subscription content for update, full
+                payload is required.
 
         Returns:
             dict: description of the updated subscription.
@@ -177,6 +178,38 @@ class SubscriptionsClient:
 
         try:
             resp = await self._session.request(method='PUT',
+                                               url=url,
+                                               json=request)
+        # Forward APIError. We don't strictly need this clause, but it
+        # makes our intent clear.
+        except APIError:
+            raise
+        except ClientError:  # pragma: no cover
+            raise
+        else:
+            sub = resp.json()
+            return sub
+
+    async def patch_subscription(self, subscription_id: str,
+                                 request: dict) -> dict:
+        """Update (edit) a Subscription via PATCH.
+
+        Args
+            subscription_id (str): id of the subscription to update.
+            request (dict): subscription content for update, only
+                attributes to update are required.
+
+        Returns:
+            dict: description of the updated subscription.
+
+        Raises:
+            APIError: on an API server error.
+            ClientError: on a client error.
+        """
+        url = f'{self._base_url}/{subscription_id}'
+
+        try:
+            resp = await self._session.request(method='PATCH',
                                                url=url,
                                                json=request)
         # Forward APIError. We don't strictly need this clause, but it

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,7 +28,6 @@ def test_disable_limiter(monkeypatch):
 
 
 @pytest.fixture
-@pytest.mark.anyio
 async def session():
     async with planet.Session() as ps:
         yield ps

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -1,13 +1,14 @@
 """Tests of the Subscriptions CLI (aka planet-subscriptions)
 
-There are 6 subscriptions commands:
+There are 7 subscriptions commands:
 
-[x] planet subscriptions list
-[x] planet subscriptions get
-[x] planet subscriptions results
-[x] planet subscriptions create
-[x] planet subscriptions update
 [x] planet subscriptions cancel
+[x] planet subscriptions create
+[x] planet subscriptions get
+[x] planet subscriptions list
+[x] planet subscriptions patch
+[x] planet subscriptions results
+[x] planet subscriptions update
 
 TODO: tests for 3 options of the planet-subscriptions-results command.
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -21,12 +21,13 @@ import pytest
 from planet.cli import cli
 
 from test_subscriptions_api import (api_mock,
-                                    failing_api_mock,
-                                    create_mock,
-                                    update_mock,
                                     cancel_mock,
+                                    create_mock,
+                                    failing_api_mock,
                                     get_mock,
+                                    patch_mock,
                                     res_api_mock,
+                                    update_mock,
                                     TEST_URL)
 
 # CliRunner doesn't agree with empty options, so a list of option
@@ -190,6 +191,34 @@ def test_subscriptions_update_success(invoke):
 
     assert result.exit_code == 0  # success.
     assert json.loads(result.output)['name'] == 'new_name'
+
+
+@failing_api_mock
+def test_subscriptions_patch_failure(invoke):
+    """Patch command exits gracefully from an API error."""
+    result = invoke(
+        ['patch', 'test', json.dumps(GOOD_SUB_REQUEST)],
+        # Note: catch_exceptions=True (the default) is required if we want
+        # to exercise the "translate_exceptions" decorator and test for
+        # failure.
+        catch_exceptions=True)
+
+    assert result.exit_code == 1  # failure.
+
+
+@patch_mock
+def test_subscriptions_patch_success(invoke):
+    """Patch command succeeds."""
+    request = {'name': 'test patch'}
+    result = invoke(
+        ['patch', 'test', json.dumps(request)],
+        # Note: catch_exceptions=True (the default) is required if we want
+        # to exercise the "translate_exceptions" decorator and test for
+        # failure.
+        catch_exceptions=True)
+
+    assert result.exit_code == 0  # success.
+    assert json.loads(result.output)['name'] == request['name']
 
 
 @failing_api_mock


### PR DESCRIPTION
**Related Issue(s):**

Closes #1019


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Support Subscriptions API `PATCH` requests

**Diff of User Interface**

- Old behavior: N/A
- New behavior: CLI and Python library both support sending `PATCH` requests to the Subscriptions API

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them
