### PR TITLE
deps - exclude click version that breaks tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "planet"
 authors = [{ name = "Planet", email = "python-sdk-contributors@planet.com" }]
 description = "Planet SDK for Python"
 dependencies = [
-  "click>=8.0",
+  "click (>=8.0,!=8.2.1)",
   "geojson",
   "httpx>=0.28.0",
   "jsonschema",


### PR DESCRIPTION
see https://github.com/pallets/click/issues/2939 for details

test breakage example: https://github.com/planetlabs/planet-client-python/actions/runs/15197299407/job/42744343858?pr=1146

**PR Checklist:**

- [X] This PR is as small and focused as possible

