### PR TITLE
Document and clean up subscriptions client limit behaviour

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -216,7 +216,8 @@ async def get_subscription_cmd(ctx, subscription_id, pretty):
               'csv_flag',
               is_flag=True,
               default=False,
-              help="Get subscription results as comma-separated fields.")
+              help="Get subscription results as comma-separated fields. When "
+              "this flag is included, --limit is ignored")
 @limit
 # TODO: the following 3 options.
 # –created: timestamp instant or range.
@@ -254,8 +255,7 @@ async def list_subscription_results_cmd(ctx,
     async with subscriptions_client(ctx) as client:
         if csv_flag:
             async for result in client.get_results_csv(subscription_id,
-                                                       status=status,
-                                                       limit=limit):
+                                                       status=status):
                 click.echo(result)
         else:
             async for result in client.get_results(subscription_id,

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -74,7 +74,7 @@ class SubscriptionsClient:
                 set, filter out subscriptions with status not in this
                 set.
             limit (int): limit the number of subscriptions in the
-                results.
+                results. When set to 0, no maximum is applied.
             TODO: user_id
 
         Yields:
@@ -270,7 +270,7 @@ class SubscriptionsClient:
             status (Set[str]): pass result with status in this set,
                 filter out results with status not in this set.
             limit (int): limit the number of subscriptions in the
-                results.
+                results. When set to 0, no maximum is applied.
             TODO: created, updated, completed, user_id
 
         Yields:
@@ -310,8 +310,7 @@ class SubscriptionsClient:
                                           "queued",
                                           "processing",
                                           "failed",
-                                          "success"]]] = None,
-        limit: int = 100,
+                                          "success"]]] = None
     ) -> AsyncIterator[str]:
         """Iterate over rows of results CSV for a Subscription.
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #1069 
Closes #1070 


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Removed the unused `limit` parameter of `SubscriptionsClient.get_results_csv`

Not intended for changelog:

1. Added documentation of the limit=0 behaviour to other SubscriptionsClient methods where this is still used(`list_subscriptions`, `get_results`)


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them
