### PR TITLE
Update Subscriptions API Data Layers With analysis_ready_ps

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -406,6 +406,7 @@ def request_catalog(item_types,
     required=True,
     help='Planetary variable type.',
     type=click.Choice([
+        "analysis_ready_ps",
         "biomass_proxy",
         "land_surface_temperature",
         "soil_water_content",

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -280,7 +280,8 @@ def catalog_source(
 
 
 def planetary_variable_source(
-    var_type: Literal["biomass_proxy",
+    var_type: Literal["analysis_ready_ps",
+                      "biomass_proxy",
                       "land_surface_temperature",
                       "soil_water_content",
                       "vegetation_optical_depth",
@@ -304,9 +305,10 @@ def planetary_variable_source(
     Note: this function does not validate variable types and ids.
 
     Parameters:
-        var_type: one of "biomass_proxy", "land_surface_temperature",
-            "soil_water_content", "vegetation_optical_depth",
-            "forest_carbon_diligence_30m, or field_boundaries_sentinel_2_p1m".
+        var_type: one of "analysis_ready_ps", "biomass_proxy",
+            "land_surface_temperature", "soil_water_content",
+            "vegetation_optical_depth", "forest_carbon_diligence_30m,
+            or field_boundaries_sentinel_2_p1m".
         var_id: a value such as "SWC-AMSR2-C_V1.0_100" for soil water
             content derived from AMSR2 C band.
         geometry: The area of interest of the subscription that will be


### PR DESCRIPTION
**Related Issue(s):**

Closes #

DND-1121

**Proposed Changes:**

For inclusion in changelog (if applicable):

1.  Update Subscriptions API data layers with analysis_ready_ps

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior: Data layer analysis_ready_ps was not enabled as a source type for Subscriptions API.

New behavior: Data layer analysis_ready_ps is enabled as a source type for Subscriptions API.




**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
