### PR TITLE
Upgrade httpx to >= 0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
     "pytest==8.3.3",
     "anyio",
     "pytest-cov",
-    "respx>=0.20",
+    "respx>=0.22.0",
 ]
 lint = [
     "flake8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Planet SDK for Python"
 dependencies = [
     "click>=8.0",
     "geojson",
-    "httpx<0.28.0",
+    "httpx>=0.28.0",
     "jsonschema",
     "pyjwt>=2.1",
     "tqdm>=4.56",

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -876,13 +876,13 @@ def test_search_get(invoke, search_id, search_result):
 @respx.mock
 def test_search_get_id_not_found(invoke, search_id):
     get_url = f'{TEST_SEARCHES_URL}/{search_id}'
-    error_json = {"message": "Error message"}
+    error_json = {"message":"Error message"}
     mock_resp = httpx.Response(404, json=error_json)
     respx.get(get_url).return_value = mock_resp
 
     result = invoke(['search-get', search_id])
     assert result.exception
-    assert 'Error: {"message": "Error message"}\n' == result.output
+    assert 'Error: {"message":"Error message"}\n' == result.output
 
 
 @respx.mock

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -876,7 +876,7 @@ def test_search_get(invoke, search_id, search_result):
 @respx.mock
 def test_search_get_id_not_found(invoke, search_id):
     get_url = f'{TEST_SEARCHES_URL}/{search_id}'
-    error_json = {"message":"Error message"}
+    error_json = {"message": "Error message"}
     mock_resp = httpx.Response(404, json=error_json)
     respx.get(get_url).return_value = mock_resp
 

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -307,8 +307,8 @@ def mock_download_response(oid, order_description):
                                     })
         respx.get(dl_url2).return_value = mock_resp2
 
-        m1_bytes = b'{"key": "value"}'
-        m2_bytes = b'{"key2": "value2"}'
+        m1_bytes = b'{"key":"value"}'
+        m2_bytes = b'{"key2":"value2"}'
         manifest_data = {
             "name": "",
             "files": [

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -194,7 +194,7 @@ def test_cli_orders_get_id_not_found(invoke, oid):
 
     result = invoke(['get', oid])
     assert result.exit_code == 1
-    assert 'Error: {"message": "Error message"}\n' == result.output
+    assert 'Error: {"message":"Error message"}\n' == result.output
 
 
 # TODO: add tests for "cancel --pretty" (gh-491).
@@ -219,7 +219,7 @@ def test_cli_orders_cancel_id_not_found(invoke, oid):
 
     result = invoke(['cancel', oid])
     assert result.exit_code == 1
-    assert 'Error: {"message": "Error message"}\n' == result.output
+    assert 'Error: {"message":"Error message"}\n' == result.output
 
 
 # TODO: add tests for "wait --state" (gh-492) and "wait --pretty" (gh-491).


### PR DESCRIPTION
This MR upgrades the `httpx` dependency version to >= 0.28.0, which was pinned to < 0.28.0 in https://github.com/planetlabs/planet-client-python/pull/1080 to work around a broken `respx` dependency which is now resolved with `respx` version 0.22.0 (https://github.com/planetlabs/planet-client-python/pull/1080#issuecomment-2555899485).
