### PR TITLE
DRAFT: Request profile claims because some Planet APIs expect the email cliam.

### DIFF
--- a/planet/auth_builtins.py
+++ b/planet/auth_builtins.py
@@ -64,9 +64,9 @@ _OIDC_AUTH_CLIENT_CONFIG__USER_SKEL = {
     "scopes": [
         PlanetOAuthScopes.PLANET,
         PlanetOAuthScopes.OFFLINE_ACCESS,
-        # PlanetOAuthScopes.OPENID,
-        # PlanetOAuthScopes.PROFILE,
-        # PlanetOAuthScopes.EMAIL
+        PlanetOAuthScopes.OPENID,
+        PlanetOAuthScopes.PROFILE,
+        PlanetOAuthScopes.EMAIL
     ],
     # "client_type": "oidc_device_code",  # Must be provided when hydrating the SKEL
     # "client_id": _SDK_CLIENT_ID_PROD,   # Must be provided when hydrating the SKEL


### PR DESCRIPTION
Change log:

1. Change default behavior to claim email and profile scopes from the Planet OAuth server
