### PR TITLE
Hotfix: Pin httpx to v0.27.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Planet SDK for Python"
 dependencies = [
     "click>=8.0",
     "geojson",
-    "httpx>=0.23.0",
+    "httpx==0.27.2",
     "jsonschema",
     "pyjwt>=2.1",
     "tqdm>=4.56",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Planet SDK for Python"
 dependencies = [
     "click>=8.0",
     "geojson",
-    "httpx==0.27.2",
+    "httpx<0.28.0",
     "jsonschema",
     "pyjwt>=2.1",
     "tqdm>=4.56",

--- a/tests/integration/test_data_api.py
+++ b/tests/integration/test_data_api.py
@@ -168,8 +168,8 @@ async def test_search_geometry(geom_fixture,
     cl = DataClient(session, base_url=TEST_URL)
     geom = request.getfixturevalue(geom_fixture)
     items_list = [
-        i async for i in cl.search(
-            ['PSScene'], name='quick_search', geometry=geom)
+        i async for i in cl.search(['PSScene'], name='quick_search',
+                                   geometry=geom)
     ]
     # check that request is correct
     expected_request = {
@@ -274,8 +274,8 @@ async def test_search_sort(item_descriptions,
 
     # run through the iterator to actually initiate the call
     [
-        i async for i in cl.search(
-            ['PSScene'], search_filter=search_filter, sort=sort)
+        i async for i in cl.search(['PSScene'], search_filter=search_filter,
+                                   sort=sort)
     ]
 
 
@@ -297,8 +297,8 @@ async def test_search_limit(item_descriptions,
 
     cl = DataClient(session, base_url=TEST_URL)
     items_list = [
-        i async for i in cl.search(
-            ['PSScene'], search_filter=search_filter, limit=2)
+        i async for i in cl.search(['PSScene'], search_filter=search_filter,
+                                   limit=2)
     ]
 
     # check only the first two results were returned


### PR DESCRIPTION
The most recent release of httpx v0.28.0 breaks all of our test pipelines across new and existing PRs with `AllMockedAssertionError`. 

This PR pins httpx to v0.27.2, which is the version that immediately precedes v0.28.0.  We should keep httpx pinned to v0.27.2 until the issue is resolved to ensure that our CI pipelines are not blocked.

respx ticket - https://github.com/lundberg/respx/issues/277
possible fix - https://github.com/lundberg/respx/pull/278

I am subscribed to both of the above respx ticket and PR, and will plan to follow up and configure httpx to pick up the latest version after the issue is resolved.