### PR TITLE
subscriptions get_results_csv uses session.stream

### DIFF
--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -336,7 +336,6 @@ class SubscriptionsClient:
         # during streaming. We may want to consider a retry decorator
         # for this entire method a la stamina:
         # https://github.com/hynek/stamina.
-        async with self._session._client.stream('GET', url,
-                                                params=params) as response:
+        async with self._session.stream('GET', url, params=params) as response:
             async for line in response.aiter_lines():
                 yield line

--- a/planet/http.py
+++ b/planet/http.py
@@ -396,8 +396,11 @@ class Session(BaseSession):
 
     @asynccontextmanager
     async def stream(
-            self, method: str,
-            url: str) -> AsyncGenerator[models.StreamingResponse, None]:
+        self,
+        method: str,
+        url: str,
+        params: Optional[dict] = None
+    ) -> AsyncGenerator[models.StreamingResponse, None]:
         """Submit a request and get the response as a stream context manager.
 
         Parameters:
@@ -407,7 +410,9 @@ class Session(BaseSession):
         Returns:
             Context manager providing the streaming response.
         """
-        request = self._client.build_request(method=method, url=url)
+        request = self._client.build_request(method=method,
+                                             url=url,
+                                             params=params)
         http_response = await self._retry(self._send, request, stream=True)
         response = models.StreamingResponse(http_response)
         try:

--- a/planet/models.py
+++ b/planet/models.py
@@ -72,6 +72,9 @@ class StreamingResponse(Response):
         async for c in self._http_response.aiter_bytes():
             yield c
 
+    def aiter_lines(self):
+        return self._http_response.aiter_lines()
+
     async def aclose(self):
         await self._http_response.aclose()
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #1059

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. get_results_csv throttled and retried
