### PR TITLE
add str to geometry type hints

### DIFF
--- a/planet/clients/data.py
+++ b/planet/clients/data.py
@@ -17,7 +17,7 @@ import hashlib
 import logging
 from pathlib import Path
 import time
-from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, TypeVar
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, TypeVar, Union
 import uuid
 
 from ..data_filter import empty_filter
@@ -117,13 +117,15 @@ class DataClient:
     def _item_url(self, item_type, item_id):
         return f'{self._base_url}/item-types/{item_type}/items/{item_id}'
 
-    async def search(self,
-                     item_types: List[str],
-                     search_filter: Optional[dict] = None,
-                     name: Optional[str] = None,
-                     sort: Optional[str] = None,
-                     limit: int = 100,
-                     geometry: Optional[dict] = None) -> AsyncIterator[dict]:
+    async def search(
+            self,
+            item_types: List[str],
+            search_filter: Optional[dict] = None,
+            name: Optional[str] = None,
+            sort: Optional[str] = None,
+            limit: int = 100,
+            geometry: Optional[Union[dict,
+                                     str]] = None) -> AsyncIterator[dict]:
         """Iterate over results from a quick search.
 
         Quick searches are saved for a short period of time (~month). The
@@ -185,7 +187,7 @@ class DataClient:
         search_filter: dict,
         name: str,
         enable_email: bool = False,
-        geometry: Optional[dict] = None,
+        geometry: Optional[Union[dict, str]] = None,
     ) -> dict:
         """Create a new saved structured item search.
 
@@ -236,13 +238,14 @@ class DataClient:
                                                json=request)
         return response.json()
 
-    async def update_search(self,
-                            search_id: str,
-                            item_types: List[str],
-                            search_filter: dict,
-                            name: str,
-                            enable_email: bool = False,
-                            geometry: Optional[dict] = None) -> dict:
+    async def update_search(
+            self,
+            search_id: str,
+            item_types: List[str],
+            search_filter: dict,
+            name: str,
+            enable_email: bool = False,
+            geometry: Optional[Union[dict, str]] = None) -> dict:
         """Update an existing saved search.
 
         Parameters:

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -165,7 +165,7 @@ def build_request(name: str,
 def catalog_source(
     item_types: List[str],
     asset_types: List[str],
-    geometry: dict,
+    geometry: Union[dict, str],
     start_time: datetime,
     filter: Optional[Mapping] = None,
     end_time: Optional[datetime] = None,
@@ -188,7 +188,8 @@ def catalog_source(
             deliver if all specified asset types are published for that
             item.
         geometry: The area of interest of the subscription that will be
-            used to determine matches.
+            used to determine matches. Can be either a geojson-like dict
+            or a Features API feature reference (string)
         start_time: The start time of the subscription. This time can be
             in the past or future.
         filter: The filter criteria based on item-level metadata.
@@ -280,7 +281,7 @@ def catalog_source(
 def planetary_variable_source(
     var_type: str,
     var_id: str,
-    geometry: dict,
+    geometry: Union[dict, str],
     start_time: datetime,
     end_time: Optional[datetime] = None,
 ) -> dict:
@@ -302,7 +303,8 @@ def planetary_variable_source(
         var_id: A Planetary Variable ID. See documenation for all
             available IDs.
         geometry: The area of interest of the subscription that will be
-            used to determine matches.
+            used to determine matches. May be a geojson-like dict or a 
+            Features API geometry reference (string)
         start_time: The start time of the subscription. This time can be
             in the past or future.
         end_time: The end time of the subscription. This time can be in

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -303,7 +303,7 @@ def planetary_variable_source(
         var_id: A Planetary Variable ID. See documenation for all
             available IDs.
         geometry: The area of interest of the subscription that will be
-            used to determine matches. May be a geojson-like dict or a 
+            used to determine matches. May be a geojson-like dict or a
             Features API geometry reference (string)
         start_time: The start time of the subscription. This time can be
             in the past or future.

--- a/planet/sync/data.py
+++ b/planet/sync/data.py
@@ -13,7 +13,7 @@
 # the License.
 """Functionality for interacting with the data api"""
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 from ..http import Session
 
@@ -47,7 +47,7 @@ class DataAPI:
         name: Optional[str] = None,
         sort: Optional[str] = None,
         limit: int = 100,
-        geometry: Optional[Dict] = None,
+        geometry: Optional[Union[Dict, str]] = None,
     ) -> Iterator[Dict]:
         """
         Search for items
@@ -92,7 +92,7 @@ class DataAPI:
         search_filter: Dict,
         name: str,
         enable_email: bool = False,
-        geometry: Optional[Dict] = None,
+        geometry: Optional[Union[Dict, str]] = None,
     ) -> Dict:
         """Create a new saved structured item search.
 
@@ -132,13 +132,14 @@ class DataAPI:
                                        enable_email,
                                        geometry))
 
-    def update_search(self,
-                      search_id: str,
-                      item_types: List[str],
-                      search_filter: Dict[str, Any],
-                      name: str,
-                      enable_email: bool = False,
-                      geometry: Optional[dict] = None) -> Dict[str, Any]:
+    def update_search(
+            self,
+            search_id: str,
+            item_types: List[str],
+            search_filter: Dict[str, Any],
+            name: str,
+            enable_email: bool = False,
+            geometry: Optional[Union[dict, str]] = None) -> Dict[str, Any]:
         """Update an existing saved search.
 
         Parameters:


### PR DESCRIPTION
Add str to `geometry` arg type hints to prevent type errors when providing string feature references.