### PR TITLE
Add a redirect to the v2 docs to the v1 gh-pages site

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -51,3 +51,23 @@ pre span {
 {
   color: #f2f2f2;
 }
+
+#redirect {
+  padding: 5px;
+  font-size: 18px;
+  text-align: center;
+  color: white;
+  background-color: rgb(0, 127, 153);
+  border-bottom: 3px solid ;
+
+}
+
+@media screen and (max-width: 875px) {
+  #redirect {
+    margin-top: -20px;
+    margin-bottom: 20px;
+    margin-left: -30px;
+    margin-right: -30px;
+    border-bottom: none;
+  }
+}

--- a/_static/documentation_options.js
+++ b/_static/documentation_options.js
@@ -10,3 +10,15 @@ var DOCUMENTATION_OPTIONS = {
     SOURCELINK_SUFFIX: '.txt',
     NAVIGATION_WITH_KEYS: false
 };
+
+//Hack to redirect to v2 docs with as little changes as possible
+window.onload = function() {
+  r = document.getElementById('redirect')
+  if (!r) {
+    r = document.createElement('div')
+    r.setAttribute('id', 'redirect')
+    r.innerHTML = 'This is the documentation for version 1 of the Planet Python Client, which is deprecated. <br /> Please visit the <a href="https://planet-sdk-for-python-v2.readthedocs.io/en/stable/get-started/upgrading/">SDK v2 documentation</a> for instructions on how to upgrade.'
+    document.body.prepend(r);
+  }
+}
+


### PR DESCRIPTION
Recently, we had some users landing on the old v1 docs rather than the v2 docs. As we do still have some users on v1, I think it is important to keep those docs around, but they should have a link to v2 so that new users don't get lost. This PR adds a deprecation notice and link to the top of the v1 docs:

<img width="985" alt="Screenshot 2024-07-23 at 10 56 41 AM" src="https://github.com/user-attachments/assets/22c77ed5-cdf4-4128-bac1-4116273ff42e">

The old v1 docs appear to be entirely static rather than the more typical Jekyll, so this change is done in JS, so it applies to all pages with minimal effort and duplication. Not optimal, but for a deprecated doc site that isn't going to change anytime soon I think its fine.

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Update the v1 gh-pages documentation with a deprecation notice and a link to the v2 documentation

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
