### PR TITLE
add planet.sync to packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [options]
-packages = planet, planet.cli, planet.clients, planet.data
+packages = planet, planet.cli, planet.clients, planet.data, planet.sync
 
 [options.packages.find]
 exclude = examples, tests


### PR DESCRIPTION
Add the new planet.sync module to packages in setup.cfg so it is included in builds.