### PR TITLE
Replace deprecated isolated_filesystem() with tmp_path in tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,13 @@ async def session():
 
 
 @pytest.fixture
+def cwd_tmp_path(tmp_path, monkeypatch):
+    """Run the test with cwd set to a fresh tmp_path, restored afterwards."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
 def order_descriptions(order_description):
     order1 = order_description
     order1['id'] = 'oid1'

--- a/tests/integration/test_data_cli.py
+++ b/tests/integration/test_data_cli.py
@@ -976,7 +976,8 @@ def test_asset_download_default(invoke,
                                 item_type,
                                 item_id,
                                 asset_type,
-                                dl_url):
+                                dl_url,
+                                tmp_path):
 
     mock_asset_get_response()
 
@@ -1002,36 +1003,36 @@ def test_asset_download_default(invoke,
     respx.get(dl_url).return_value = mock_resp_download
 
     runner = CliRunner()
-    with runner.isolated_filesystem() as folder:
-        if exists:
-            Path(folder, 'img.tif').write_bytes(b'01010')
+    folder = tmp_path
+    if exists:
+        Path(folder, 'img.tif').write_bytes(b'01010')
 
-        asset_download_command = [
-            'asset-download',
-            item_type,
-            item_id,
-            asset_type,
-            f'--directory={Path(folder)}',
-            '--filename',
-            'img.tif'
-        ]
-        if overwrite:
-            asset_download_command.append('--overwrite')
+    asset_download_command = [
+        'asset-download',
+        item_type,
+        item_id,
+        asset_type,
+        f'--directory={Path(folder)}',
+        '--filename',
+        'img.tif'
+    ]
+    if overwrite:
+        asset_download_command.append('--overwrite')
 
-        result = invoke(asset_download_command, runner=runner)
-        assert result.exit_code == 0
+    result = invoke(asset_download_command, runner=runner)
+    assert result.exit_code == 0
 
-        path = Path(folder, 'img.tif')
+    path = Path(folder, 'img.tif')
 
-        assert path.name == 'img.tif'
-        assert path.is_file()
+    assert path.name == 'img.tif'
+    assert path.is_file()
 
-        if exists and not overwrite:
-            assert len(path.read_bytes()) == 5
-            assert len(result.output) == 0
-        else:
-            assert len(path.read_bytes()) == 527
-            assert path.name in result.output
+    if exists and not overwrite:
+        assert len(path.read_bytes()) == 5
+        assert len(result.output) == 0
+    else:
+        assert len(path.read_bytes()) == 527
+        assert path.name in result.output
 
 
 @respx.mock

--- a/tests/integration/test_mosaics_api.py
+++ b/tests/integration/test_mosaics_api.py
@@ -34,8 +34,8 @@ def async_wrap(api):
 # @pytest.mark.skip
 @pytest.mark.parametrize(
     "tc", [pytest.param(tc, id=tc.id) for tc in test_mosaics_cli.test_cases])
-def test_api(tc):
+def test_api(tc, cwd_tmp_path):
     api = async_wrap(MosaicsAPI)
     with patch('planet.cli.mosaics.MosaicsClient', api):
-        test_mosaics_cli.run_test(tc)
+        test_mosaics_cli.run_test(tc, cwd_tmp_path)
         api._pool.shutdown()

--- a/tests/integration/test_mosaics_cli.py
+++ b/tests/integration/test_mosaics_cli.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from pathlib import Path
 import json
+import os
+import tempfile
 from typing import Optional
 import httpx
 import pytest
@@ -383,12 +385,17 @@ def test_cli(tc: CLITestCase):
 @respx.mock
 def run_test(tc: CLITestCase):
     runner = CliRunner()
-    with runner.isolated_filesystem() as folder:
-        for r in tc.requests:
-            r()
+    with tempfile.TemporaryDirectory() as folder:
+        prev_dir = os.getcwd()
+        os.chdir(folder)
+        try:
+            for r in tc.requests:
+                r()
 
-        args = ["mosaics", "-u", baseurl] + tc.command + tc.args
-        result = runner.invoke(cli.main, args=args)
+            args = ["mosaics", "-u", baseurl] + tc.command + tc.args
+            result = runner.invoke(cli.main, args=args)
+        finally:
+            os.chdir(prev_dir)
         # result.exception may be SystemExit which we want to ignore
         # but if we don't raise a "true error" exception, there's no
         # stack trace, making it difficult to diagnose

--- a/tests/integration/test_mosaics_cli.py
+++ b/tests/integration/test_mosaics_cli.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
 import json
-import os
-import tempfile
 from typing import Optional
 import httpx
 import pytest
@@ -378,37 +376,31 @@ test_cases = info_cases + series_info_cases + list_mosaic_cases + list_series_ca
 
 @pytest.mark.parametrize("tc",
                          [pytest.param(tc, id=tc.id) for tc in test_cases])
-def test_cli(tc: CLITestCase):
-    run_test(tc)
+def test_cli(tc: CLITestCase, cwd_tmp_path):
+    run_test(tc, cwd_tmp_path)
 
 
 @respx.mock
-def run_test(tc: CLITestCase):
+def run_test(tc: CLITestCase, folder):
     runner = CliRunner()
-    with tempfile.TemporaryDirectory() as folder:
-        prev_dir = os.getcwd()
-        os.chdir(folder)
-        try:
-            for r in tc.requests:
-                r()
+    for r in tc.requests:
+        r()
 
-            args = ["mosaics", "-u", baseurl] + tc.command + tc.args
-            result = runner.invoke(cli.main, args=args)
-        finally:
-            os.chdir(prev_dir)
-        # result.exception may be SystemExit which we want to ignore
-        # but if we don't raise a "true error" exception, there's no
-        # stack trace, making it difficult to diagnose
-        if result.exception and tc.exit_code == 0:
-            raise result.exception
-        assert result.exit_code == tc.exit_code, result.output
-        if tc.output:
-            try:
-                # error output (always?) not JSON
-                output = json.loads(result.output)
-            except json.JSONDecodeError:
-                output = result.output
-            assert output == tc.output
-        if tc.expect_files:
-            for f in tc.expect_files:
-                assert Path(folder, f).exists(), f
+    args = ["mosaics", "-u", baseurl] + tc.command + tc.args
+    result = runner.invoke(cli.main, args=args)
+    # result.exception may be SystemExit which we want to ignore
+    # but if we don't raise a "true error" exception, there's no
+    # stack trace, making it difficult to diagnose
+    if result.exception and tc.exit_code == 0:
+        raise result.exception
+    assert result.exit_code == tc.exit_code, result.output
+    if tc.output:
+        try:
+            # error output (always?) not JSON
+            output = json.loads(result.output)
+        except json.JSONDecodeError:
+            output = result.output
+        assert output == tc.output
+    if tc.expect_files:
+        for f in tc.expect_files:
+            assert Path(folder, f).exists(), f

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -16,7 +16,6 @@ import copy
 import hashlib
 from http import HTTPStatus
 import json
-from pathlib import Path
 from unittest.mock import Mock
 
 from click.testing import CliRunner
@@ -359,81 +358,95 @@ def mock_download_response(oid, order_description):
 
 
 @respx.mock
-def test_cli_orders_download_default(invoke, mock_download_response, oid):
+def test_cli_orders_download_default(invoke,
+                                     mock_download_response,
+                                     oid,
+                                     tmp_path):
     mock_download_response()
 
     runner = CliRunner()
-    with runner.isolated_filesystem() as folder:
-        result = invoke(['download', oid], runner=runner)
-        assert result.exit_code == 0
+    result = invoke(['download', '--directory', str(tmp_path), oid],
+                    runner=runner)
+    assert result.exit_code == 0
 
-        # basic check of progress reporting
-        assert 'm1.json' in result.output
+    # basic check of progress reporting
+    assert 'm1.json' in result.output
 
-        # Check that the files were downloaded and have the correct contents
-        with open(Path(folder) / f'{oid}/itemtype/m1.json') as f:
-            assert json.load(f) == {'key': 'value'}
-        with open(Path(folder) / f'{oid}/itemtype/m2.json') as f:
-            assert json.load(f) == {'key2': 'value2'}
+    # Check that the files were downloaded and have the correct contents
+    with open(tmp_path / f'{oid}/itemtype/m1.json') as f:
+        assert json.load(f) == {'key': 'value'}
+    with open(tmp_path / f'{oid}/itemtype/m2.json') as f:
+        assert json.load(f) == {'key2': 'value2'}
 
 
 @respx.mock
-def test_cli_orders_download_checksum(invoke, mock_download_response, oid):
+def test_cli_orders_download_checksum(invoke,
+                                      mock_download_response,
+                                      oid,
+                                      tmp_path):
     """checksum is successful"""
     mock_download_response()
 
     runner = CliRunner()
-    with runner.isolated_filesystem():
-        result = invoke(['download', oid, '--checksum=MD5'], runner=runner)
-        assert result.exit_code == 0
+    result = invoke(
+        ['download', '--directory', str(tmp_path), oid, '--checksum=MD5'],
+        runner=runner)
+    assert result.exit_code == 0
 
 
 @respx.mock
-def test_cli_orders_download_dest(invoke, mock_download_response, oid):
+def test_cli_orders_download_dest(invoke,
+                                  mock_download_response,
+                                  oid,
+                                  tmp_path):
     mock_download_response()
 
+    dest_dir = tmp_path / 'foobar'
+    dest_dir.mkdir()
+
     runner = CliRunner()
-    with runner.isolated_filesystem() as folder:
-        dest_dir = Path(folder) / 'foobar'
-        dest_dir.mkdir()
-        result = invoke(['download', '--directory', 'foobar', oid],
-                        runner=runner)
-        assert result.exit_code == 0
+    result = invoke(['download', '--directory', str(dest_dir), oid],
+                    runner=runner)
+    assert result.exit_code == 0
 
-        # Check that the files were downloaded to the custom directory
-        with open(dest_dir / f'{oid}/itemtype/m1.json') as f:
-            assert json.load(f) == {'key': 'value'}
+    # Check that the files were downloaded to the custom directory
+    with open(dest_dir / f'{oid}/itemtype/m1.json') as f:
+        assert json.load(f) == {'key': 'value'}
 
-        with open(dest_dir / f'{oid}/itemtype/m2.json') as f:
-            assert json.load(f) == {'key2': 'value2'}
+    with open(dest_dir / f'{oid}/itemtype/m2.json') as f:
+        assert json.load(f) == {'key2': 'value2'}
 
 
 @respx.mock
 def test_cli_orders_download_overwrite(invoke,
                                        mock_download_response,
                                        oid,
-                                       write_to_tmp_json_file):
+                                       write_to_tmp_json_file,
+                                       tmp_path):
     mock_download_response()
 
+    filepath = tmp_path / f'{oid}/itemtype/m1.json'
+    filepath.parent.mkdir(parents=True)
+    filepath.write_text(json.dumps({'foo': 'bar'}))
+
     runner = CliRunner()
-    with runner.isolated_filesystem() as folder:
-        filepath = Path(folder) / f'{oid}/itemtype/m1.json'
-        filepath.parent.mkdir(parents=True)
-        filepath.write_text(json.dumps({'foo': 'bar'}))
 
-        # check the file doesn't get overwritten by default
-        result = invoke(['download', oid], runner=runner)
-        assert result.exit_code == 0
+    # check the file doesn't get overwritten by default
+    result = invoke(['download', '--directory', str(tmp_path), oid],
+                    runner=runner)
+    assert result.exit_code == 0
 
-        with open(filepath, 'r') as f:
-            assert json.load(f) == {'foo': 'bar'}
+    with open(filepath, 'r') as f:
+        assert json.load(f) == {'foo': 'bar'}
 
-        # check the file gets overwritten
-        result = invoke(['download', '--overwrite', oid], runner=runner)
-        assert result.exit_code == 0
+    # check the file gets overwritten
+    result = invoke(
+        ['download', '--overwrite', '--directory', str(tmp_path), oid],
+        runner=runner)
+    assert result.exit_code == 0
 
-        with open(filepath, 'r') as f:
-            assert json.load(f) == {'key': 'value'}
+    with open(filepath, 'r') as f:
+        assert json.load(f) == {'key': 'value'}
 
 
 @respx.mock

--- a/tests/integration/test_orders_cli.py
+++ b/tests/integration/test_orders_cli.py
@@ -361,12 +361,13 @@ def mock_download_response(oid, order_description):
 def test_cli_orders_download_default(invoke,
                                      mock_download_response,
                                      oid,
-                                     tmp_path):
+                                     tmp_path,
+                                     monkeypatch):
     mock_download_response()
+    monkeypatch.chdir(tmp_path)
 
     runner = CliRunner()
-    result = invoke(['download', '--directory', str(tmp_path), oid],
-                    runner=runner)
+    result = invoke(['download', oid], runner=runner)
     assert result.exit_code == 0
 
     # basic check of progress reporting

--- a/tests/unit/test_cli_collect.py
+++ b/tests/unit/test_cli_collect.py
@@ -50,7 +50,7 @@ def test_cli_collect_stdin_features(feature_geojson):
     assert json.loads(result.output) == expected
 
 
-def test_cli_collect_file(feature_geojson):
+def test_cli_collect_file(feature_geojson, tmp_path):
     feature2 = feature_geojson.copy()
     feature2['properties'] = {'foo': 'bar'}
     values = [feature_geojson, feature2]
@@ -58,12 +58,11 @@ def test_cli_collect_file(feature_geojson):
     runner = CliRunner()
     sequence = '\n'.join([json.dumps(v) for v in values])
 
-    with runner.isolated_filesystem():
-        with open('input.json', 'w') as f:
-            f.write(sequence)
+    input_file = tmp_path / 'input.json'
+    input_file.write_text(sequence)
 
-        result = runner.invoke(cli.main, ['collect', 'input.json'])
+    result = runner.invoke(cli.main, ['collect', str(input_file)])
 
-        assert result.exit_code == 0
-        expected = {'type': 'FeatureCollection', 'features': values}
-        assert json.loads(result.output) == expected
+    assert result.exit_code == 0
+    expected = {'type': 'FeatureCollection', 'features': values}
+    assert json.loads(result.output) == expected


### PR DESCRIPTION
`isolated_filesystem` is being deprecated and now manifests as warnings in the tests. The test stage fails since we run with `-Werror`. We can use the `tmp_path` fixture from pytest instead.

**PR Checklist:**

- [x] This PR is as small and focused as possible
- [ ] If this PR includes proposed changes for inclusion in the changelog, the title of this PR summarizes those changes and is ready for inclusion in the Changelog.
- [x] I have updated docstrings for function changes and docs in the 'docs' folder for user interface / behavior changes
- [x] This PR does not break any examples or I have updated them

