### PR TITLE
hotfix: omit page_size arg to client call  if not provided in subs cli list command

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -144,7 +144,8 @@ async def list_subscriptions_cmd(ctx,
         if page_size is not None:
             list_subscriptions_kwargs['page_size'] = page_size
 
-        async for sub in client.list_subscriptions(**list_subscriptions_kwargs):
+        async for sub in client.list_subscriptions(
+                **list_subscriptions_kwargs):
             echo_json(sub, pretty)
 
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -128,19 +128,23 @@ async def list_subscriptions_cmd(ctx,
                                  pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
     async with subscriptions_client(ctx) as client:
-        async for sub in client.list_subscriptions(
-                created=created,
-                end_time=end_time,
-                hosting=hosting,
-                name__contains=name_contains,
-                name=name,
-                source_type=source_type,
-                start_time=start_time,
-                status=status,
-                sort_by=sort_by,
-                updated=updated,
-                limit=limit,
-                page_size=page_size):
+        list_subscriptions_kwargs = {
+            'created': created,
+            'end_time': end_time,
+            'hosting': hosting,
+            'name__contains': name_contains,
+            'name': name,
+            'source_type': source_type,
+            'start_time': start_time,
+            'status': status,
+            'sort_by': sort_by,
+            'updated': updated,
+            'limit': limit,
+        }
+        if page_size is not None:
+            list_subscriptions_kwargs['page_size'] = page_size
+
+        async for sub in client.list_subscriptions(**list_subscriptions_kwargs):
             echo_json(sub, pretty)
 
 

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -563,6 +563,16 @@ async def test_list_subscriptions_cycle_break():
 
 
 @pytest.mark.anyio
+@failing_api_mock
+async def test_get_summary_failure():
+    """ServerError is raised if there is an internal server error (500)."""
+    with pytest.raises(ServerError):
+        async with Session() as session:
+            client = SubscriptionsClient(session, base_url=TEST_URL)
+            _ = await client.get_summary()
+
+
+@pytest.mark.anyio
 @summary_mock
 async def test_get_summary():
     """Summary fetched, has expected totals, async."""
@@ -599,6 +609,16 @@ def test_get_summary_sync():
             "failed": 0
         }
     }
+
+
+@pytest.mark.anyio
+@failing_api_mock
+async def test_get_sub_summary_failure():
+    """ServerError is raised if there is an internal server error (500)."""
+    with pytest.raises(ServerError):
+        async with Session() as session:
+            client = SubscriptionsClient(session, base_url=TEST_URL)
+            _ = await client.get_subscription_summary("test")
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
**Related Issue(s):**

Closes #1101

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Omit page_size in list_subscriptions client call if --page-size not included in cli command `planet subscriptions list`

Not intended for changelog:

1. Added two more tests to keep overall coverage above 98%, those tests are unrelated to this change. There isn't coverage on the hotfix test case because we mock the api interactions.

**PR Checklist:**

- [X] This PR is as small and focused as possible
- [X] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [X] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [X] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
