### PR TITLE
orders + subscriptions: support user_id query param

### DIFF
--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -120,6 +120,16 @@ To list orders with a name containing `xyz`:
 planet orders list --name-contains xyz
 ```
 
+To list orders for all users in your organization (organization admin only):
+```sh
+planet orders list --user-id all
+```
+
+To list orders for a specific user ID (organization admin only):
+```sh
+planet orders list --user-id 12345
+```
+
 #### Sorting
 
 The `list` command also supports sorting the orders on one or more fields: `name`, `created_on`, `state`, and `last_modified`. The sort direction can be specified by appending ` ASC` or ` DESC` to the field name (default is ascending).

--- a/docs/cli/cli-orders.md
+++ b/docs/cli/cli-orders.md
@@ -84,6 +84,7 @@ The `list` command supports filtering on a variety of fields:
 * `--last-modified`: Filter on the order's last modified time or an interval of last modified times.
 * `--hosting`: Filter on orders containing a hosting location (e.g. SentinelHub). Accepted values are `true` or `false`.
 * `--destination-ref`: Filter on orders created with the provided destination reference.
+* `--user-id`: Filter by user ID. Only available to organization admins. Accepts "all" or a specific user ID.
 
 Datetime args (`--created-on` and `--last-modified`) can either be a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.
 * A date-time: `2018-02-12T23:20:50Z`

--- a/docs/cli/cli-subscriptions.md
+++ b/docs/cli/cli-subscriptions.md
@@ -145,6 +145,7 @@ The `list` command supports filtering on a variety of fields:
 * `--status`: Filter on the status of the subscription. Status options include `running`, `cancelled`, `preparing`, `pending`, `completed`, `suspended`, and `failed`. Multiple status args are allowed.
 * `--updated`: Filter on the subscription update time or an interval of updated times.
 * `--destination-ref`: Filter on subscriptions created with the provided destination reference.
+* `--user-id`: Filter by user ID. Only available to organization admins. Accepts "all" or a specific user ID.
 
 Datetime args (`--created`, `end-time`, `--start-time`, and `--updated`) can either be a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.
 * A date-time: `2018-02-12T23:20:50Z`
@@ -169,6 +170,16 @@ planet subscriptions list --created 2024-01-01T00:00:00Z/2025-01-01T00:00:00Z
 To list subscriptions with an end time after Jan 1, 2025:
 ```sh
 planet subscriptions list --end-time 2025-01-01T00:00:00Z/..
+```
+
+To list subscriptions for all users in your organization (organization admin only):
+```sh
+planet subscriptions list --user-id all
+```
+
+To list subscriptions for a specific user ID (organization admin only):
+```sh
+planet subscriptions list --user-id 12345
 ```
 
 To list subscriptions with a hosting location:

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -135,11 +135,8 @@ def orders(ctx, base_url):
 @click.option(
     '--destination-ref',
     help="Filter by orders created with the provided destination reference.")
-@click.option(
-    '--user-id',
-    help=
-    "Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID."
-)
+@click.option('--user-id',
+              help="Filter by user ID. Accepts 'all' or a specific user ID.")
 @limit
 @pretty
 async def list(ctx,

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -137,7 +137,9 @@ def orders(ctx, base_url):
     help="Filter by orders created with the provided destination reference.")
 @click.option(
     '--user-id',
-    help="Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID.")
+    help=
+    "Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID."
+)
 @limit
 @pretty
 async def list(ctx,

--- a/planet/cli/orders.py
+++ b/planet/cli/orders.py
@@ -135,6 +135,9 @@ def orders(ctx, base_url):
 @click.option(
     '--destination-ref',
     help="Filter by orders created with the provided destination reference.")
+@click.option(
+    '--user-id',
+    help="Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID.")
 @limit
 @pretty
 async def list(ctx,
@@ -147,6 +150,7 @@ async def list(ctx,
                hosting,
                sort_by,
                destination_ref,
+               user_id,
                limit,
                pretty):
     """List orders
@@ -167,6 +171,7 @@ async def list(ctx,
                                       hosting=hosting,
                                       sort_by=sort_by,
                                       destination_ref=destination_ref,
+                                      user_id=user_id,
                                       limit=limit):
             echo_json(o, pretty)
 

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -110,11 +110,8 @@ def subscriptions(ctx, base_url):
     '--destination-ref',
     help="Filter subscriptions created with the provided destination reference."
 )
-@click.option(
-    '--user-id',
-    help=
-    "Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID."
-)
+@click.option('--user-id',
+              help="Filter by user ID. Accepts 'all' or a specific user ID.")
 @limit
 @click.option('--page-size',
               type=click.INT,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -112,7 +112,9 @@ def subscriptions(ctx, base_url):
 )
 @click.option(
     '--user-id',
-    help="Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID.")
+    help=
+    "Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID."
+)
 @limit
 @click.option('--page-size',
               type=click.INT,

--- a/planet/cli/subscriptions.py
+++ b/planet/cli/subscriptions.py
@@ -110,6 +110,9 @@ def subscriptions(ctx, base_url):
     '--destination-ref',
     help="Filter subscriptions created with the provided destination reference."
 )
+@click.option(
+    '--user-id',
+    help="Filter by user ID. Only available to organization admins. Accepts 'all' or a specific user ID.")
 @limit
 @click.option('--page-size',
               type=click.INT,
@@ -130,6 +133,7 @@ async def list_subscriptions_cmd(ctx,
                                  updated,
                                  limit,
                                  destination_ref,
+                                 user_id,
                                  page_size,
                                  pretty):
     """Prints a sequence of JSON-encoded Subscription descriptions."""
@@ -146,7 +150,8 @@ async def list_subscriptions_cmd(ctx,
             'sort_by': sort_by,
             'updated': updated,
             'limit': limit,
-            'destination_ref': destination_ref
+            'destination_ref': destination_ref,
+            'user_id': user_id
         }
         if page_size is not None:
             list_subscriptions_kwargs['page_size'] = page_size

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -551,7 +551,7 @@ class OrdersClient(_BaseClient):
         if destination_ref is not None:
             params["destination_ref"] = destination_ref
         if user_id is not None:
-            params["user_id"] = user_id
+            params["user_id"] = str(user_id)
         if state:
             if state not in ORDER_STATE_SEQUENCE:
                 raise exceptions.ClientError(

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -474,7 +474,8 @@ class OrdersClient(_BaseClient):
             last_modified: Optional[str] = None,
             hosting: Optional[bool] = None,
             destination_ref: Optional[str] = None,
-            sort_by: Optional[str] = None) -> AsyncIterator[dict]:
+            sort_by: Optional[str] = None,
+            user_id: Optional[Union[str, int]] = None) -> AsyncIterator[dict]:
         """Iterate over the list of stored orders.
 
         By default, order descriptions are sorted by creation date with the last created
@@ -510,6 +511,8 @@ class OrdersClient(_BaseClient):
                  * "name"
                  * "name DESC"
                  * "name,state DESC,last_modified"
+            user_id (str or int): filter by user ID. Only available to organization admins.
+                Accepts "all" or a specific user ID.
 
         Datetime args (created_on and last_modified) can either be a date-time or an
         interval, open or closed. Date and time expressions adhere to RFC 3339. Open
@@ -547,6 +550,8 @@ class OrdersClient(_BaseClient):
             params["sort_by"] = sort_by
         if destination_ref is not None:
             params["destination_ref"] = destination_ref
+        if user_id is not None:
+            params["user_id"] = user_id
         if state:
             if state not in ORDER_STATE_SEQUENCE:
                 raise exceptions.ClientError(

--- a/planet/clients/orders.py
+++ b/planet/clients/orders.py
@@ -16,7 +16,7 @@
 import asyncio
 import logging
 import time
-from typing import AsyncIterator, Callable, Dict, List, Optional, Sequence, TypeVar, Union
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, TypeVar, Union
 import uuid
 import json
 import hashlib
@@ -531,7 +531,7 @@ class OrdersClient(_BaseClient):
             planet.exceptions.ClientError: If state is not valid.
         """
         url = self._orders_url()
-        params: Dict[str, Union[str, Sequence[str], bool]] = {}
+        params: Dict[str, Any] = {}
         if source_type is not None:
             params["source_type"] = source_type
         else:
@@ -551,7 +551,7 @@ class OrdersClient(_BaseClient):
         if destination_ref is not None:
             params["destination_ref"] = destination_ref
         if user_id is not None:
-            params["user_id"] = str(user_id)
+            params["user_id"] = user_id
         if state:
             if state not in ORDER_STATE_SEQUENCE:
                 raise exceptions.ClientError(

--- a/planet/clients/subscriptions.py
+++ b/planet/clients/subscriptions.py
@@ -1,7 +1,7 @@
 """Planet Subscriptions API Python client."""
 
 import logging
-from typing import Any, AsyncIterator, Dict, Optional, Sequence, TypeVar, List
+from typing import Any, AsyncIterator, Dict, Optional, Sequence, TypeVar, List, Union
 
 from typing_extensions import Literal
 
@@ -71,6 +71,7 @@ class SubscriptionsClient(_BaseClient):
                                  sort_by: Optional[str] = None,
                                  updated: Optional[str] = None,
                                  destination_ref: Optional[str] = None,
+                                 user_id: Optional[Union[str, int]] = None,
                                  page_size: int = 500) -> AsyncIterator[dict]:
         """Iterate over list of account subscriptions with optional filtering.
 
@@ -108,6 +109,8 @@ class SubscriptionsClient(_BaseClient):
             updated (str): filter by updated time or interval.
             destination_ref (str): filter by subscriptions created with the
                 provided destination reference.
+            user_id (str or int): filter by user ID. Only available to organization admins.
+                Accepts "all" or a specific user ID.
             page_size (int): number of subscriptions to return per page.
 
         Datetime args (created, end_time, start_time, updated) can either be a
@@ -127,8 +130,6 @@ class SubscriptionsClient(_BaseClient):
             ClientError: on a client error.
         """
 
-        # TODO from old doc string, which breaks strict document checking:
-        #    Add Parameter user_id
         class _SubscriptionsPager(Paged):
             """Navigates pages of messages about subscriptions."""
             ITEMS_KEY = 'subscriptions'
@@ -156,6 +157,8 @@ class SubscriptionsClient(_BaseClient):
             params['updated'] = updated
         if destination_ref is not None:
             params['destination_ref'] = destination_ref
+        if user_id is not None:
+            params['user_id'] = user_id
 
         params['page_size'] = page_size
 

--- a/planet/sync/orders.py
+++ b/planet/sync/orders.py
@@ -252,18 +252,19 @@ class OrdersAPI:
         return self._client._call_sync(
             self._client.wait(order_id, state, delay, max_attempts, callback))
 
-    def list_orders(self,
-                    state: Optional[str] = None,
-                    limit: int = 100,
-                    source_type: Optional[str] = None,
-                    name: Optional[str] = None,
-                    name__contains: Optional[str] = None,
-                    created_on: Optional[str] = None,
-                    last_modified: Optional[str] = None,
-                    hosting: Optional[bool] = None,
-                    destination_ref: Optional[str] = None,
-                    sort_by: Optional[str] = None,
-                    user_id: Optional[Union[str, int]] = None) -> Iterator[dict]:
+    def list_orders(
+            self,
+            state: Optional[str] = None,
+            limit: int = 100,
+            source_type: Optional[str] = None,
+            name: Optional[str] = None,
+            name__contains: Optional[str] = None,
+            created_on: Optional[str] = None,
+            last_modified: Optional[str] = None,
+            hosting: Optional[bool] = None,
+            destination_ref: Optional[str] = None,
+            sort_by: Optional[str] = None,
+            user_id: Optional[Union[str, int]] = None) -> Iterator[dict]:
         """Iterate over the list of stored orders.
 
         By default, order descriptions are sorted by creation date with the last created

--- a/planet/sync/orders.py
+++ b/planet/sync/orders.py
@@ -13,7 +13,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 """Functionality for interacting with the orders api"""
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 from pathlib import Path
 from ..http import Session
@@ -262,7 +262,8 @@ class OrdersAPI:
                     last_modified: Optional[str] = None,
                     hosting: Optional[bool] = None,
                     destination_ref: Optional[str] = None,
-                    sort_by: Optional[str] = None) -> Iterator[dict]:
+                    sort_by: Optional[str] = None,
+                    user_id: Optional[Union[str, int]] = None) -> Iterator[dict]:
         """Iterate over the list of stored orders.
 
         By default, order descriptions are sorted by creation date with the last created
@@ -296,6 +297,8 @@ class OrdersAPI:
                  * "name"
                  * "name DESC"
                  * "name,state DESC,last_modified"
+            user_id (str or int): filter by user ID. Only available to organization admins.
+                Accepts "all" or a specific user ID.
             limit (int): maximum number of results to return. When set to 0, no
                 maximum is applied.
 
@@ -320,4 +323,5 @@ class OrdersAPI:
                                      last_modified,
                                      hosting,
                                      destination_ref,
-                                     sort_by))
+                                     sort_by,
+                                     user_id))

--- a/planet/sync/subscriptions.py
+++ b/planet/sync/subscriptions.py
@@ -47,6 +47,7 @@ class SubscriptionsAPI:
                            sort_by: Optional[str] = None,
                            updated: Optional[str] = None,
                            destination_ref: Optional[str] = None,
+                           user_id: Optional[Union[str, int]] = None,
                            page_size: int = 500) -> Iterator[dict]:
         """Iterate over list of account subscriptions with optional filtering.
 
@@ -82,10 +83,11 @@ class SubscriptionsAPI:
             updated (str): filter by updated time or interval.
             destination_ref (str): filter by subscriptions created with the
                 provided destination reference.
+            user_id (str or int): filter by user ID. Only available to organization admins.
+                Accepts "all" or a specific user ID.
             limit (int): limit the number of subscriptions in the
                 results. When set to 0, no maximum is applied.
             page_size (int): number of subscriptions to return per page.
-            TODO: user_id
 
         Datetime args (created, end_time, start_time, updated) can either be a
         date-time or an interval, open or closed. Date and time expressions adhere
@@ -117,6 +119,7 @@ class SubscriptionsAPI:
                                             sort_by,
                                             updated,
                                             destination_ref,
+                                            user_id,
                                             page_size))
 
     def create_subscription(self, request: Dict) -> Dict:

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -191,9 +191,7 @@ async def test_list_orders_user_id_filtering(order_descriptions, session):
 
     # if the value of user_id doesn't get sent as a url parameter,
     # the mock will fail and this test will fail
-    assert [order1, order2] == [
-        o async for o in cl.list_orders(user_id='all')
-    ]
+    assert [order1, order2] == [o async for o in cl.list_orders(user_id='all')]
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -173,7 +173,7 @@ async def test_list_orders_filtering_and_sorting(order_descriptions, session):
 
 @respx.mock
 @pytest.mark.anyio
-@pytest.mark.parametrize("user_id"['all', '123', 456])
+@pytest.mark.parametrize("user_id", ['all', '123', 456])
 async def test_list_orders_user_id_filtering(order_descriptions,
                                              session,
                                              user_id):

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -172,6 +172,54 @@ async def test_list_orders_filtering_and_sorting(order_descriptions, session):
 
 
 @respx.mock
+@pytest.mark.anyio
+async def test_list_orders_user_id_filtering(order_descriptions, session):
+    """Test user_id parameter filtering for organization admins."""
+    list_url = TEST_ORDERS_URL + '?source_type=all&user_id=all'
+
+    order1, order2, _ = order_descriptions
+
+    page1_response = {
+        "_links": {
+            "_self": "string"
+        }, "orders": [order1, order2]
+    }
+    mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
+    respx.get(list_url).return_value = mock_resp
+
+    cl = OrdersClient(session, base_url=TEST_URL)
+
+    # if the value of user_id doesn't get sent as a url parameter,
+    # the mock will fail and this test will fail
+    assert [order1, order2] == [
+        o async for o in cl.list_orders(user_id='all')
+    ]
+
+
+@respx.mock
+def test_list_orders_user_id_sync(order_descriptions, session):
+    """Test sync client user_id parameter for organization admins."""
+    list_url = TEST_ORDERS_URL + '?source_type=all&user_id=all'
+
+    order1, order2, _ = order_descriptions
+
+    page1_response = {
+        "_links": {
+            "_self": "string"
+        }, "orders": [order1, order2]
+    }
+    mock_resp = httpx.Response(HTTPStatus.OK, json=page1_response)
+    respx.get(list_url).return_value = mock_resp
+
+    pl = Planet()
+    pl.orders._client._base_url = TEST_URL
+
+    # if the value of user_id doesn't get sent as a url parameter,
+    # the mock will fail and this test will fail
+    assert [order1, order2] == list(pl.orders.list_orders(user_id='all'))
+
+
+@respx.mock
 def test_list_orders_state_success_sync(order_descriptions, session):
     list_url = TEST_ORDERS_URL + '?source_type=all&state=failed'
 

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -173,9 +173,12 @@ async def test_list_orders_filtering_and_sorting(order_descriptions, session):
 
 @respx.mock
 @pytest.mark.anyio
-async def test_list_orders_user_id_filtering(order_descriptions, session):
+@pytest.mark.parametrize("user_id"['all', '123', 456])
+async def test_list_orders_user_id_filtering(order_descriptions,
+                                             session,
+                                             user_id):
     """Test user_id parameter filtering for organization admins."""
-    list_url = TEST_ORDERS_URL + '?source_type=all&user_id=all'
+    list_url = TEST_ORDERS_URL + f'?source_type=all&user_id={user_id}'
 
     order1, order2, _ = order_descriptions
 
@@ -191,7 +194,8 @@ async def test_list_orders_user_id_filtering(order_descriptions, session):
 
     # if the value of user_id doesn't get sent as a url parameter,
     # the mock will fail and this test will fail
-    assert [order1, order2] == [o async for o in cl.list_orders(user_id='all')]
+    assert [order1,
+            order2] == [o async for o in cl.list_orders(user_id=user_id)]
 
 
 @respx.mock

--- a/tests/integration/test_orders_api.py
+++ b/tests/integration/test_orders_api.py
@@ -173,7 +173,7 @@ async def test_list_orders_filtering_and_sorting(order_descriptions, session):
 
 @respx.mock
 @pytest.mark.anyio
-@pytest.mark.parametrize("user_id", ['all', '123', 456])
+@pytest.mark.parametrize("user_id", ["all", "123", 456])
 async def test_list_orders_user_id_filtering(order_descriptions,
                                              session,
                                              user_id):

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -122,7 +122,7 @@ def test_cli_orders_list_filtering_and_sorting(invoke, order_descriptions):
 
 
 @respx.mock
-@pytest.mark.parametrize("user_id"['all', '123'])
+@pytest.mark.parametrize("user_id", ['all', '123'])
 def test_cli_orders_list_user_id(invoke, order_descriptions, user_id):
     """Test CLI user_id parameter for organization admins."""
     list_url = TEST_ORDERS_URL + f'?source_type=all&user_id={user_id}'

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -122,9 +122,10 @@ def test_cli_orders_list_filtering_and_sorting(invoke, order_descriptions):
 
 
 @respx.mock
-def test_cli_orders_list_user_id(invoke, order_descriptions):
+@pytest.mark.parametrize("user_id"['all', '123'])
+def test_cli_orders_list_user_id(invoke, order_descriptions, user_id):
     """Test CLI user_id parameter for organization admins."""
-    list_url = TEST_ORDERS_URL + '?source_type=all&user_id=all'
+    list_url = TEST_ORDERS_URL + f'?source_type=all&user_id={user_id}'
 
     order1, order2, _ = order_descriptions
 
@@ -138,7 +139,7 @@ def test_cli_orders_list_user_id(invoke, order_descriptions):
 
     # if the value of user_id doesn't get sent as a url parameter,
     # the mock will fail and this test will fail
-    result = invoke(['list', '--user-id', 'all'])
+    result = invoke(['list', '--user-id', user_id])
     assert result.exit_code == 0
     sequence = '\n'.join([json.dumps(o) for o in [order1, order2]])
     assert result.output == sequence + '\n'

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -138,11 +138,7 @@ def test_cli_orders_list_user_id(invoke, order_descriptions):
 
     # if the value of user_id doesn't get sent as a url parameter,
     # the mock will fail and this test will fail
-    result = invoke([
-        'list',
-        '--user-id',
-        'all'
-    ])
+    result = invoke(['list', '--user-id', 'all'])
     assert result.exit_code == 0
     sequence = '\n'.join([json.dumps(o) for o in [order1, order2]])
     assert result.output == sequence + '\n'

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -122,7 +122,7 @@ def test_cli_orders_list_filtering_and_sorting(invoke, order_descriptions):
 
 
 @respx.mock
-@pytest.mark.parametrize("user_id", ['all', '123'])
+@pytest.mark.parametrize("user_id", ["all", "123"])
 def test_cli_orders_list_user_id(invoke, order_descriptions, user_id):
     """Test CLI user_id parameter for organization admins."""
     list_url = TEST_ORDERS_URL + f'?source_type=all&user_id={user_id}'

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -312,6 +312,17 @@ async def test_list_subscriptions_filtering_and_sorting():
         ]) == 2
 
 
+@pytest.mark.anyio
+@api_mock
+async def test_list_subscriptions_user_id_filtering():
+    """Test user_id parameter filtering for organization admins."""
+    async with Session() as session:
+        client = SubscriptionsClient(session, base_url=TEST_URL)
+        assert len([
+            sub async for sub in client.list_subscriptions(user_id='all')
+        ]) == 100
+
+
 @pytest.mark.parametrize("page_size, count", [(50, 100), (100, 100)])
 @pytest.mark.anyio
 @api_mock

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -312,7 +312,7 @@ async def test_list_subscriptions_filtering_and_sorting():
         ]) == 2
 
 
-@pytest.mark.parametrize("user_id", ['all', '123', 456])
+@pytest.mark.parametrize("user_id", ["all", "123", 456])
 @pytest.mark.anyio
 @api_mock
 async def test_list_subscriptions_user_id_filtering(user_id):

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -312,14 +312,15 @@ async def test_list_subscriptions_filtering_and_sorting():
         ]) == 2
 
 
+@pytest.mark.parametrize("user_id"['all', '123', 456])
 @pytest.mark.anyio
 @api_mock
-async def test_list_subscriptions_user_id_filtering():
+async def test_list_subscriptions_user_id_filtering(user_id):
     """Test user_id parameter filtering for organization admins."""
     async with Session() as session:
         client = SubscriptionsClient(session, base_url=TEST_URL)
         assert len([
-            sub async for sub in client.list_subscriptions(user_id='all')
+            sub async for sub in client.list_subscriptions(user_id=user_id)
         ]) == 100
 
 

--- a/tests/integration/test_subscriptions_api.py
+++ b/tests/integration/test_subscriptions_api.py
@@ -312,7 +312,7 @@ async def test_list_subscriptions_filtering_and_sorting():
         ]) == 2
 
 
-@pytest.mark.parametrize("user_id"['all', '123', 456])
+@pytest.mark.parametrize("user_id", ['all', '123', 456])
 @pytest.mark.anyio
 @api_mock
 async def test_list_subscriptions_user_id_filtering(user_id):

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -72,9 +72,7 @@ def invoke():
          '--hosting=true',
          '--sort-by=name DESC'
      ],
-      2),
-     (['--user-id=all'], 100),
-     (['--user-id=12345'], 100)])
+      2), (['--user-id=all'], 100), (['--user-id=12345'], 100)])
 @api_mock
 # Remember, parameters come before fixtures in the function definition.
 def test_subscriptions_list_options(invoke, options, expected_count):

--- a/tests/integration/test_subscriptions_cli.py
+++ b/tests/integration/test_subscriptions_cli.py
@@ -72,7 +72,9 @@ def invoke():
          '--hosting=true',
          '--sort-by=name DESC'
      ],
-      2)])
+      2),
+     (['--user-id=all'], 100),
+     (['--user-id=12345'], 100)])
 @api_mock
 # Remember, parameters come before fixtures in the function definition.
 def test_subscriptions_list_options(invoke, options, expected_count):


### PR DESCRIPTION
**Proposed Changes:**

For inclusion in changelog (if applicable):

1. Add support for Orders API & Subscriptions API `user_id` query parameter 

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them
