### PR TITLE
http: increase default read timeout; make configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
+Changelog moved to https://github.com/planetlabs/planet-client-python/releases
+
 2.13.0 (2024-12-18)
 - Add Planet class (`from planet import Planet`)
-  - Planet is a client that uses sync methods. Users do not have 
+  - Planet is a client that uses sync methods. Users do not have
     to interact with asyncio to use the sync client.
   - the Planet class is implemented by calling out to the async methods.
     This should be transparent to users. Depending on uptake and feedback,

--- a/planet/http.py
+++ b/planet/http.py
@@ -238,6 +238,7 @@ class Session(BaseSession):
 
         Parameters:
             auth: Planet server authentication.
+            read_timeout_secs: Maximum time to wait for data to be received.
         """
         if auth is None:
             # Try getting credentials from environment before checking

--- a/planet/http.py
+++ b/planet/http.py
@@ -50,9 +50,7 @@ RETRY_EXCEPTIONS = [
 MAX_RETRIES = 5
 MAX_RETRY_BACKOFF = 64  # seconds
 
-# For how these settings were determined, see
-# https://github.com/planetlabs/planet-client-python/issues/580
-READ_TIMEOUT = 30.0
+DEFAULT_READ_TIMEOUT_SECS = 125.0
 RATE_LIMIT = 10  # per second
 MAX_ACTIVE = 50
 
@@ -231,7 +229,11 @@ class Session(BaseSession):
     ```
     """
 
-    def __init__(self, auth: Optional[AuthType] = None):
+    def __init__(
+        self,
+        auth: Optional[AuthType] = None,
+        read_timeout_secs: Optional[float] = None,
+    ):
         """Initialize a Session.
 
         Parameters:
@@ -246,8 +248,12 @@ class Session(BaseSession):
             except exceptions.PlanetError:
                 auth = Auth.from_file()
 
-        LOGGER.info(f'Session read timeout set to {READ_TIMEOUT}.')
-        timeout = httpx.Timeout(10.0, read=READ_TIMEOUT)
+        if read_timeout_secs is None:
+            read_timeout_secs = DEFAULT_READ_TIMEOUT_SECS
+
+        LOGGER.info(
+            f'Session read timeout set to {read_timeout_secs} seconds.')
+        timeout = httpx.Timeout(10.0, read=read_timeout_secs)
 
         headers = {
             'User-Agent': self._get_user_agent(), 'X-Planet-App': 'python-sdk'


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Increase default read timeout to 125s
2. Make read timeout configurable per Session

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
