### PR TITLE
subscriptions: make source type optional for planetary_variable_source function

### DIFF
--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -514,10 +514,10 @@ def request_pv(var_type, var_id, geometry, start_time, end_time, pretty):
     more details.
     """
     res = subscription_request.planetary_variable_source(
-        var_type,
         var_id,
         geometry,
         start_time,
+        var_type=var_type,
         end_time=end_time,
     )
     echo_json(res, pretty)

--- a/planet/subscription_request.py
+++ b/planet/subscription_request.py
@@ -285,10 +285,10 @@ def catalog_source(
 
 
 def planetary_variable_source(
-    var_type: Optional[str],
     var_id: str,
     geometry: Union[dict, str],
     start_time: datetime,
+    var_type: Optional[str] = None,
     end_time: Optional[datetime] = None,
 ) -> dict:
     """Construct a Planetary Variable subscription source.
@@ -304,9 +304,6 @@ def planetary_variable_source(
     Note: this function does not validate variable types and ids.
 
     Parameters:
-        var_type: Planetary Variable type. See documentation for all
-            available types.  Used to be a required parameter but
-            is now optional and can be 'None'.
         var_id: A Planetary Variable ID. See documenation for all
             available IDs.
         geometry: The area of interest of the subscription that will be
@@ -314,6 +311,9 @@ def planetary_variable_source(
             Features API geometry reference (string)
         start_time: The start time of the subscription. This time can be
             in the past or future.
+        var_type: Planetary Variable type. See documentation for all
+            available types.  Used to be a required parameter but
+            is now optional and can be 'None'.
         end_time: The end time of the subscription. This time can be in
             the past or future, and must be after the start_time.
 

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -579,6 +579,7 @@ def test_pv_source_success(geom_geojson, var_type, var_id):
         var_id,
         geometry=geom_geojson,
         start_time=datetime(2021, 3, 1),
+        var_type=var_type,
         end_time=datetime(2021, 3, 2),
     )
 

--- a/tests/unit/test_subscription_request.py
+++ b/tests/unit/test_subscription_request.py
@@ -576,7 +576,6 @@ def test_toar_tool_success():
 def test_pv_source_success(geom_geojson, var_type, var_id):
     """Configure a planetary variable subscription source."""
     source = subscription_request.planetary_variable_source(
-        var_type,
         var_id,
         geometry=geom_geojson,
         start_time=datetime(2021, 3, 1),
@@ -591,6 +590,17 @@ def test_pv_source_success(geom_geojson, var_type, var_id):
     assert params["id"] == var_id
     assert params["geometry"] == geom_geojson
     assert params["start_time"].startswith("2021-03-01")
+
+
+def test_pv_source_no_type(geom_geojson):
+    """Configure a planetary variable subscription source."""
+    source = subscription_request.planetary_variable_source(
+        "BIOMASS-PROXY_V3.0_10",
+        geometry=geom_geojson,
+        start_time=datetime(2021, 3, 1),
+        end_time=datetime(2021, 3, 2),
+    )
+    assert source.get("type") is None
 
 
 @respx.mock


### PR DESCRIPTION
In draft mode until the next major release is cut!

**Related Issue(s):**

Closes #


**Proposed Changes:**

For inclusion in changelog (if applicable):

1. `planetary_variable_source` constructor doesn't require `var_type` at all. If using `planetary_variable_source` please refer to the new function signature [here](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/python/sdk-reference/#planet.subscription_request.planetary_variable_source).

Not intended for changelog:

1. Added a test

**Diff of User Interface**
Previously [changes](https://github.com/planetlabs/planet-client-python/pull/1107) were made to make source type optional. However, in the `planetary_variable_source` definition, `var_type` is still required though allowed to be null. This MR changes that such that `var_type` need not be included at all. This does reorder input arguments, so users should reference the release notes.

Old behavior:
```
pv_source = planetary_variable_source(
    var_type=None,
    var_id="SWC-AMSR2-X_V5.0_1000",
    start_time=datetime.fromisoformat("2022-12-07T00:00:00Z"),
    end_time=datetime.fromisoformat("2022-12-16T00:00:00Z"),
    geometry={
        "coordinates": [
            [
                [139.56481933, 35.42374884],
                [140.10314941, 35.42374884],
                [140.10314941, 35.77102915],
                [139.56481933, 35.77102915],
                [139.56481933, 35.42374884],
            ]
        ],
        "type": "Polygon",
    },
)
```

New behavior:
```
pv_source = planetary_variable_source(
    start_time=datetime.fromisoformat("2022-12-07T00:00:00Z"),
    end_time=datetime.fromisoformat("2022-12-16T00:00:00Z"),
    geometry={
        "coordinates": [
            [
                [139.56481933, 35.42374884],
                [140.10314941, 35.42374884],
                [140.10314941, 35.77102915],
                [139.56481933, 35.77102915],
                [139.56481933, 35.42374884],
            ]
        ],
        "type": "Polygon",
    },
)
```
**PR Checklist:**

- [X] This PR is as small and focused as possible
- [X] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [X] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [X] This PR does not break any examples or I have updated them

**(Optional) @mentions for Notifications:**
