### PR TITLE
session stops background loop on exit/close

### DIFF
--- a/planet/http.py
+++ b/planet/http.py
@@ -282,6 +282,12 @@ class Session(BaseSession):
         self._limiter = _Limiter(rate_limit=RATE_LIMIT, max_workers=MAX_ACTIVE)
         self.outcomes: Counter[str] = Counter()
 
+        self._loop: asyncio.AbstractEventLoop = None  # type: ignore
+
+    def _init_loop(self):
+        if self._loop:
+            return
+
         # create a dedicated event loop for this httpx session.
         def _start_background_loop(loop):
             asyncio.set_event_loop(loop)
@@ -294,6 +300,7 @@ class Session(BaseSession):
         self._loop_thread.start()
 
     def _call_sync(self, f: Awaitable[T]) -> T:
+        self._init_loop()
         return asyncio.run_coroutine_threadsafe(f, self._loop).result()
 
     @classmethod


### PR DESCRIPTION
I was unable to cleanly close the event loop and, therefore, the background thread.

One issue is that the sync API doesn't have any explicit resource cleanup hook.

I attempted to override `__del__` for the `Session` as a means to cleanup and while this "worked" (tests all pass without -Werror)... When run w/ -Werror, it seems like a socket gets garbage collected before close is called and this triggers a warning that fails the test due to -Werror (convert warnings to errors)

