### PR TITLE
Subscriptions API Hosting Support for Sentinel Hub

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -249,7 +249,6 @@ async def list_subscription_results_cmd(ctx,
               help='Source JSON. Can be a string, filename, or - for stdin.')
 @click.option(
     '--delivery',
-    required=True,
     type=types.JSON(),
     help=("Delivery configuration, including credentials for a cloud "
           "storage provider, to enable cloud delivery of data. Can be a "
@@ -263,6 +262,10 @@ async def list_subscription_results_cmd(ctx,
     type=types.JSON(),
     help='Toolchain JSON. Can be a string, filename, or - for stdin.')
 @click.option(
+    '--hosting',
+    type=types.JSON(),
+    help='Hosting JSON.  Can be a string, a filename, or - for stdin.')
+@click.option(
     '--clip-to-source',
     is_flag=True,
     default=False,
@@ -273,6 +276,7 @@ def request(name,
             delivery,
             notifications,
             tools,
+            hosting,
             clip_to_source,
             pretty):
     """Generate a subscriptions request.
@@ -287,6 +291,7 @@ def request(name,
                                              delivery,
                                              notifications=notifications,
                                              tools=tools,
+                                             hosting=hosting,
                                              clip_to_source=clip_to_source)
     echo_json(res, pretty)
 

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -205,6 +205,18 @@ async def test_create_subscription_success():
 
 
 @pytest.mark.anyio
+@create_mock
+async def test_create_subscription_with_hosting_success():
+    """Subscription is created, description has the expected items."""
+    async with Session() as session:
+        client = SubscriptionsClient(session, base_url=TEST_URL)
+        sub = await client.create_subscription({
+            'name': 'test', 'source': 'test', 'hosting': 'yes, please'
+        })
+        assert sub['name'] == 'test'
+
+
+@pytest.mark.anyio
 @failing_api_mock
 async def test_cancel_subscription_failure():
     """APIError is raised if there is a server error."""

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -95,11 +95,16 @@ def test_subscriptions_create_failure(invoke):
 # It must be updated when we begin to test against a more strict
 # imitation of the Planet Subscriptions API.
 GOOD_SUB_REQUEST = {'name': 'lol', 'delivery': True, 'source': 'wut'}
+GOOD_SUB_REQUEST_WITH_HOSTING = {
+    'name': 'lol', 'source': 'wut', 'hosting': True
+}
 
 
 @pytest.mark.parametrize('cmd_arg, runner_input',
                          [('-', json.dumps(GOOD_SUB_REQUEST)),
-                          (json.dumps(GOOD_SUB_REQUEST), None)])
+                          (json.dumps(GOOD_SUB_REQUEST), None),
+                          ('-', json.dumps(GOOD_SUB_REQUEST_WITH_HOSTING)),
+                          (json.dumps(GOOD_SUB_REQUEST_WITH_HOSTING), None)])
 @create_mock
 def test_subscriptions_create_success(invoke, cmd_arg, runner_input):
     """Subscriptions creation succeeds with a valid subscription request."""

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -119,6 +119,59 @@ def test_build_request_clip_to_source_failure(geom_geojson):
         )
 
 
+def test_build_request_host_sentinel_hub_with_collection(geom_geojson):
+    source = {
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "end_time": "2023-11-01T00:00:00Z",
+            "rrule": "FREQ=MONTHLY;BYMONTH=3,4,5,6,7,8,9,10",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    }
+
+    hosting = {"type": "sentinel-hub"}
+
+    res = subscription_request.build_request('test',
+                                             source=source,
+                                             hosting=hosting)
+
+    expected = {"name": "test", "source": source, "hosting": hosting}
+
+    assert res == expected
+
+
+def test_build_request_host_sentinel_hub_no_collection(geom_geojson):
+    source = {
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "end_time": "2023-11-01T00:00:00Z",
+            "rrule": "FREQ=MONTHLY;BYMONTH=3,4,5,6,7,8,9,10",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    }
+
+    hosting = {
+        "type": "sentinel-hub",
+        "parameters": {
+            "collection_id": "4c9af036-4274-4a97-bf0d-eb2a7853330d"
+        }
+    }
+
+    res = subscription_request.build_request('test',
+                                             source=source,
+                                             hosting=hosting)
+
+    expected = {"name": "test", "source": source, "hosting": hosting}
+
+    assert res == expected
+
+
 def test_catalog_source_success(geom_geojson):
     res = subscription_request.catalog_source(
         item_types=["PSScene"],


### PR DESCRIPTION
**Related Issue(s):**

Closes # Internal DND-879


**Proposed Changes:**

For inclusion in changelog (if applicable):

1.  Support Subscriptions API hosting block for Sentinel Hub.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:
- Delivery block is required and hosting block is not supported.

New behavior:
- CLI and Python SDK both support specifying a hosting block, and delivery block is no longer required.




**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
