### PR TITLE
pin mkdocs_autorefs to compatible version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ doc_requires = [
     'mkdocs==1.3',
     'mkdocs-click==0.7.0',
     'mkdocs-material==8.2.11',
-    'mkdocstrings==0.18.1'
+    'mkdocstrings==0.18.1',
+    'mkdocs_autorefs==1.0.1',
 ]
 
 setup(


### PR DESCRIPTION
fixes an error in mkdocs_autorefs/plugin.py, line 77:

TypeError: type 'BasePlugin' is not subscriptable

Bigger picture, mkdocs added type annotations to it's plugin system (in 1.4.0?) and the downstream plugin began using the new API after 1.0.1 or so

**Related Issue(s):**

Fixes nox 'docs' session, example breakage here: https://github.com/planetlabs/planet-client-python/actions/runs/10857195949/job/30210383772?pr=1055

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**

@stephenhillier @tbarsballe 