### PR TITLE
add "create configuration" support for SH hosting in orders and subs

### DIFF
--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -239,8 +239,19 @@ planet orders request \
     --collection_id ba8f7274-aacc-425e-8a38-e21517bfbeff
 ```
 
+```
+planet orders request \
+    --item-type PSScene \
+    --bundle analytic_sr_udm2 \
+    --name 'My First Order' \
+    20220605_124027_64_242b \
+    --hosting sentinel_hub \
+    --create_configuration
+```
+
 - The --hosting option is optional and currently supports sentinel_hub as its only value.
 - The --collection_id is also optional. If you decide to use this, ensure that the order request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection_id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
+- The --create_configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection_id.
 
 For more information on Sentinel Hub hosting, see the [Orders API documentation](https://developers.planet.com/apis/orders/delivery/#delivery-to-sentinel-hub-collection) and the [Linking Planet User to Sentinel Hub User
 ](https://support.planet.com/hc/en-us/articles/16550358397469-Linking-Planet-User-to-Sentinel-Hub-User) support post.
@@ -307,12 +318,18 @@ if you run that command again it will create a second order).
 
 #### Sentinel Hub Hosting
 
-For convenience, `planet orders create` accepts the same `--hosting` and `--collection_id` options that [`planet orders request`](#sentinel-hub-hosting) does.
+For convenience, `planet orders create` accepts the same `--hosting`, `--collection_id`, and `--create_configuration` options that [`planet orders request`](#sentinel-hub-hosting) does.
 
 ```sh
 planet orders create request-1.json \
     --hosting sentinel_hub \
     --collection_id ba8f7274-aacc-425e-8a38-e21517bfbeff
+```
+
+```sh
+planet orders create request-1.json \
+    --hosting sentinel_hub \
+    --create_configuration
 ```
 
 ### Create Request and Order in One Call

--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -236,7 +236,7 @@ planet orders request \
     --name 'My First Order' \
     20220605_124027_64_242b \
     --hosting sentinel_hub \
-    --collection_id ba8f7274-aacc-425e-8a38-e21517bfbeff
+    --collection-id ba8f7274-aacc-425e-8a38-e21517bfbeff
 ```
 
 ```
@@ -246,12 +246,12 @@ planet orders request \
     --name 'My First Order' \
     20220605_124027_64_242b \
     --hosting sentinel_hub \
-    --create_configuration
+    --create-configuration
 ```
 
 - The --hosting option is optional and currently supports sentinel_hub as its only value.
-- The --collection_id is also optional. If you decide to use this, ensure that the order request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection_id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
-- The --create_configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection_id.
+- The --collection-id is also optional. If you decide to use this, ensure that the order request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection-id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
+- The --create-configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection-id.
 
 For more information on Sentinel Hub hosting, see the [Orders API documentation](https://developers.planet.com/apis/orders/delivery/#delivery-to-sentinel-hub-collection) and the [Linking Planet User to Sentinel Hub User
 ](https://support.planet.com/hc/en-us/articles/16550358397469-Linking-Planet-User-to-Sentinel-Hub-User) support post.
@@ -318,18 +318,18 @@ if you run that command again it will create a second order).
 
 #### Sentinel Hub Hosting
 
-For convenience, `planet orders create` accepts the same `--hosting`, `--collection_id`, and `--create_configuration` options that [`planet orders request`](#sentinel-hub-hosting) does.
+For convenience, `planet orders create` accepts the same `--hosting`, `--collection-id`, and `--create-configuration` options that [`planet orders request`](#sentinel-hub-hosting) does.
 
 ```sh
 planet orders create request-1.json \
     --hosting sentinel_hub \
-    --collection_id ba8f7274-aacc-425e-8a38-e21517bfbeff
+    --collection-id ba8f7274-aacc-425e-8a38-e21517bfbeff
 ```
 
 ```sh
 planet orders create request-1.json \
     --hosting sentinel_hub \
-    --create_configuration
+    --create-configuration
 ```
 
 ### Create Request and Order in One Call

--- a/docs/cli/cli-subscriptions.md
+++ b/docs/cli/cli-subscriptions.md
@@ -538,10 +538,11 @@ planet subscriptions request \
 
 #### Sentinel Hub Hosting
 
-When creating a new subscription, you can include hosting options directly using the --hosting and --collection-id flags.
+When creating a new subscription, you can include hosting options directly using the --hosting, --collection-id, and --create-configuration flags.
 
 - The --hosting option is optional and currently supports sentinel_hub as its only value.
 - The --collection_id is also optional. If you decide to use this, ensure that the subscription request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection_id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
+- The --create_configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection_id.
 - You may also input --hosting as a JSON file. The file should be formatted:
 
 ```sh

--- a/docs/cli/cli-subscriptions.md
+++ b/docs/cli/cli-subscriptions.md
@@ -541,8 +541,8 @@ planet subscriptions request \
 When creating a new subscription, you can include hosting options directly using the --hosting, --collection-id, and --create-configuration flags.
 
 - The --hosting option is optional and currently supports sentinel_hub as its only value.
-- The --collection_id is also optional. If you decide to use this, ensure that the subscription request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection_id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
-- The --create_configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection_id.
+- The --collection-id is also optional. If you decide to use this, ensure that the subscription request and the collection have matching bands. If you're unsure, allow the system to create a new collection for you by omitting the --collection-id option. This will ensure the newly set-up collection is configured correctly, and you can subsequently add items to this collection as needed.
+- The --create_configuration option will create a new [layer configuration](https://apps.sentinel-hub.com/dashboard/#/configurations) in Sentinel Hub on your behalf. This option cannot be used with --collection-id.
 - You may also input --hosting as a JSON file. The file should be formatted:
 
 ```sh

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -269,10 +269,10 @@ async def download(ctx, order_id, overwrite, directory, checksum):
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
 @click.option(
-    '--create_configuration',
+    '--create-configuration',
     is_flag=True,
     default=False,
-    help='Automatically create a layer configuration for your collection.'
+    help='Automatically create a layer configuration for your collection. '
     'If omitted, no configuration will be created.')
 @pretty
 async def create(ctx, request, pretty, **kwargs):
@@ -374,9 +374,9 @@ async def create(ctx, request, pretty, **kwargs):
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
 @click.option(
-    '--create_configuration',
+    '--create-configuration',
     is_flag=True,
-    help='Automatically create a layer configuration for your collection.'
+    help='Automatically create a layer configuration for your collection. '
     'If omitted, no configuration will be created.')
 @pretty
 async def request(ctx,

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -370,7 +370,7 @@ async def create(ctx, request, pretty, **kwargs):
               type=click.Choice(['sentinel_hub']),
               help='Hosting for data delivery. '
               'Currently, only "sentinel_hub" is supported.')
-@click.option('--collection_id',
+@click.option('--collection-id',
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
 @click.option(

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -268,6 +268,12 @@ async def download(ctx, order_id, overwrite, directory, checksum):
               default=None,
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
+@click.option(
+    '--create_configuration',
+    is_flag=True,
+    default=False,
+    help='Automatically create a layer configuration for your collection.'
+    'If omitted, no configuration will be created.')
 @pretty
 async def create(ctx, request, pretty, **kwargs):
     """Create an order.
@@ -278,17 +284,21 @@ async def create(ctx, request, pretty, **kwargs):
     REQUEST is the full description of the order to be created. It must be JSON
     and can be specified a json string, filename, or '-' for stdin.
 
-    Other flag options are hosting and collection_id. The hosting flag
-    specifies the hosting type, and the collection_id flag specifies the
-    collection ID for Sentinel Hub. If the collection_id is omitted, a new
-    collection will be created.
+    Other flag options are hosting, collection_id, and create_configuration.
+    The hosting flag specifies the hosting type, the collection_id flag specifies the
+    collection ID for Sentinel Hub, and the create_configuration flag specifies
+    whether or not to create a layer configuration for your collection. If the
+    collection_id is omitted, a new collection will be created. If the
+    create_configuration flag is omitted, no configuration will be created. The
+    collection_id flag and create_configuration flag cannot be used together.
     """
 
     hosting = kwargs.get('hosting')
     collection_id = kwargs.get('collection_id')
+    create_configuration = bool(kwargs.get('create_configuration', False))
 
     if hosting == "sentinel_hub":
-        request["hosting"] = sentinel_hub(collection_id)
+        request["hosting"] = sentinel_hub(collection_id, create_configuration)
 
     async with orders_client(ctx) as cl:
         order = await cl.create_order(request)
@@ -363,6 +373,11 @@ async def create(ctx, request, pretty, **kwargs):
 @click.option('--collection_id',
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
+@click.option(
+    '--create_configuration',
+    is_flag=True,
+    help='Automatically create a layer configuration for your collection.'
+    'If omitted, no configuration will be created.')
 @pretty
 async def request(ctx,
                   item_type,
@@ -379,6 +394,7 @@ async def request(ctx,
                   stac,
                   hosting,
                   collection_id,
+                  create_configuration,
                   pretty):
     """Generate an order request.
 
@@ -416,13 +432,15 @@ async def request(ctx,
     else:
         stac_json = {}
 
-    request = planet.order_request.build_request(name,
-                                                 products=[product],
-                                                 delivery=delivery,
-                                                 notifications=notifications,
-                                                 tools=tools,
-                                                 stac=stac_json,
-                                                 hosting=hosting,
-                                                 collection_id=collection_id)
+    request = planet.order_request.build_request(
+        name,
+        products=[product],
+        delivery=delivery,
+        notifications=notifications,
+        tools=tools,
+        stac=stac_json,
+        hosting=hosting,
+        collection_id=collection_id,
+        create_configuration=create_configuration)
 
     echo_json(request, pretty)

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -165,6 +165,11 @@ async def list_subscriptions_cmd(ctx,
               default=None,
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
+@click.option(
+    '--create_configuration',
+    is_flag=True,
+    help='Automatically create a layer configuration for your collection.'
+    'If omitted, no configuration will be created.')
 @pretty
 @click.pass_context
 @translate_exceptions
@@ -178,17 +183,21 @@ async def create_subscription_cmd(ctx, request, pretty, **kwargs):
     REQUEST is the full description of the subscription to be created. It must
     be JSON and can be specified a json string, filename, or '-' for stdin.
 
-    Other flag options are hosting and collection_id. The hosting flag
-    specifies the hosting type, and the collection_id flag specifies the
-    collection ID for Sentinel Hub. If the collection_id is omitted, a new
-    collection will be created.
+    Other flag options are hosting, collection_id, and create_configuration.
+    The hosting flag specifies the hosting type, the collection_id flag specifies the
+    collection ID for Sentinel Hub, and the create_configuration flag specifies
+    whether or not to create a layer configuration for your collection. If the
+    collection_id is omitted, a new collection will be created. If the
+    create_configuration flag is omitted, no configuration will be created. The
+    collection_id flag and create_configuration flag cannot be used together.
     """
 
     hosting = kwargs.get("hosting", None)
     collection_id = kwargs.get("collection_id", None)
+    create_configuration = kwargs.get('create_configuration', False)
 
     if hosting == "sentinel_hub":
-        hosting_info = sentinel_hub(collection_id)
+        hosting_info = sentinel_hub(collection_id, create_configuration)
         request["hosting"] = hosting_info
 
     async with subscriptions_client(ctx) as client:
@@ -366,6 +375,12 @@ async def list_subscription_results_cmd(ctx,
               default=None,
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
+@click.option(
+    '--create_configuration',
+    is_flag=True,
+    default=False,
+    help='Automatically create a layer configuration for your collection.'
+    'If omitted, no configuration will be created.')
 @pretty
 def request(name,
             source,
@@ -374,6 +389,7 @@ def request(name,
             tools,
             hosting,
             collection_id,
+            create_configuration,
             clip_to_source,
             pretty):
     """Generate a subscriptions request.
@@ -384,14 +400,16 @@ def request(name,
     default behavior.
     """
 
-    res = subscription_request.build_request(name,
-                                             source,
-                                             delivery,
-                                             notifications=notifications,
-                                             tools=tools,
-                                             hosting=hosting,
-                                             collection_id=collection_id,
-                                             clip_to_source=clip_to_source)
+    res = subscription_request.build_request(
+        name,
+        source,
+        delivery,
+        notifications=notifications,
+        tools=tools,
+        hosting=hosting,
+        collection_id=collection_id,
+        create_configuration=create_configuration,
+        clip_to_source=clip_to_source)
     echo_json(res, pretty)
 
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -166,9 +166,9 @@ async def list_subscriptions_cmd(ctx,
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
 @click.option(
-    '--create_configuration',
+    '--create-configuration',
     is_flag=True,
-    help='Automatically create a layer configuration for your collection.'
+    help='Automatically create a layer configuration for your collection. '
     'If omitted, no configuration will be created.')
 @pretty
 @click.pass_context
@@ -376,10 +376,10 @@ async def list_subscription_results_cmd(ctx,
               help='Collection ID for Sentinel Hub hosting. '
               'If omitted, a new collection will be created.')
 @click.option(
-    '--create_configuration',
+    '--create-configuration',
     is_flag=True,
     default=False,
-    help='Automatically create a layer configuration for your collection.'
+    help='Automatically create a layer configuration for your collection. '
     'If omitted, no configuration will be created.')
 @pretty
 def request(name,

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -32,7 +32,8 @@ def build_request(name: str,
                   tools: Optional[List[dict]] = None,
                   stac: Optional[dict] = None,
                   hosting: Optional[str] = None,
-                  collection_id: Optional[str] = None) -> dict:
+                  collection_id: Optional[str] = None,
+                  create_configuration: Optional[bool] = False) -> dict:
     """Prepare an order request.
 
     ```python
@@ -70,6 +71,7 @@ def build_request(name: str,
         stac: Include STAC metadata.
         hosting: A hosting destination (e.g. Sentinel Hub).
         collection_id: A Sentinel Hub collection ID.
+        create_configuration: Automatically create a layer configuration for your collection.
 
     Raises:
         planet.specs.SpecificationException: If order_type is not a valid
@@ -97,7 +99,7 @@ def build_request(name: str,
         details['metadata'] = stac
 
     if hosting == 'sentinel_hub':
-        details['hosting'] = sentinel_hub(collection_id)
+        details['hosting'] = sentinel_hub(collection_id, create_configuration)
 
     return details
 
@@ -598,9 +600,12 @@ def band_math_tool(b1: str,
     return _tool('bandmath', parameters)
 
 
-def sentinel_hub(collection_id: Optional[str] = None) -> dict:
+def sentinel_hub(collection_id: Optional[str] = None,
+                 create_configuration: Optional[bool] = False) -> dict:
     """Specify a Sentinel Hub hosting destination."""
     params = {}
     if collection_id:
         params['collection_id'] = collection_id
+    if create_configuration:
+        params['create_configuration'] = create_configuration
     return {'sentinel_hub': params}

--- a/planet/order_request.py
+++ b/planet/order_request.py
@@ -603,7 +603,7 @@ def band_math_tool(b1: str,
 def sentinel_hub(collection_id: Optional[str] = None,
                  create_configuration: Optional[bool] = False) -> dict:
     """Specify a Sentinel Hub hosting destination."""
-    params = {}
+    params: Dict[str, Union[str, bool]] = {}
     if collection_id:
         params['collection_id'] = collection_id
     if create_configuration:

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -790,7 +790,7 @@ def sentinel_hub(collection_id: Optional[str],
         create_configuration: Automatically create a layer configuration for your collection.
     """
 
-    parameters = {}
+    parameters: Dict[str, Union[str, bool]] = {}
     if collection_id:
         parameters['collection_id'] = collection_id
     if create_configuration:

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -54,6 +54,7 @@ def build_request(name: str,
                   tools: Optional[List[Mapping]] = None,
                   hosting: Optional[Union[Mapping, str]] = None,
                   collection_id: Optional[str] = None,
+                  create_configuration: Optional[bool] = False,
                   clip_to_source: Optional[bool] = False) -> dict:
     """Construct a Subscriptions API request.
 
@@ -68,6 +69,8 @@ def build_request(name: str,
         tools: Tools to apply to the products. The order of operation
             is determined by the service.
         hosting: A hosting destination e.g. Sentinel Hub.
+        collection_id: A Sentinel Hub collection ID.
+        create_configuration: Automatically create a layer configuration for your collection.
         clip_to_source: whether to clip to the source geometry or not
             (the default). If True a clip configuration will be added to
             the list of requested tools unless an existing clip tool
@@ -155,6 +158,9 @@ def build_request(name: str,
         }
         if collection_id:
             hosting_info["parameters"]["collection_id"] = collection_id
+        if create_configuration:
+            hosting_info["parameters"][
+                "create_configuration"] = create_configuration
         details['hosting'] = hosting_info
     elif isinstance(hosting, dict):
         details['hosting'] = hosting
@@ -769,18 +775,24 @@ def _hosting(type: str, parameters: dict) -> dict:
     return {"type": type, "parameters": parameters}
 
 
-def sentinel_hub(collection_id: Optional[str]) -> dict:
+def sentinel_hub(collection_id: Optional[str],
+                 create_configuration: Optional[bool] = False) -> dict:
     """Specify a Sentinel Hub hosting destination.
 
     Requires the user to have a Sentinel Hub account linked with their Planet
-    account.  Subscriptions API will create a new collection to deliver data to
-    if collection_id is omitted from the request.
+    account. Subscriptions API will create a new collection to deliver data to
+    if collection_id is omitted from the request. Will also create a new layer
+    configuration for the collection if create_configuration is True.
+    collection_id and create_configuration are mutually exclusive in the API.
 
     Parameters:
         collection_id: Sentinel Hub collection
+        create_configuration: Automatically create a layer configuration for your collection.
     """
 
     parameters = {}
     if collection_id:
         parameters['collection_id'] = collection_id
+    if create_configuration:
+        parameters['create_configuration'] = create_configuration
     return _hosting("sentinel_hub", parameters)

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -826,7 +826,7 @@ def test_cli_orders_request_hosting_sentinel_hub_collection_id(
         '--name=test',
         '20220325_131639_20_2402',
         '--hosting=sentinel_hub',
-        '--collection_id=1234'
+        '--collection-id=1234'
     ])
 
     order_request = {
@@ -859,7 +859,7 @@ def test_cli_orders_request_hosting_sentinel_hub_create_configuration(
         '--name=test',
         '20220325_131639_20_2402',
         '--hosting=sentinel_hub',
-        '--create_configuration'
+        '--create-configuration'
     ])
 
     order_request = {
@@ -892,8 +892,8 @@ def test_cli_orders_request_hosting_sentinel_hub_collection_configuration(
         '--name=test',
         '20220325_131639_20_2402',
         '--hosting=sentinel_hub',
-        '--collection_id=1234',
-        '--create_configuration'
+        '--collection-id=1234',
+        '--create-configuration'
     ])
 
     order_request = {

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -846,3 +846,70 @@ def test_cli_orders_request_hosting_sentinel_hub_collection_id(
         }
     }
     assert order_request == json.loads(result.output)
+
+
+@respx.mock
+def test_cli_orders_request_hosting_sentinel_hub_create_configuration(
+        invoke, stac_json):
+
+    result = invoke([
+        'request',
+        '--item-type=PSScene',
+        '--bundle=visual',
+        '--name=test',
+        '20220325_131639_20_2402',
+        '--hosting=sentinel_hub',
+        '--create_configuration'
+    ])
+
+    order_request = {
+        "name":
+        "test",
+        "products": [{
+            "item_ids": ["20220325_131639_20_2402"],
+            "item_type": "PSScene",
+            "product_bundle": "visual",
+        }],
+        "metadata":
+        stac_json,
+        "hosting": {
+            "sentinel_hub": {
+                "create_configuration": True
+            }
+        }
+    }
+    assert order_request == json.loads(result.output)
+
+
+@respx.mock
+def test_cli_orders_request_hosting_sentinel_hub_collection_configuration(
+        invoke, stac_json):
+    # Note, this behavior will be rejected by the API, but it is valid in building a request
+    result = invoke([
+        'request',
+        '--item-type=PSScene',
+        '--bundle=visual',
+        '--name=test',
+        '20220325_131639_20_2402',
+        '--hosting=sentinel_hub',
+        '--collection_id=1234',
+        '--create_configuration'
+    ])
+
+    order_request = {
+        "name":
+        "test",
+        "products": [{
+            "item_ids": ["20220325_131639_20_2402"],
+            "item_type": "PSScene",
+            "product_bundle": "visual",
+        }],
+        "metadata":
+        stac_json,
+        "hosting": {
+            "sentinel_hub": {
+                "collection_id": "1234", "create_configuration": True
+            }
+        }
+    }
+    assert order_request == json.loads(result.output)

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -460,17 +460,24 @@ def test_catalog_source_time_range_type(invoke, geom_geojson, time_range_type):
 
 
 @pytest.mark.parametrize(
-    "hosting_option, collection_id_option, expected_success",
+    "hosting_option, collection_id_option, configuration_option, expected_success",
     [
-        ("--hosting=sentinel_hub", None, True),
+        ("--hosting=sentinel_hub", None, None, True),
         ("--hosting=sentinel_hub",
          "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734",
+         None,
+         True),
+        ("--hosting=sentinel_hub", None, "--create_configuration", True),
+        ("--hosting=sentinel_hub",
+         "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734",
+         "--create_configuration",
          True),
     ])
 def test_request_hosting(invoke,
                          geom_geojson,
                          hosting_option,
                          collection_id_option,
+                         configuration_option,
                          expected_success):
     """Test request command with various hosting and collection ID options."""
     source = json.dumps({
@@ -494,6 +501,8 @@ def test_request_hosting(invoke,
 
     if collection_id_option:
         cmd.append(collection_id_option)
+    if configuration_option:
+        cmd.append(configuration_option)
 
     result = invoke(cmd)
 

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -467,10 +467,10 @@ def test_catalog_source_time_range_type(invoke, geom_geojson, time_range_type):
          "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734",
          None,
          True),
-        ("--hosting=sentinel_hub", None, "--create_configuration", True),
+        ("--hosting=sentinel_hub", None, "--create-configuration", True),
         ("--hosting=sentinel_hub",
          "--collection-id=7ff105c4-e0de-4910-96db-8345d86ab734",
-         "--create_configuration",
+         "--create-configuration",
          True),
     ])
 def test_request_hosting(invoke,

--- a/tests/unit/test_order_request.py
+++ b/tests/unit/test_order_request.py
@@ -383,3 +383,21 @@ def test_sentinel_hub_collection_id():
     sh_config = order_request.sentinel_hub("1234")
     expected = {'sentinel_hub': {'collection_id': "1234"}}
     assert sh_config == expected
+
+
+def test_sentinel_hub_create_configuration():
+    sh_config = order_request.sentinel_hub(create_configuration=True)
+    expected = {'sentinel_hub': {'create_configuration': True}}
+    assert sh_config == expected
+
+
+def test_sentinel_hub_collection_configuration():
+    # Note, this behavior will be rejected by the API, but it is valid in building a request
+    sh_config = order_request.sentinel_hub(collection_id="1234",
+                                           create_configuration=True)
+    expected = {
+        'sentinel_hub': {
+            'collection_id': '1234', 'create_configuration': True
+        }
+    }
+    assert sh_config == expected

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -119,7 +119,7 @@ def test_build_request_clip_to_source_failure(geom_geojson):
         )
 
 
-def test_build_request_host_sentinel_hub_with_collection(geom_geojson):
+def test_build_request_host_sentinel_hub_no_collection(geom_geojson):
     source = {
         "type": "catalog",
         "parameters": {
@@ -143,7 +143,7 @@ def test_build_request_host_sentinel_hub_with_collection(geom_geojson):
     assert res == expected
 
 
-def test_build_request_host_sentinel_hub_no_collection(geom_geojson):
+def test_build_request_host_sentinel_hub_with_collection(geom_geojson):
     source = {
         "type": "catalog",
         "parameters": {
@@ -160,6 +160,64 @@ def test_build_request_host_sentinel_hub_no_collection(geom_geojson):
         "type": "sentinel-hub",
         "parameters": {
             "collection_id": "4c9af036-4274-4a97-bf0d-eb2a7853330d"
+        }
+    }
+
+    res = subscription_request.build_request('test',
+                                             source=source,
+                                             hosting=hosting)
+
+    expected = {"name": "test", "source": source, "hosting": hosting}
+
+    assert res == expected
+
+
+def test_build_request_host_sentinel_hub_create_configuration(geom_geojson):
+    source = {
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "end_time": "2023-11-01T00:00:00Z",
+            "rrule": "FREQ=MONTHLY;BYMONTH=3,4,5,6,7,8,9,10",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    }
+
+    hosting = {
+        "type": "sentinel-hub", "parameters": {
+            "create_configuration": True
+        }
+    }
+
+    res = subscription_request.build_request('test',
+                                             source=source,
+                                             hosting=hosting)
+
+    expected = {"name": "test", "source": source, "hosting": hosting}
+
+    assert res == expected
+
+
+def test_build_request_host_sentinel_hub_collection_configuration(
+        geom_geojson):
+    source = {
+        "type": "catalog",
+        "parameters": {
+            "geometry": geom_geojson,
+            "start_time": "2021-03-01T00:00:00Z",
+            "end_time": "2023-11-01T00:00:00Z",
+            "rrule": "FREQ=MONTHLY;BYMONTH=3,4,5,6,7,8,9,10",
+            "item_types": ["PSScene"],
+            "asset_types": ["ortho_analytic_4b"]
+        }
+    }
+
+    hosting = {
+        "type": "sentinel-hub",
+        "parameters": {
+            "collection_id": "1234", "create_configuration": True
         }
     }
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. `create_configuration` for Sentinel Hub hosting supported in Orders and Subscriptions Python SDK
2. `--create-configuration` for Sentinel Hub hosting supported in Orders and Subscriptions CLI

Not intended for changelog:

1. 

**Diff of User Interface**

Old behavior:

New behavior:
- Extra optional parameter of `create_configuration` in:
  - planet.subscription_request -> `build_request`
  - planet.order_request -> `build_request`
- Extra optional option of --create-configuration in:
  - `planet orders request`
  - `planet orders create`
  - `planet subscriptions request`
  - `planet subscriptions create` 


Note: create configuration and collection id are mutually exclusive but I have chosen to clean on the API to validate and not do that client side. So a `request` can be built successfully that will fail when submitted to the API.

**PR Checklist:**

- [X] This PR is as small and focused as possible
- [X] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [X] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [X] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
@pl-gideon 