### PR TITLE
Add space to checkbox markdown in PR template, so they actually render as checkboxes if unedited

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,9 @@ New behavior:
 
 **PR Checklist:**
 
-- [] This PR is as small and focused as possible
-- [] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
-- [] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
-- [] This PR does not break any examples or I have updated them
+- [ ] This PR is as small and focused as possible
+- [ ] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
+- [ ] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
+- [ ] This PR does not break any examples or I have updated them
 
 **(Optional) @mentions for Notifications:**


### PR DESCRIPTION
From this:
<img width="835" height="264" alt="Screenshot 2026-05-13 at 3 11 56 PM" src="https://github.com/user-attachments/assets/3ad54f7e-286a-42b2-bb3b-051ba1b06893" />

To this:
<img width="827" height="272" alt="Screenshot 2026-05-13 at 3 12 17 PM" src="https://github.com/user-attachments/assets/e4c2fabd-71d2-4dcb-b79d-5a98bfbbdd4a" />

**Related Issue(s):**

Closes #


**Proposed Changes:**

N/A


**Diff of User Interface**

N/A


**PR Checklist:**

- [x] This PR is as small and focused as possible
- [x] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them
