### PR TITLE
Reorder list kwargs to maintain consistency between releases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
-2.12.0 (2024-12-06)
-- Add parameters to the subscriptions list command: --created, --start-time,
+2.12.0 (2024-12-09)
+- Add parameters to the subscriptions list command: --source-type, --created, --start-time,
   --end-time, --updated, --hosting, --name, --name-contains, and --sort-by.
 - Add parameters to the orders list command: --source-type, --name,
   --name-contains, --created-on, --last-modified, --hosting, and --sort-by.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
   --end-time, --updated, --hosting, --name, --name-contains, and --sort-by.
 - Add parameters to the orders list command: --source-type, --name,
   --name-contains, --created-on, --last-modified, --hosting, and --sort-by.
+- Remove the unused limit parameter of SubscriptionsClient.get_results_csv
 
 2.11.0 (2024-10-21)
 

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -462,16 +462,17 @@ class OrdersClient:
 
         return current_state
 
-    async def list_orders(self,
-                          state: Optional[str] = None,
-                          source_type: Optional[str] = None,
-                          name: Optional[str] = None,
-                          name__contains: Optional[str] = None,
-                          created_on: Optional[str] = None,
-                          last_modified: Optional[str] = None,
-                          hosting: Optional[bool] = None,
-                          sort_by: Optional[str] = None,
-                          limit: int = 100) -> AsyncIterator[dict]:
+    async def list_orders(
+            self,
+            state: Optional[str] = None,
+            limit: int = 100,
+            source_type: Optional[str] = None,
+            name: Optional[str] = None,
+            name__contains: Optional[str] = None,
+            created_on: Optional[str] = None,
+            last_modified: Optional[str] = None,
+            hosting: Optional[bool] = None,
+            sort_by: Optional[str] = None) -> AsyncIterator[dict]:
         """Iterate over the list of stored orders.
 
         By default, order descriptions are sorted by creation date with the last created

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -59,18 +59,19 @@ class SubscriptionsClient:
         if self._base_url.endswith('/'):
             self._base_url = self._base_url[:-1]
 
-    async def list_subscriptions(self,
-                                 created: Optional[str] = None,
-                                 end_time: Optional[str] = None,
-                                 hosting: Optional[bool] = None,
-                                 name__contains: Optional[str] = None,
-                                 name: Optional[str] = None,
-                                 source_type: Optional[str] = None,
-                                 start_time: Optional[str] = None,
-                                 status: Optional[Sequence[str]] = None,
-                                 sort_by: Optional[str] = None,
-                                 updated: Optional[str] = None,
-                                 limit: int = 100) -> AsyncIterator[dict]:
+    async def list_subscriptions(
+            self,
+            status: Optional[Sequence[str]] = None,
+            limit: int = 100,
+            created: Optional[str] = None,
+            end_time: Optional[str] = None,
+            hosting: Optional[bool] = None,
+            name__contains: Optional[str] = None,
+            name: Optional[str] = None,
+            source_type: Optional[str] = None,
+            start_time: Optional[str] = None,
+            sort_by: Optional[str] = None,
+            updated: Optional[str] = None) -> AsyncIterator[dict]:
         """Iterate over list of account subscriptions with optional filtering and sorting.
 
         Note:


### PR DESCRIPTION
**Related Issue(s):**

[DND-1610](https://hello.planet.com/jira/browse/DND-1610)

**Proposed Changes:**

Not intended for changelog:

1. Updates the kwarg order for the orders & subscriptions list method so that the order of existing kwargs (prior to the latest release) remain the same.
2. Preps CHANGES.txt for release 2.12.0

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**@mentions for Notifications:**
@ischneider @asonnenschein 