### PR TITLE
Add group_by to composite tool function (#1053)

### DIFF
--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -373,10 +373,27 @@ def clip_tool(aoi: dict) -> dict:
     return _tool('clip', {'aoi': geom})
 
 
-def composite_tool() -> dict:
-    """Create the API spec representation of a composite tool.
+def composite_tool(group_by: Optional[str] = None) -> dict:
     """
-    return _tool('composite', {})
+    Create the API spec representation of a composite tool.
+
+    Parameters:
+        group_by: (Optional) Defines how items are grouped to create one or more composites.
+                  Supported values are:
+                  - "order": All input items are used to create a single composite output.
+                  - "strip_id": Input items are grouped by their strip_id to create multiple composites.
+
+    Returns:
+        dict: A dictionary representing the composite tool configuration.
+    """
+    if group_by and group_by not in ["order", "strip_id"]:
+        raise ValueError(f"Invalid group_by value: {group_by}. Must be 'order' or 'strip_id'.")
+    
+    parameters = {}
+    if group_by:
+        parameters['group_by'] = group_by
+
+    return _tool('composite', parameters)
 
 
 def coregister_tool(anchor_item: str) -> dict:

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -387,7 +387,9 @@ def composite_tool(group_by: Optional[str] = None) -> dict:
         dict: A dictionary representing the composite tool configuration.
     """
     if group_by and group_by not in ["order", "strip_id"]:
-        raise ValueError(f"Invalid group_by value: {group_by}. Must be 'order' or 'strip_id'.")
+        raise ValueError(
+            f"Invalid group_by value: {group_by}. Must be 'order' or 'strip_id'."
+        )
 
     parameters = {}
     if group_by:

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -388,7 +388,7 @@ def composite_tool(group_by: Optional[str] = None) -> dict:
     """
     if group_by and group_by not in ["order", "strip_id"]:
         raise ValueError(f"Invalid group_by value: {group_by}. Must be 'order' or 'strip_id'.")
-    
+
     parameters = {}
     if group_by:
         parameters['group_by'] = group_by

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -387,7 +387,7 @@ def composite_tool(group_by: Optional[str] = None) -> dict:
         dict: A dictionary representing the composite tool configuration.
     """
     if group_by and group_by not in ["order", "strip_id"]:
-        raise ValueError(
+        raise ClientError(
             f"Invalid group_by value: {group_by}. Must be 'order' or 'strip_id'."
         )
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #1053

**Proposed Changes:**

For inclusion in changelog (if applicable):
1. Added `group_by` parameter to the `composite_tool` function to define grouping behavior.

Not intended for changelog:
1. Improved validation for `group_by` parameter values.

**Diff of User Interface**

Old behavior:
- No `group_by` option available for `composite_tool`.

New behavior:
- `composite_tool` now supports `group_by` with the following options:
  - `"order"`: Creates a single composite output.
  - `"strip_id"`: Creates multiple composites grouped by `strip_id`.

**PR Checklist:**

- [x] This PR is as small and focused as possible.
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes.
- [x] This PR does not break any examples or I have updated them.

**(Optional) @mentions for Notifications:**
