### PR TITLE
doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,7 @@ document explains how to contribute successfully.
 
 #### Development Branch
 
-Implementation of new features will be tracked in the `main` branch, while bug
-fixes and doc changes for the latest release will be tracked in the maintenance
-branch, called `maint-RELEASE_VERSION`. All work will be performed in a
-new development branch starting with the appropriate base branch and merged
-back into that branch.
-
-For new features:
+The default branch is always `main` and should be always considered in-development.  Feature enhancements, bug fixes, and other maintenance should be performed in a development branch, starting with the appropriate base branch and merged back into that branch:
 
 ```console
 git checkout main
@@ -23,21 +17,9 @@ git pull
 git checkout -b new-branch-name
 ```
 
-For example, for bug fixes and doc changes to release version 2.0:
-
-```console
-git checkout maint-2.0
-git pull
-git checkout -b new-branch-name
-```
-
 #### Branch Naming
 
-Please use the following naming convention for development branches:
-
-`{up to 3-word summary of topic, separated by a dash)-{ticket number}`
-
-For example: `release-contributing-691` for [ticket 691](https://github.com/planetlabs/planet-client-python/issues/691).
+Branch names should describe the work performed within the branch, and include a ticket number if applicable.  For example, a branch that corrects typos in documentation and is not ticketed could be named `fix-documentation-typos`, and a branch that adds a new feature and is ticketed could be named `new-feature-123` (where 'new-feature' is the name of the feature and '-123' is the ticket number).
 
 ### Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,11 @@ remaining Planet APIs: [basemaps](https://developers.planet.com/docs/basemaps/),
 
 ## Versions and Stability
 
-The default branch (main) of this repo is for the [Planet SDK for
-Python](https://github.com/planetlabs/planet-client-python/projects/2),
-a complete rewrite and upgrade from the original [Planet Python
-Client](https://developers.planet.com/docs/pythonclient/). If you
-are looking for the source code to that library see the
-[v1](https://github.com/planetlabs/planet-client-python/tree/v1) branch.
+The SDK follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and therefore only major releases should break compatibility. Minor versions may include new functionality and patch versions address bugs or trivial changes (like documentation).
 
-The Planet SDK for Python is in 'pre-release' stages, working towards a solid
-beta release in December. Upcoming milestones are tracked in the [Planet SDK
-for Python Milestones](https://github.com/planetlabs/planet-client-python/milestones).
+If depending upon official packages from PyPI, a developer should feel comfortable specifying `planet == 2.*` unless depending on a specific feature introduced at a minor version, in which case `planet == 2.x.*` (where x is the minor version of the new feature) should suffice.
+
+The default branch is always `main` and should be considered in-development but with tests and other build steps succeeding.
 
 ## Installation and Quick Start
 

--- a/README.md
+++ b/README.md
@@ -16,36 +16,43 @@ Version 2.0 includes support for the core workflows of the following APIs:
 
 After the initial 2.0 release there will be additional work to support the
 remaining Planet APIs: [basemaps](https://developers.planet.com/docs/basemaps/),
-[tasking](https://developers.planet.com/docs/tasking/)) and
+[tasking](https://developers.planet.com/docs/tasking/) and
 [analytics](https://developers.planet.com/docs/analytics/).
 
 ## Versions and Stability
 
-The SDK follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and therefore only major releases should break compatibility. Minor versions may include new functionality and patch versions address bugs or trivial changes (like documentation).
+The default branch (main) of this repo is for the [Planet SDK for
+Python](https://github.com/planetlabs/planet-client-python/projects/2),
+a complete rewrite and upgrade from the original [Planet Python
+Client](https://developers.planet.com/docs/pythonclient/). If you
+are looking for the source code to that library see the
+[v1](https://github.com/planetlabs/planet-client-python/tree/v1) branch.
 
-If depending upon official packages from PyPI, a developer should feel comfortable specifying `planet == 2.*` unless depending on a specific feature introduced at a minor version, in which case `planet == 2.x.*` (where x is the minor version of the new feature) should suffice.
-
-The default branch is always `main` and should be considered in-development but with tests and other build steps succeeding.
+The Planet SDK for Python is in 'pre-release' stages, working towards a solid
+beta release in December. Upcoming milestones are tracked in the [Planet SDK
+for Python Milestones](https://github.com/planetlabs/planet-client-python/milestones).
 
 ## Installation and Quick Start
 
-The main installation path and first steps are found in the
-[Quick Start Guide](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/get-started/quick-start-guide/)
-of the documentation.
-
-### Installing from source
-
-This option enables you to get all the latest changes, but things might also be a bit less stable.
-To install you must [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
-the [planet-client-python](https://github.com/planetlabs/planet-client-python) repository
-to your local computer. After you have the repo local just navigate to the root
-directory, where this readme lives.
-
-Then you can install locally with pip:
+The Planet SDK for Python is [hosted on PyPI](https://pypi.org/project/planet/) and can simply be installed via:
 
 ```console
-$ pip install .
+pip install planet
 ```
+
+To install from source, first clone this repository, then navigate to the root directory (where `setup.py` lives) and run:
+
+```console
+pip install .
+```
+
+Note that the above commands will install the Planet SDK into the global system Python unless a virtual environment is enabled.  For more information on configuring a virtual environment from system Python, see the official Python [venv](https://docs.python.org/3/library/venv.html) documentation.  For users who are running multiple versions of Python via [pyenv](https://github.com/pyenv/pyenv), see the [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) extension documentation.
+
+Detailed installation instructions for the Planet SDK can be found in the [Quick Start Guide](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/get-started/quick-start-guide/) of the documentation.
+
+## Contributing and Development
+
+To contribute or develop with this library, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Documentation
 
@@ -58,8 +65,3 @@ read from source in the [docs](/docs) directory.
 
 Planet's APIs require an account for use. To get started you need to
 [Get a Planet Account](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/get-started/get-your-planet-account/).
-
-## Development
-
-To contribute or develop with this library, see
-[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/cli/cli-subscriptions.md
+++ b/docs/cli/cli-subscriptions.md
@@ -171,8 +171,7 @@ You can also filter by status:
 planet subscriptions results SUBSCRIPTION_ID --status processing
 ```
 
-The available statuses are `created`, `queued`, `processing`, `failed`, and `success`. Note it’s quite useful
-to use `jq` to help filter out results as well.
+See the Subscriptions API documentation for the [official list of available statuses](https://developers.planet.com/docs/subscriptions/#subscription-status).
 
 #### Results as comma-separated values (CSV)
 

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,9 @@ setup(
         'Topic :: Utilities'
     ],
     keywords='planet api sdk client',
-    author='Jennifer Reiber Kyle',
-    maintainer='Planet Dev Rel Team',
-    maintainer_email='developers@planet.com',
+    author='Planet',
+    maintainer='Planet',
+    maintainer_email='python-sdk-contributors@planet.com',
     url='https://github.com/planetlabs/planet-client-python',
     license='Apache 2.0',
     packages=find_packages(exclude=['examples', 'tests']),


### PR DESCRIPTION
This MR includes updates to several different parts of the documentation:
- Updated the Installation/Quick Start README docs to include installation instructions from PyPI, and some links to docs about configuring virtual environments in Python.  Also updated the section on versions and stability in the README.
- Added clearer link to CONTRIBUTING.md from README.md.
- Updated CONTRIBUTING.md to align with changes to branch naming conventions described in https://github.com/planetlabs/planet-client-python/pull/1061.
- Updated Subscriptions CLI documentation to point to official Subscriptions API statuses documentation (https://github.com/planetlabs/planet-client-python/issues/1001).