### PR TITLE
Draft: Make Subscription Source Type Optional

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -483,7 +483,7 @@ def request_catalog(item_types,
 @translate_exceptions
 @click.option(
     '--var-type',
-    required=True,
+    required=False,
     help='A Planetary Variable type. See documentation for all available types.'
 )
 @click.option(

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -281,7 +281,7 @@ def catalog_source(
     if time_range_type:
         parameters['time_range_type'] = time_range_type
 
-    return {"type": "catalog", "parameters": parameters}
+    return {"parameters": parameters}
 
 
 def planetary_variable_source(
@@ -369,7 +369,10 @@ def planetary_variable_source(
         except AttributeError:
             raise ClientError('Could not convert end_time to an iso string')
 
-    return {"type": var_type, "parameters": parameters}
+    source: dict[str, Any] = {"parameters": parameters}
+    if var_type:
+        source["type"] = var_type
+    return source
 
 
 def _datetime_to_rfc3339(value: datetime) -> str:


### PR DESCRIPTION
This MR updates the Subscriptions SDK and CLI to make the subscription source `type` parameter optional.  For catalog source subscriptions this is a simple change because the `catalog` source type was programmatically appended to the catalog source instead of requiring user input as a positional arg to `catalog_source()`.  To make the `catalog` type optional then I simply removed the line in `catalog_source()` that appends `catalog` source `type`.

For planetary variable source subscriptions this change is a bit more difficult to make without introducing a breaking change, because the source type is variable and is the first required positional arg to `planetary_variable_source()`.  To avoid the breaking change, I added a condition to `planetary_variable_source()` that checks if the `var_type` arg is `None` and only appends the source type if it is not `None`.  This gives us the desired UX for the CLI which no longer requires the `--var-type` parameter, but keeps the positional `var_type` arg in `planetary_variable_source()`.

Note - I did explore the possibility of making the positional `var_type` arg optional by counting the number of input args to `planetary_variable_source()`, checking their types, and inferring whether or not the user specified the `var_type` arg.  While this does technically work, I think it would introduce an anti-pattern to the method because `var_type` is the first positional arg in the method.
