### PR TITLE
Added field_boundaries_sentinel_2_p1m for Field Boundaries PV support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+
+
+Added:
+ - Support for field_boundaries_sentinel_2_p1m in Subscriptions API (#1026)
+
 2.4.0 (2024-03-19)
 
 Added:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,6 @@ extra_css:
     
 plugins:
   - search
-  - with-pdf
   - mkdocstrings:
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ extra_css:
     
 plugins:
   - search
+  - with-pdf
   - mkdocstrings:
       handlers:
         python:

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -373,7 +373,8 @@ def request_catalog(item_types,
         "land_surface_temperature",
         "soil_water_content",
         "vegetation_optical_depth",
-        "forest_carbon_diligence_30m"
+        "forest_carbon_diligence_30m",
+        "field_boundaries_sentinel_2_p1m"
     ]),
 )
 @click.option('--var-id', required=True, help='Planetary variable id.')

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -276,7 +276,8 @@ def planetary_variable_source(
                       "land_surface_temperature",
                       "soil_water_content",
                       "vegetation_optical_depth",
-                      "forest_carbon_diligence_30m"],
+                      "forest_carbon_diligence_30m",
+                      "field_boundaries_sentinel_2_p1m"],
     var_id: str,
     geometry: Mapping,
     start_time: datetime,
@@ -296,8 +297,8 @@ def planetary_variable_source(
 
     Parameters:
         var_type: one of "biomass_proxy", "land_surface_temperature",
-            "soil_water_content", "vegetation_optical_depth", or
-            "forest_carbon_diligence_30m".
+            "soil_water_content", "vegetation_optical_depth",
+            "forest_carbon_diligence_30m, or field_boundaries_sentinel_2_p1m".
         var_id: a value such as "SWC-AMSR2-C_V1.0_100" for soil water
             content derived from AMSR2 C band.
         geometry: The area of interest of the subscription that will be


### PR DESCRIPTION
**Related Issue(s):**

Closes #1026

I modeled this off of https://github.com/planetlabs/planet-client-python/commit/4c920fde74706da7724323522f606586815ab583 which didn't have any tests, so hopefully none are needed. Just adds an option for the new https://developers.planet.com/docs/planetary-variables/field-boundaries/

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Support for field_boundaries_sentinel_2_p1m in Subscriptions API

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior: No mention of `field_boundaries_sentinel_2_p1m`, and failure if you try to use it.

New behavior: `field_boundaries_sentinel_2_p1m` can be provided to a PV subscription, and it shows up as an option in the CLI.




**PR Checklist:**

- [] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
