### PR TITLE
update user agent for sync client

### DIFF
--- a/planet/sync/client.py
+++ b/planet/sync/client.py
@@ -47,7 +47,7 @@ class Planet:
             "X-Planet-App":
             SYNC_CLIENT_AGENT,
             "User-Agent":
-            "planet-client-python/" + __version__
+            "planet-client-python/sync/" + __version__
         })
 
         self.data = DataAPI(self._session)

--- a/planet/sync/client.py
+++ b/planet/sync/client.py
@@ -47,7 +47,7 @@ class Planet:
             "X-Planet-App":
             SYNC_CLIENT_X_PLANET_APP,
             "User-Agent":
-            "planet-client-python/sync/" + __version__
+            f"planet-client-python/{__version__}/sync"
         })
 
         self.data = DataAPI(self._session)

--- a/planet/sync/client.py
+++ b/planet/sync/client.py
@@ -5,7 +5,7 @@ from .subscriptions import SubscriptionsAPI
 from planet.http import Session
 from planet.__version__ import __version__
 
-SYNC_CLIENT_AGENT = "python-sdk-sync"
+SYNC_CLIENT_X_PLANET_APP = "python-sdk-sync"
 
 
 class Planet:
@@ -45,7 +45,7 @@ class Planet:
         self._session = session or Session()
         self._session._client.headers.update({
             "X-Planet-App":
-            SYNC_CLIENT_AGENT,
+            SYNC_CLIENT_X_PLANET_APP,
             "User-Agent":
             "planet-client-python/sync/" + __version__
         })

--- a/planet/sync/client.py
+++ b/planet/sync/client.py
@@ -3,6 +3,7 @@ from .data import DataAPI
 from .orders import OrdersAPI
 from .subscriptions import SubscriptionsAPI
 from planet.http import Session
+from planet.__version__ import __version__
 
 SYNC_CLIENT_AGENT = "python-sdk-sync"
 
@@ -42,8 +43,12 @@ class Planet:
 
     def __init__(self, session: Optional[Session] = None) -> None:
         self._session = session or Session()
-        self._session._client.headers.update(
-            {"X-Planet-App": SYNC_CLIENT_AGENT})
+        self._session._client.headers.update({
+            "X-Planet-App":
+            SYNC_CLIENT_AGENT,
+            "User-Agent":
+            "planet-client-python/" + __version__
+        })
 
         self.data = DataAPI(self._session)
         self.orders = OrdersAPI(self._session)


### PR DESCRIPTION
Update the Session user agent when using the sync client.

Note:
The user agent and X-Planet-App values are different in the async client. They're different here too, but I kept them roughly consistent with the async client.

existing async X-Planet-App: `python-sdk`
sync client X-Planet-App: `python-sdk-sync`

async User-Agent: `planet-client-python/<version>`
sync User-Agent: `planet-client-python/<version>/sync`