### PR TITLE
make call_sync internal API

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -98,9 +98,9 @@ class DataClient:
         if self._base_url.endswith('/'):
             self._base_url = self._base_url[:-1]
 
-    def call_sync(self, f: Awaitable[T]) -> T:
+    def _call_sync(self, f: Awaitable[T]) -> T:
         """block on an async function call, using the call_sync method of the session"""
-        return self._session.call_sync(f)
+        return self._session._call_sync(f)
 
     @staticmethod
     def _check_search_id(sid):

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -99,9 +99,9 @@ class OrdersClient:
         if self._base_url.endswith('/'):
             self._base_url = self._base_url[:-1]
 
-    def call_sync(self, f: Awaitable[T]) -> T:
+    def _call_sync(self, f: Awaitable[T]) -> T:
         """block on an async function call, using the call_sync method of the session"""
-        return self._session.call_sync(f)
+        return self._session._call_sync(f)
 
     @staticmethod
     def _check_order_id(oid):

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -61,9 +61,9 @@ class SubscriptionsClient:
         if self._base_url.endswith('/'):
             self._base_url = self._base_url[:-1]
 
-    def call_sync(self, f: Awaitable[T]) -> T:
+    def _call_sync(self, f: Awaitable[T]) -> T:
         """block on an async function call, using the call_sync method of the session"""
-        return self._session.call_sync(f)
+        return self._session._call_sync(f)
 
     async def list_subscriptions(
             self,

--- a/planet/http.py
+++ b/planet/http.py
@@ -286,7 +286,7 @@ class Session(BaseSession):
                                              daemon=True)
         self._loop_thread.start()
 
-    def call_sync(self, f: Awaitable[T]) -> T:
+    def _call_sync(self, f: Awaitable[T]) -> T:
         return asyncio.run_coroutine_threadsafe(f, self._loop).result()
 
     @classmethod

--- a/planet/sync/data.py
+++ b/planet/sync/data.py
@@ -82,7 +82,7 @@ class DataAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass
 
@@ -125,7 +125,7 @@ class DataAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.create_search(item_types,
                                        search_filter,
                                        name,
@@ -152,7 +152,7 @@ class DataAPI:
         Returns:
             Description of the saved search.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.update_search(search_id,
                                        item_types,
                                        search_filter,
@@ -184,7 +184,7 @@ class DataAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass
 
@@ -197,7 +197,7 @@ class DataAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.delete_search(search_id))
+        return self._client._call_sync(self._client.delete_search(search_id))
 
     def get_search(self, search_id: str) -> Dict:
         """Get a saved search by id.
@@ -211,7 +211,7 @@ class DataAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.get_search(search_id))
+        return self._client._call_sync(self._client.get_search(search_id))
 
     def run_search(self,
                    search_id: str,
@@ -243,7 +243,7 @@ class DataAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass
 
@@ -266,7 +266,7 @@ class DataAPI:
             planet.exceptions.APIError: On API error.
             planet.exceptions.ClientError: If interval is not valid.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.get_stats(item_types, search_filter, interval))
 
     def list_item_assets(self, item_type_id: str,
@@ -288,7 +288,7 @@ class DataAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.list_item_assets(item_type_id, item_id))
 
     def get_asset(self, item_type_id: str, item_id: str,
@@ -308,7 +308,7 @@ class DataAPI:
             planet.exceptions.ClientError: If asset type identifier is not
             valid.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.get_asset(item_type_id, item_id, asset_type_id))
 
     def activate_asset(self, asset: Dict[str, Any]):
@@ -322,7 +322,7 @@ class DataAPI:
             planet.exceptions.ClientError: If asset description is not
             valid.
         """
-        return self._client.call_sync(self._client.activate_asset(asset))
+        return self._client._call_sync(self._client.activate_asset(asset))
 
     def wait_asset(
             self,
@@ -352,7 +352,7 @@ class DataAPI:
                 not available or if the maximum number of attempts is reached
                 before the asset is active.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.wait_asset(asset, delay, max_attempts, callback))
 
     def download_asset(self,
@@ -385,7 +385,7 @@ class DataAPI:
             planet.exceptions.ClientError: If asset is not active or asset
             description is not valid.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.download_asset(asset,
                                         filename,
                                         directory,

--- a/planet/sync/orders.py
+++ b/planet/sync/orders.py
@@ -63,7 +63,7 @@ class OrdersAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.create_order(request))
+        return self._client._call_sync(self._client.create_order(request))
 
     def get_order(self, order_id: str) -> Dict:
         """Get order details by Order ID.
@@ -78,7 +78,7 @@ class OrdersAPI:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.get_order(order_id))
+        return self._client._call_sync(self._client.get_order(order_id))
 
     def cancel_order(self, order_id: str) -> Dict[str, Any]:
         """Cancel a queued order.
@@ -93,7 +93,7 @@ class OrdersAPI:
             planet.exceptions.ClientError: If order_id is not a valid UUID.
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.cancel_order(order_id))
+        return self._client._call_sync(self._client.cancel_order(order_id))
 
     def cancel_orders(self,
                       order_ids: Optional[List[str]] = None) -> Dict[str, Any]:
@@ -111,7 +111,7 @@ class OrdersAPI:
                 valid UUID.
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.cancel_orders(order_ids))
+        return self._client._call_sync(self._client.cancel_orders(order_ids))
 
     def aggregated_order_stats(self) -> Dict[str, Any]:
         """Get aggregated counts of active orders.
@@ -122,7 +122,7 @@ class OrdersAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(self._client.aggregated_order_stats())
+        return self._client._call_sync(self._client.aggregated_order_stats())
 
     def download_asset(self,
                        location: str,
@@ -146,7 +146,7 @@ class OrdersAPI:
         Raises:
             planet.exceptions.APIError: On API error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.download_asset(location,
                                         filename,
                                         directory,
@@ -175,7 +175,7 @@ class OrdersAPI:
             planet.exceptions.ClientError: If the order is not in a final
                 state.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.download_order(order_id,
                                         directory,
                                         overwrite,
@@ -249,7 +249,7 @@ class OrdersAPI:
                 if the maximum number of attempts is reached before the
                 specified state or a final state is reached.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.wait(order_id, state, delay, max_attempts, callback))
 
     def list_orders(self,
@@ -319,6 +319,6 @@ class OrdersAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass

--- a/planet/sync/subscriptions.py
+++ b/planet/sync/subscriptions.py
@@ -113,7 +113,7 @@ class SubscriptionsAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass
 
@@ -130,7 +130,7 @@ class SubscriptionsAPI:
             APIError: on an API server error.
             ClientError: on a client error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.create_subscription(request))
 
     def cancel_subscription(self, subscription_id: str) -> None:
@@ -146,7 +146,7 @@ class SubscriptionsAPI:
             APIError: on an API server error.
             ClientError: on a client error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.cancel_subscription(subscription_id))
 
     def update_subscription(self, subscription_id: str, request: dict) -> dict:
@@ -164,7 +164,7 @@ class SubscriptionsAPI:
             APIError: on an API server error.
             ClientError: on a client error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.update_subscription(subscription_id, request))
 
     def patch_subscription(self, subscription_id: str,
@@ -183,7 +183,7 @@ class SubscriptionsAPI:
             APIError: on an API server error.
             ClientError: on a client error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.patch_subscription(subscription_id, request))
 
     def get_subscription(self, subscription_id: str) -> Dict[str, Any]:
@@ -199,7 +199,7 @@ class SubscriptionsAPI:
             APIError: on an API server error.
             ClientError: on a client error.
         """
-        return self._client.call_sync(
+        return self._client._call_sync(
             self._client.get_subscription(subscription_id))
 
     def get_results(
@@ -238,7 +238,7 @@ class SubscriptionsAPI:
 
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass
 
@@ -274,6 +274,6 @@ class SubscriptionsAPI:
         # https://github.com/hynek/stamina.
         try:
             while True:
-                yield self._client.call_sync(results.__anext__())
+                yield self._client._call_sync(results.__anext__())
         except StopAsyncIteration:
             pass


### PR DESCRIPTION
**Diff of User Interface**

This is follow up to "unreleased" API, so should not be considered breaking (yet!)

Old behavior: `call_async` was "public"

New behavior: `_call_async` is "internal"

Rationale: while it might be a 3rd party needs a sync/async API, this feels like it would likely cause more potential questions, etc. If a 3rd party wants this, they can still use it and it's unlikely to change frequently/drastically...

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [ ] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them
