### PR TITLE
Add Support For Forest Carbon Monitoring 3m

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+2.9.0 (2024-06-05)
+
+Added:
+- Support for forest_carbon_monitoring_3m (#).
+
 2.8.0 (2024-06-05)
 
 Added:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 2.9.0 (2024-06-05)
 
 Added:
-- Support for forest_carbon_monitoring_3m (#).
+- Support for forest_carbon_monitoring_3m (#1045).
 
 2.8.0 (2024-06-05)
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -413,6 +413,7 @@ def request_catalog(item_types,
         "land_surface_temperature",
         "soil_water_content",
         "vegetation_optical_depth",
+        "forest_carbon_monitoring_3m",
         "forest_carbon_diligence_30m",
         "field_boundaries_sentinel_2_p1m"
     ]),

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -283,6 +283,7 @@ def planetary_variable_source(
                       "land_surface_temperature",
                       "soil_water_content",
                       "vegetation_optical_depth",
+                      "forest_carbon_monitoring_3m",
                       "forest_carbon_diligence_30m",
                       "field_boundaries_sentinel_2_p1m"],
     var_id: str,
@@ -305,8 +306,8 @@ def planetary_variable_source(
     Parameters:
         var_type: one of "analysis_ready_ps", "biomass_proxy",
             "land_surface_temperature", "soil_water_content",
-            "vegetation_optical_depth", "forest_carbon_diligence_30m,
-            or field_boundaries_sentinel_2_p1m".
+            "vegetation_optical_depth", "forest_carbon_monitoring_3m",
+            "forest_carbon_diligence_30m, or field_boundaries_sentinel_2_p1m".
         var_id: a value such as "SWC-AMSR2-C_V1.0_100" for soil water
             content derived from AMSR2 C band.
         geometry: The area of interest of the subscription that will be


### PR DESCRIPTION
**Related Issue(s):**

Closes #


**Proposed Changes:**

For inclusion in changelog (if applicable):

1.  Add support for forest_carbon_monitoring_3m PVs to Subscriptions API.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

New behavior:




**PR Checklist:**

- [] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
