### PR TITLE
Adjust how PV source types are documented.

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -406,19 +406,12 @@ def request_catalog(item_types,
 @click.option(
     '--var-type',
     required=True,
-    help='Planetary variable type.',
-    type=click.Choice([
-        "analysis_ready_ps",
-        "biomass_proxy",
-        "land_surface_temperature",
-        "soil_water_content",
-        "vegetation_optical_depth",
-        "forest_carbon_monitoring_3m",
-        "forest_carbon_diligence_30m",
-        "field_boundaries_sentinel_2_p1m"
-    ]),
+    help='A Planetary Variable type. See documentation for all available types.'
 )
-@click.option('--var-id', required=True, help='Planetary variable id.')
+@click.option(
+    '--var-id',
+    required=True,
+    help='A Planetary Variable ID. See documenation for all available IDs.')
 @click.option(
     '--geometry',
     required=True,
@@ -438,9 +431,9 @@ def request_pv(var_type, var_id, geometry, start_time, end_time, pretty):
     """Generate a Planetary Variable subscription source.
 
     Planetary Variables come in 4 types and are further subdivided
-    within these types. See [Subscribing to Planetary
-    Variables](https://developers.planet.com/docs/subscriptions/pvs-subs/#planetary-variables-types-and-ids)
-    for details.
+    within these types. See [Subscribing to Planetary Variables](https://developers.planet.com/docs/subscriptions/pvs-subs/#planetary-variables-types-and-ids)
+    or the [OpenAPI spec](https://api.planet.com/subscriptions/v1/spec) for
+    more details.
     """
     res = subscription_request.planetary_variable_source(
         var_type,

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -278,14 +278,7 @@ def catalog_source(
 
 
 def planetary_variable_source(
-    var_type: Literal["analysis_ready_ps",
-                      "biomass_proxy",
-                      "land_surface_temperature",
-                      "soil_water_content",
-                      "vegetation_optical_depth",
-                      "forest_carbon_monitoring_3m",
-                      "forest_carbon_diligence_30m",
-                      "field_boundaries_sentinel_2_p1m"],
+    var_type: str,
     var_id: str,
     geometry: dict,
     start_time: datetime,
@@ -294,9 +287,9 @@ def planetary_variable_source(
     """Construct a Planetary Variable subscription source.
 
     Planetary Variables come in 4 types and are further subdivided
-    within these types. See [Subscribing to Planetary
-    Variables](https://developers.planet.com/docs/subscriptions/pvs-subs/#planetary-variables-types-and-ids)
-    for details.
+    within these types. See [Subscribing to Planetary Variables](https://developers.planet.com/docs/subscriptions/pvs-subs/#planetary-variables-types-and-ids)
+    or the [OpenAPI spec](https://api.planet.com/subscriptions/v1/spec) for
+    more details.
 
     The return value can be passed to
     [planet.subscription_request.build_request][].
@@ -304,12 +297,10 @@ def planetary_variable_source(
     Note: this function does not validate variable types and ids.
 
     Parameters:
-        var_type: one of "analysis_ready_ps", "biomass_proxy",
-            "land_surface_temperature", "soil_water_content",
-            "vegetation_optical_depth", "forest_carbon_monitoring_3m",
-            "forest_carbon_diligence_30m, or field_boundaries_sentinel_2_p1m".
-        var_id: a value such as "SWC-AMSR2-C_V1.0_100" for soil water
-            content derived from AMSR2 C band.
+        var_type: Planetary Variable type. See documentation for all
+            available types.
+        var_id: A Planetary Variable ID. See documenation for all
+            available IDs.
         geometry: The area of interest of the subscription that will be
             used to determine matches.
         start_time: The start time of the subscription. This time can be


### PR DESCRIPTION
Link to documentation and OpenAPI spec instead of maintaining separately.

**Related Issue(s):**

Closes #


**Proposed Changes:**

For inclusion in changelog (if applicable):

Client does not require a new release to support additional PV source types.

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

Client requires a new release to support additional PV source types.

New behavior:

Client does not require a new release to support additional PV source types.

* Validate source types in CLI with API instead of `click.Option`.
* Refer to Developer Center documentation in docstrings and CLI `--help` instead of maintaining separately

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
