### PR TITLE
subcommands should provide the click context when creating CLI sessions.  This enables the session to pick-up options set by the root command.

### DIFF
--- a/planet/cli/destinations.py
+++ b/planet/cli/destinations.py
@@ -11,7 +11,7 @@ from .session import CliSession
 
 @asynccontextmanager
 async def destinations_client(ctx):
-    async with CliSession() as sess:
+    async with CliSession(ctx) as sess:
         cl = DestinationsClient(sess, base_url=ctx.obj['BASE_URL'])
         yield cl
 

--- a/planet/cli/features.py
+++ b/planet/cli/features.py
@@ -14,7 +14,7 @@ from .session import CliSession
 
 @asynccontextmanager
 async def features_client(ctx):
-    async with CliSession() as sess:
+    async with CliSession(ctx) as sess:
         cl = FeaturesClient(sess, base_url=ctx.obj['BASE_URL'])
         yield cl
 

--- a/planet/cli/mosaics.py
+++ b/planet/cli/mosaics.py
@@ -13,7 +13,7 @@ from planet.clients.mosaics import MosaicsClient
 
 @asynccontextmanager
 async def client(ctx):
-    async with CliSession() as sess:
+    async with CliSession(ctx) as sess:
         cl = MosaicsClient(sess, base_url=ctx.obj['BASE_URL'])
         yield cl
 


### PR DESCRIPTION
Cick sub-commands should provide the click context when creating CLI sessions.  This enables the session to pick-up options set by the root command.
