### PR TITLE
Add Hosting Block Convenience Method to SDK

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.5.0 (2024-03-27)
+- Support Subscriptions API hosting block for Sentinel Hub in the CLI (#1029).
+
 2.4.0 (2024-03-19)
 
 Added:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,8 +3,7 @@
 Added:
 - Support Subscriptions API hosting block for Sentinel Hub in the CLI (#1029).
 
-Added:
- - Support for field_boundaries_sentinel_2_p1m in Subscriptions API (#1026)
+- Support for field_boundaries_sentinel_2_p1m in Subscriptions API (#1026)
 
 2.4.0 (2024-03-19)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 2.5.0 (2024-03-27)
+
+Added:
 - Support Subscriptions API hosting block for Sentinel Hub in the CLI (#1029).
 
 2.4.0 (2024-03-19)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-2.5.0 (2024-03-27)
+2.5.0 (2024-04-04)
 
 Added:
 - Support Subscriptions API hosting block for Sentinel Hub in the CLI (#1029).

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -92,6 +92,7 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.argument("request", type=types.JSON())
 @click.option(
     "--hosting",
+    type=click.Choice(["sentinel_hub",]),
     default=None,
     help='Hosting type. Currently, only "sentinel_hub" is supported.',
 )
@@ -103,8 +104,7 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.pass_context
 @translate_exceptions
 @coro
-async def create_subscription_cmd(ctx, request, hosting, collection_id,
-                                  pretty):
+async def create_subscription_cmd(ctx, request, pretty, **kwargs):
     """Create a subscription.
 
     Submits a subscription request for creation and prints the created
@@ -113,6 +113,9 @@ async def create_subscription_cmd(ctx, request, hosting, collection_id,
     REQUEST is the full description of the subscription to be created. It must
     be JSON and can be specified a json string, filename, or '-' for stdin.
     """
+
+    hosting = kwargs.get("hosting", None)
+    collection_id = kwargs.get("collection_id", None)
 
     if hosting == "sentinel_hub":
         hosting_info = sentinel_hub(collection_id)
@@ -280,6 +283,7 @@ async def list_subscription_results_cmd(ctx,
 @click.option(
     '--hosting',
     default=None,
+    type=click.Choice(["sentinel_hub",]),
     help='Hosting configuration. Can be JSON, "sentinel_hub", or omitted.')
 @click.option(
     '--clip-to-source',

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -98,15 +98,13 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.option(
     "--collection_id",
     default=None,
-    help=
-    "Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
+    help="Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
 )
 @pretty
 @click.pass_context
 @translate_exceptions
 @coro
-async def create_subscription_cmd(ctx, request, hosting, collection_id, 
-                pretty):
+async def create_subscription_cmd(ctx, request, hosting, collection_id, pretty):
     """Create a subscription.
 
     Submits a subscription request for creation and prints the created

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -98,13 +98,15 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.option(
     "--collection_id",
     default=None,
-    help="Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
+    help=
+    "Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
 )
 @pretty
 @click.pass_context
 @translate_exceptions
 @coro
-async def create_subscription_cmd(ctx, request, hosting, collection_id, pretty):
+async def create_subscription_cmd(ctx, request, hosting, collection_id, 
+                pretty):
     """Create a subscription.
 
     Submits a subscription request for creation and prints the created

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -98,13 +98,15 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.option(
     "--collection_id",
     default=None,
-    help="Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
+    help=
+    "Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
 )
 @pretty
 @click.pass_context
 @translate_exceptions
 @coro
-async def create_subscription_cmd(ctx, request, hosting, collection_id, pretty):
+async def create_subscription_cmd(ctx, request, hosting, collection_id,
+                                  pretty):
     """Create a subscription.
 
     Submits a subscription request for creation and prints the created

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -114,6 +114,11 @@ async def create_subscription_cmd(ctx, request, pretty, **kwargs):
 
     REQUEST is the full description of the subscription to be created. It must
     be JSON and can be specified a json string, filename, or '-' for stdin.
+
+    Other flag options are hosting and collection_id. The hosting flag
+    specifies the hosting type, and the collection_id flag specifies the
+    collection ID for Sentinel Hub. If the collection_id is omitted, a new
+    collection will be created.
     """
 
     hosting = kwargs.get("hosting", None)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -92,7 +92,9 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
 @click.argument("request", type=types.JSON())
 @click.option(
     "--hosting",
-    type=click.Choice(["sentinel_hub",]),
+    type=click.Choice([
+        "sentinel_hub",
+    ]),
     default=None,
     help='Hosting type. Currently, only "sentinel_hub" is supported.',
 )
@@ -283,7 +285,9 @@ async def list_subscription_results_cmd(ctx,
 @click.option(
     '--hosting',
     default=None,
-    type=click.Choice(["sentinel_hub",]),
+    type=click.Choice([
+        "sentinel_hub",
+    ]),
     help='Hosting configuration. Can be JSON, "sentinel_hub", or omitted.')
 @click.option(
     '--clip-to-source',

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -99,7 +99,7 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
     "--collection_id",
     default=None,
     help=
-    "Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.",
+    'Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.',
 )
 @pretty
 @click.pass_context
@@ -282,12 +282,13 @@ async def list_subscription_results_cmd(ctx,
 @click.option(
     '--hosting',
     type=types.JSON(),
-    help='Hosting JSON.  Can be a string, a filename, or - for stdin.')
+    help='Hosting JSON.  Can be a string, a filename, or - for stdin. Currently, only "sentinel_hub" is supported.')
 @click.option(
     '--clip-to-source',
     is_flag=True,
     default=False,
     help="Clip to the source geometry without specifying a clip tool.")
+@click.option("--collection-id", default=None, help='Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.')
 @pretty
 def request(name,
             source,
@@ -295,6 +296,7 @@ def request(name,
             notifications,
             tools,
             hosting,
+            collection_id,
             clip_to_source,
             pretty):
     """Generate a subscriptions request.
@@ -304,12 +306,14 @@ def request(name,
     --clip-to-source option is a preview of the next API version's
     default behavior.
     """
+
     res = subscription_request.build_request(name,
                                              source,
                                              delivery,
                                              notifications=notifications,
                                              tools=tools,
                                              hosting=hosting,
+                                             collection_id=collection_id,
                                              clip_to_source=clip_to_source)
     echo_json(res, pretty)
 
@@ -367,6 +371,7 @@ def request_catalog(item_types,
                     time_range_type,
                     pretty):
     """Generate a subscriptions request catalog source description."""
+
     res = subscription_request.catalog_source(
         item_types,
         asset_types,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -95,12 +95,10 @@ async def list_subscriptions_cmd(ctx, status, limit, pretty):
     default=None,
     help='Hosting type. Currently, only "sentinel_hub" is supported.',
 )
-@click.option(
-    "--collection_id",
-    default=None,
-    help=
-    'Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.',
-)
+@click.option("--collection-id",
+              default=None,
+              help='Collection ID for Sentinel Hub.'
+              'If omitted, a new collection will be created.')
 @pretty
 @click.pass_context
 @translate_exceptions
@@ -281,14 +279,17 @@ async def list_subscription_results_cmd(ctx,
     help='Toolchain JSON. Can be a string, filename, or - for stdin.')
 @click.option(
     '--hosting',
-    type=types.JSON(),
-    help='Hosting JSON.  Can be a string, a filename, or - for stdin. Currently, only "sentinel_hub" is supported.')
+    default=None,
+    help='Hosting configuration. Can be JSON, "sentinel_hub", or omitted.')
 @click.option(
     '--clip-to-source',
     is_flag=True,
     default=False,
     help="Clip to the source geometry without specifying a clip tool.")
-@click.option("--collection-id", default=None, help='Optional collection ID for Sentinel Hub. If omitted, a new collection will be created.')
+@click.option("--collection-id",
+              default=None,
+              help='Collection ID for Sentinel Hub.'
+              'If omitted, a new collection will be created.')
 @pretty
 def request(name,
             source,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -113,8 +113,8 @@ async def create_subscription_cmd(ctx, request, hosting, collection_id, pretty):
     REQUEST is the full description of the subscription to be created. It must
     be JSON and can be specified a json string, filename, or '-' for stdin.
     """
-    
-    if hosting or hosting.lower() == "sentinel_hub":
+
+    if hosting == "sentinel_hub":
         hosting_info = sentinel_hub(collection_id)
         request["hosting"] = hosting_info
 

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -52,7 +52,8 @@ def build_request(name: str,
                   delivery: Optional[Mapping] = None,
                   notifications: Optional[Mapping] = None,
                   tools: Optional[List[Mapping]] = None,
-                  hosting: Optional[Mapping] = None,
+                  hosting: Optional[Union[Mapping, str]] = None,
+                  collection_id: Optional[str] = None,
                   clip_to_source: Optional[bool] = False) -> dict:
     """Construct a Subscriptions API request.
 
@@ -150,8 +151,15 @@ def build_request(name: str,
 
         details['tools'] = tool_list
 
-    if hosting:
-        details['hosting'] = dict(hosting)
+    if hosting == "sentinel_hub":
+        hosting_info: Dict[str, Any] = {
+            "type": "sentinel_hub", "parameters": {}
+        }
+        if collection_id:
+            hosting_info["parameters"]["collection_id"] = collection_id
+        details['hosting'] = hosting_info
+    elif isinstance(hosting, dict):
+        details['hosting'] = hosting
 
     return details
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -444,7 +444,7 @@ def test_catalog_source_time_range_type(invoke, geom_geojson, time_range_type):
         ("--hosting=sentinel_hub", "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734", True),
     ]
 )
-def test_request_base_hosting(invoke, geom_geojson, hosting_option, collection_id_option, expected_success):
+def test_request_hosting(invoke, geom_geojson, hosting_option, collection_id_option, expected_success):
     """Test request command with various hosting and collection ID options."""
     source = json.dumps({
         "type": "catalog",

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -464,7 +464,7 @@ def test_request_base_hosting(invoke, geom_geojson, hosting_option, collection_i
         f'--source={source}',
         hosting_option,
     ]
-    
+
     if collection_id_option:
         cmd.append(collection_id_option)
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -441,10 +441,15 @@ def test_catalog_source_time_range_type(invoke, geom_geojson, time_range_type):
     "hosting_option, collection_id_option, expected_success",
     [
         ("--hosting=sentinel_hub", None, True),
-        ("--hosting=sentinel_hub", "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734", True),
-    ]
-)
-def test_request_hosting(invoke, geom_geojson, hosting_option, collection_id_option, expected_success):
+        ("--hosting=sentinel_hub",
+         "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734",
+         True),
+    ])
+def test_request_hosting(invoke,
+                         geom_geojson,
+                         hosting_option,
+                         collection_id_option,
+                         expected_success):
     """Test request command with various hosting and collection ID options."""
     source = json.dumps({
         "type": "catalog",

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -435,3 +435,39 @@ def test_catalog_source_time_range_type(invoke, geom_geojson, time_range_type):
     assert result.exit_code == 0  # success.
     req = json.loads(result.output)
     assert req['parameters']['time_range_type'] == time_range_type
+
+
+@pytest.mark.parametrize(
+    "hosting_option, collection_id_option, expected_success",
+    [
+        ("--hosting=sentinel_hub", None, True),
+        ("--hosting=sentinel_hub", "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734", True),
+    ]
+)
+def test_request_base_hosting(invoke, geom_geojson, hosting_option, collection_id_option, expected_success):
+    """Test request command with various hosting and collection ID options."""
+    source = json.dumps({
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "end_time": "2023-11-01T00:00:00Z",
+            "rrule": "FREQ=MONTHLY;BYMONTH=3,4,5,6,7,8,9,10",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    })
+
+    cmd = [
+        'request',
+        '--name=test',
+        f'--source={source}',
+        hosting_option,
+    ]
+    
+    if collection_id_option:
+        cmd.append(collection_id_option)
+
+    result = invoke(cmd)
+
+    assert result.exit_code == 0, "Expected command to succeed."


### PR DESCRIPTION
**Related Issue(s):**

Closes #


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Support Subscriptions API hosting block for Sentinel Hub in the CLI (#1029).

Not intended for changelog:

1. N/A

**Diff of User Interface**

Old behavior: Hosting was not supported for create and request for the Subscriptions CLI. 

New behavior: Hosting is now supported for both create and request in the Subscriptions CLI. --hosting and --collection_id are flags used for this. 



**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
